### PR TITLE
fix: cron scheduler hot-reload - start goroutines for new jobs

### DIFF
--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fastclaw-ai/fastclaw/internal/bus"
@@ -59,10 +60,14 @@ type StoreJob struct {
 
 // Scheduler manages cron job execution.
 type Scheduler struct {
+	mu         sync.Mutex
 	jobs       []Job
 	bus        *bus.MessageBus
 	store      StoreInterface
 	instanceID string
+	// hot-reload support
+	parentCtx context.Context
+	jobCancel context.CancelFunc
 }
 
 // NewScheduler creates a scheduler from config.
@@ -99,17 +104,13 @@ func LoadJobs(path string) ([]Job, error) {
 
 // Start begins the scheduler. It blocks until ctx is cancelled.
 func (s *Scheduler) Start(ctx context.Context) {
-	if len(s.jobs) == 0 && s.store == nil {
-		slog.Info("no cron jobs configured")
-		return
-	}
-
+	s.mu.Lock()
+	s.parentCtx = ctx
 	slog.Info("cron scheduler started", "jobs", len(s.jobs), "store_backed", s.store != nil)
 
-	// Start a goroutine for each in-memory job
-	for _, job := range s.jobs {
-		go s.runJob(ctx, job)
-	}
+	// Start goroutines for initial in-memory jobs
+	s.startJobGoroutines()
+	s.mu.Unlock()
 
 	// If store is set, poll for DB-backed jobs
 	if s.store != nil {
@@ -320,7 +321,34 @@ func (s *Scheduler) fireJob(job Job) {
 }
 
 // UpdateJobs replaces the scheduler's job list (hot-reload).
-// Note: this updates the list for the next scheduling cycle.
+// It cancels goroutines for old jobs and starts new ones.
 func (s *Scheduler) UpdateJobs(jobs []Job) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.jobs = jobs
+
+	// If the scheduler is running, restart job goroutines
+	if s.parentCtx != nil {
+		s.startJobGoroutines()
+	}
+
+	slog.Info("cron jobs updated (hot-reload)", "jobs", len(jobs))
+}
+
+// startJobGoroutines cancels any existing job goroutines and starts new ones.
+// Must be called with s.mu held.
+func (s *Scheduler) startJobGoroutines() {
+	// Cancel previous batch of job goroutines
+	if s.jobCancel != nil {
+		s.jobCancel()
+	}
+
+	// Create a new child context for this batch
+	jobCtx, cancel := context.WithCancel(s.parentCtx)
+	s.jobCancel = cancel
+
+	for _, job := range s.jobs {
+		go s.runJob(jobCtx, job)
+	}
 }


### PR DESCRIPTION
## Summary

- Fix `Start()` returning early when 0 initial jobs, which kills the scheduler goroutine entirely — it now always blocks on `<-ctx.Done()` so hot-reloaded jobs can be picked up
- Fix `UpdateJobs()` only replacing the job list without starting goroutines — it now cancels old job goroutines and starts new ones using a child context

## Problem

When the gateway starts with no cron jobs configured, `Start()` returns immediately. Later when jobs are added via the setup API and hot-reloaded, `UpdateJobs()` updates the list but no goroutines are running to execute them. The jobs are registered but never fire.

## Test plan

- [ ] Start gateway with 0 cron jobs
- [ ] Add a cron job via `POST /api/cron` (interval type, 1m)
- [ ] Verify hot-reload triggers `UpdateJobs` and job goroutine starts
- [ ] Verify job fires after interval
- [ ] Delete the job, verify old goroutine is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)