### PR TITLE
feat: support Telegram image sending with captions

### DIFF
--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -25,15 +25,15 @@ type OutboundButton struct {
 
 // OutboundMessage represents a message to be sent to a channel.
 type OutboundMessage struct {
-	Channel      string              // target channel type
-	AccountID    string              // target account within the channel
-	ChatID       string              // target chat identifier
-	Text         string              // message text
-	ReplyToMsgID string              // reply to specific message
-	ParseMode    string              // "MarkdownV2", "HTML", ""
-	Buttons      [][]OutboundButton  // inline keyboard rows
-	EditMsgID    string              // edit existing message instead of sending new
-	MediaPaths   []string            // file paths to attach (from MEDIA: protocol)
+	Channel      string             // target channel type
+	AccountID    string             // target account within the channel
+	ChatID       string             // target chat identifier
+	Text         string             // message text
+	ReplyToMsgID string             // reply to specific message
+	ParseMode    string             // "MarkdownV2", "HTML", ""
+	Buttons      [][]OutboundButton // inline keyboard rows
+	EditMsgID    string             // edit existing message instead of sending new
+	MediaPaths   []string           // file paths to attach (currently used for Telegram image sending via MEDIA:)
 }
 
 // MessageBus is an async message queue backed by Go channels.

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -3,7 +3,11 @@ package channels
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -19,9 +23,30 @@ var mentionRe = regexp.MustCompile(`@(\w+)`)
 // markdownV2Escaper escapes special characters for Telegram MarkdownV2.
 var markdownV2SpecialChars = []string{"_", "*", "[", "]", "(", ")", "~", "`", ">", "#", "+", "-", "=", "|", "{", "}", ".", "!"}
 
+const (
+	telegramCaptionLimit  = 1024
+	telegramMediaGroupMax = 10
+)
+
+var telegramImageExtensions = map[string]struct{}{
+	".jpg":  {},
+	".jpeg": {},
+	".png":  {},
+	".webp": {},
+}
+
+type telegramAPI interface {
+	GetUpdatesChan(tgbotapi.UpdateConfig) tgbotapi.UpdatesChannel
+	StopReceivingUpdates()
+	GetFileDirectURL(string) (string, error)
+	Request(tgbotapi.Chattable) (*tgbotapi.APIResponse, error)
+	Send(tgbotapi.Chattable) (tgbotapi.Message, error)
+	SendMediaGroup(tgbotapi.MediaGroupConfig) ([]tgbotapi.Message, error)
+}
+
 // Telegram implements the Channel interface for Telegram Bot API.
 type Telegram struct {
-	bot         *tgbotapi.BotAPI
+	bot         telegramAPI
 	bus         *bus.MessageBus
 	accountID   string
 	botUsername string
@@ -249,16 +274,24 @@ func (t *Telegram) SendMessage(msg bus.OutboundMessage) error {
 		return fmt.Errorf("parse chat ID: %w", err)
 	}
 
+	if len(msg.MediaPaths) > 0 {
+		return t.sendMediaMessage(id, msg)
+	}
+
+	return t.sendTextMessage(id, msg)
+}
+
+func (t *Telegram) sendTextMessage(chatID int64, msg bus.OutboundMessage) error {
 	// Edit existing message
 	if msg.EditMsgID != "" {
-		return t.editMessage(id, msg)
+		return t.editMessage(chatID, msg)
 	}
 
 	// Split long messages at paragraph boundaries
 	chunks := splitTelegramMessage(msg.Text)
 
 	for i, chunk := range chunks {
-		if err := t.sendSingleMessage(id, chunk, msg, i == 0); err != nil {
+		if err := t.sendSingleMessage(chatID, chunk, msg, i == 0); err != nil {
 			return err
 		}
 		// Small delay between split messages
@@ -267,6 +300,41 @@ func (t *Telegram) SendMessage(msg bus.OutboundMessage) error {
 		}
 	}
 	return nil
+}
+
+func (t *Telegram) sendMediaMessage(chatID int64, msg bus.OutboundMessage) error {
+	if msg.EditMsgID != "" {
+		return fmt.Errorf("telegram does not support editing media messages")
+	}
+	if len(msg.Buttons) > 0 {
+		return fmt.Errorf("telegram does not support inline keyboards on media messages")
+	}
+
+	mediaPaths, err := normalizeTelegramMediaPaths(msg.MediaPaths)
+	if err != nil {
+		return err
+	}
+
+	caption, overflowText := splitTelegramCaption(msg.Text)
+
+	if len(mediaPaths) == 1 {
+		if err := t.sendPhoto(chatID, mediaPaths[0], caption, msg.ParseMode, msg.ReplyToMsgID); err != nil {
+			return err
+		}
+	} else {
+		if err := t.sendPhotoAlbum(chatID, mediaPaths, caption, msg.ParseMode, msg.ReplyToMsgID); err != nil {
+			return err
+		}
+	}
+
+	if overflowText == "" {
+		return nil
+	}
+
+	return t.sendTextMessage(chatID, bus.OutboundMessage{
+		Text:      overflowText,
+		ParseMode: msg.ParseMode,
+	})
 }
 
 func (t *Telegram) sendSingleMessage(chatID int64, text string, msg bus.OutboundMessage, isFirst bool) error {
@@ -309,6 +377,111 @@ func (t *Telegram) sendSingleMessage(chatID int64, text string, msg bus.Outbound
 		}
 	}
 	return err
+}
+
+func (t *Telegram) sendPhotoAlbum(chatID int64, mediaPaths []string, caption string, parseMode string, replyToMsgID string) error {
+	for start := 0; start < len(mediaPaths); start += telegramMediaGroupMax {
+		end := start + telegramMediaGroupMax
+		if end > len(mediaPaths) {
+			end = len(mediaPaths)
+		}
+
+		batch := mediaPaths[start:end]
+		batchCaption := ""
+		batchReplyTo := ""
+		if start == 0 {
+			batchCaption = caption
+			batchReplyTo = replyToMsgID
+		}
+
+		if len(batch) == 1 {
+			if err := t.sendPhoto(chatID, batch[0], batchCaption, parseMode, batchReplyTo); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := t.sendMediaGroupBatch(chatID, batch, batchCaption, parseMode, batchReplyTo); err != nil {
+			slog.Warn("telegram media group failed, falling back to individual photos",
+				"chat_id", chatID,
+				"batch_size", len(batch),
+				"error", err,
+			)
+			if err := t.sendPhotosIndividually(chatID, batch, batchCaption, parseMode, batchReplyTo); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (t *Telegram) sendMediaGroupBatch(chatID int64, mediaPaths []string, caption string, parseMode string, replyToMsgID string) error {
+	replyID := parseTelegramReplyToMessageID(replyToMsgID)
+	var lastErr error
+
+	for _, mode := range telegramParseModes(parseMode) {
+		media := make([]interface{}, 0, len(mediaPaths))
+		for i, path := range mediaPaths {
+			photo := tgbotapi.NewInputMediaPhoto(tgbotapi.FilePath(path))
+			if i == 0 && caption != "" {
+				photo.Caption = formatTelegramCaption(caption, mode)
+				photo.ParseMode = mode
+			}
+			media = append(media, photo)
+		}
+
+		cfg := tgbotapi.NewMediaGroup(chatID, media)
+		if replyID > 0 {
+			cfg.ReplyToMessageID = replyID
+		}
+
+		if _, err := t.bot.SendMediaGroup(cfg); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+
+	return lastErr
+}
+
+func (t *Telegram) sendPhotosIndividually(chatID int64, mediaPaths []string, caption string, parseMode string, replyToMsgID string) error {
+	for i, path := range mediaPaths {
+		photoCaption := ""
+		photoReplyTo := ""
+		if i == 0 {
+			photoCaption = caption
+			photoReplyTo = replyToMsgID
+		}
+		if err := t.sendPhoto(chatID, path, photoCaption, parseMode, photoReplyTo); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Telegram) sendPhoto(chatID int64, mediaPath string, caption string, parseMode string, replyToMsgID string) error {
+	replyID := parseTelegramReplyToMessageID(replyToMsgID)
+	var lastErr error
+
+	for _, mode := range telegramParseModes(parseMode) {
+		photo := tgbotapi.NewPhoto(chatID, tgbotapi.FilePath(mediaPath))
+		if caption != "" {
+			photo.Caption = formatTelegramCaption(caption, mode)
+			photo.ParseMode = mode
+		}
+		if replyID > 0 {
+			photo.ReplyToMessageID = replyID
+		}
+
+		if _, err := t.bot.Send(photo); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+
+	return lastErr
 }
 
 func (t *Telegram) editMessage(chatID int64, msg bus.OutboundMessage) error {
@@ -354,6 +527,82 @@ func (t *Telegram) SendTyping(chatID string) error {
 	action := tgbotapi.NewChatAction(id, tgbotapi.ChatTyping)
 	_, err = t.bot.Send(action)
 	return err
+}
+
+func normalizeTelegramMediaPaths(paths []string) ([]string, error) {
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err != nil {
+			return nil, fmt.Errorf("telegram media path %q: %w", path, err)
+		}
+		if !isTelegramImagePath(path) {
+			return nil, fmt.Errorf("telegram media path %q is not a supported image", path)
+		}
+		normalized = append(normalized, path)
+	}
+	if len(normalized) == 0 {
+		return nil, fmt.Errorf("telegram media message has no valid image paths")
+	}
+	return normalized, nil
+}
+
+func isTelegramImagePath(path string) bool {
+	if _, ok := telegramImageExtensions[strings.ToLower(filepath.Ext(path))]; ok {
+		return true
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	header := make([]byte, 512)
+	n, err := f.Read(header)
+	if err != nil && err != io.EOF {
+		return false
+	}
+
+	return strings.HasPrefix(http.DetectContentType(header[:n]), "image/")
+}
+
+func splitTelegramCaption(text string) (caption string, overflow string) {
+	if len(text) <= telegramCaptionLimit {
+		return text, ""
+	}
+	return "", text
+}
+
+func parseTelegramReplyToMessageID(replyToMsgID string) int {
+	replyID, err := strconv.Atoi(replyToMsgID)
+	if err != nil {
+		return 0
+	}
+	return replyID
+}
+
+func telegramParseModes(parseMode string) []string {
+	switch parseMode {
+	case "MarkdownV2":
+		return []string{"MarkdownV2", "HTML", ""}
+	case "HTML":
+		return []string{"HTML", ""}
+	case "":
+		return []string{""}
+	default:
+		return []string{parseMode, ""}
+	}
+}
+
+func formatTelegramCaption(caption string, parseMode string) string {
+	if parseMode == "MarkdownV2" {
+		return escapeMarkdownV2(caption)
+	}
+	return caption
 }
 
 // escapeMarkdownV2 escapes special characters for Telegram MarkdownV2 format.

--- a/internal/channels/telegram_test.go
+++ b/internal/channels/telegram_test.go
@@ -1,0 +1,299 @@
+package channels
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
+	"github.com/fastclaw-ai/fastclaw/internal/bus"
+)
+
+type fakeTelegramBot struct {
+	sendCalls       []tgbotapi.Chattable
+	mediaGroupCalls []tgbotapi.MediaGroupConfig
+	mediaGroupErr   error
+}
+
+func (f *fakeTelegramBot) GetUpdatesChan(tgbotapi.UpdateConfig) tgbotapi.UpdatesChannel {
+	return nil
+}
+
+func (f *fakeTelegramBot) StopReceivingUpdates() {}
+
+func (f *fakeTelegramBot) GetFileDirectURL(string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeTelegramBot) Request(tgbotapi.Chattable) (*tgbotapi.APIResponse, error) {
+	return &tgbotapi.APIResponse{Ok: true}, nil
+}
+
+func (f *fakeTelegramBot) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
+	f.sendCalls = append(f.sendCalls, c)
+	return tgbotapi.Message{}, nil
+}
+
+func (f *fakeTelegramBot) SendMediaGroup(cfg tgbotapi.MediaGroupConfig) ([]tgbotapi.Message, error) {
+	f.mediaGroupCalls = append(f.mediaGroupCalls, cfg)
+	if f.mediaGroupErr != nil {
+		return nil, f.mediaGroupErr
+	}
+	return []tgbotapi.Message{}, nil
+}
+
+func TestTelegramSendMessageSinglePhotoUsesCaption(t *testing.T) {
+	tg, fake := newTestTelegram()
+	path := writeTestImage(t, "one.png")
+
+	err := tg.SendMessage(bus.OutboundMessage{
+		ChatID:     "42",
+		Text:       "hello image",
+		MediaPaths: []string{path},
+	})
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+
+	if len(fake.sendCalls) != 1 {
+		t.Fatalf("expected 1 send call, got %d", len(fake.sendCalls))
+	}
+
+	photo, ok := fake.sendCalls[0].(tgbotapi.PhotoConfig)
+	if !ok {
+		t.Fatalf("expected PhotoConfig, got %T", fake.sendCalls[0])
+	}
+	if photo.Caption != "hello image" {
+		t.Fatalf("expected caption %q, got %q", "hello image", photo.Caption)
+	}
+	filePath, ok := photo.File.(tgbotapi.FilePath)
+	if !ok {
+		t.Fatalf("expected FilePath, got %T", photo.File)
+	}
+	if string(filePath) != path {
+		t.Fatalf("expected file path %q, got %q", path, string(filePath))
+	}
+}
+
+func TestTelegramSendMessageMultiPhotoUsesMediaGroup(t *testing.T) {
+	tg, fake := newTestTelegram()
+	first := writeTestImage(t, "one.png")
+	second := writeTestImage(t, "two.png")
+
+	err := tg.SendMessage(bus.OutboundMessage{
+		ChatID:     "42",
+		Text:       "album caption",
+		MediaPaths: []string{first, second},
+	})
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+
+	if len(fake.mediaGroupCalls) != 1 {
+		t.Fatalf("expected 1 media group call, got %d", len(fake.mediaGroupCalls))
+	}
+	if len(fake.sendCalls) != 0 {
+		t.Fatalf("expected no direct send calls, got %d", len(fake.sendCalls))
+	}
+
+	cfg := fake.mediaGroupCalls[0]
+	if len(cfg.Media) != 2 {
+		t.Fatalf("expected 2 media items, got %d", len(cfg.Media))
+	}
+	firstPhoto, ok := cfg.Media[0].(tgbotapi.InputMediaPhoto)
+	if !ok {
+		t.Fatalf("expected first media item to be InputMediaPhoto, got %T", cfg.Media[0])
+	}
+	secondPhoto, ok := cfg.Media[1].(tgbotapi.InputMediaPhoto)
+	if !ok {
+		t.Fatalf("expected second media item to be InputMediaPhoto, got %T", cfg.Media[1])
+	}
+	if firstPhoto.Caption != "album caption" {
+		t.Fatalf("expected first caption %q, got %q", "album caption", firstPhoto.Caption)
+	}
+	if secondPhoto.Caption != "" {
+		t.Fatalf("expected second caption to be empty, got %q", secondPhoto.Caption)
+	}
+}
+
+func TestTelegramSendMessageLongTextSendsExtraMessage(t *testing.T) {
+	tg, fake := newTestTelegram()
+	first := writeTestImage(t, "one.png")
+	second := writeTestImage(t, "two.png")
+	longText := strings.Repeat("a", telegramCaptionLimit+1)
+
+	err := tg.SendMessage(bus.OutboundMessage{
+		ChatID:     "42",
+		Text:       longText,
+		MediaPaths: []string{first, second},
+	})
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+
+	if len(fake.mediaGroupCalls) != 1 {
+		t.Fatalf("expected 1 media group call, got %d", len(fake.mediaGroupCalls))
+	}
+	if len(fake.sendCalls) != 1 {
+		t.Fatalf("expected 1 text send call, got %d", len(fake.sendCalls))
+	}
+
+	firstPhoto := fake.mediaGroupCalls[0].Media[0].(tgbotapi.InputMediaPhoto)
+	if firstPhoto.Caption != "" {
+		t.Fatalf("expected empty media caption for long text, got %q", firstPhoto.Caption)
+	}
+
+	textMsg, ok := fake.sendCalls[0].(tgbotapi.MessageConfig)
+	if !ok {
+		t.Fatalf("expected MessageConfig, got %T", fake.sendCalls[0])
+	}
+	if textMsg.Text != longText {
+		t.Fatalf("expected text %q, got %q", longText, textMsg.Text)
+	}
+}
+
+func TestTelegramSendMessageFallsBackToIndividualPhotos(t *testing.T) {
+	tg, fake := newTestTelegram()
+	fake.mediaGroupErr = errors.New("media group failed")
+	first := writeTestImage(t, "one.png")
+	second := writeTestImage(t, "two.png")
+
+	err := tg.SendMessage(bus.OutboundMessage{
+		ChatID:     "42",
+		Text:       "fallback caption",
+		MediaPaths: []string{first, second},
+	})
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+
+	if len(fake.mediaGroupCalls) != 1 {
+		t.Fatalf("expected 1 media group attempt, got %d", len(fake.mediaGroupCalls))
+	}
+	if len(fake.sendCalls) != 2 {
+		t.Fatalf("expected 2 fallback photo sends, got %d", len(fake.sendCalls))
+	}
+
+	firstPhoto := fake.sendCalls[0].(tgbotapi.PhotoConfig)
+	secondPhoto := fake.sendCalls[1].(tgbotapi.PhotoConfig)
+	if firstPhoto.Caption != "fallback caption" {
+		t.Fatalf("expected first fallback caption %q, got %q", "fallback caption", firstPhoto.Caption)
+	}
+	if secondPhoto.Caption != "" {
+		t.Fatalf("expected second fallback caption to be empty, got %q", secondPhoto.Caption)
+	}
+}
+
+func TestTelegramSendMessageSplitsAlbumsAboveTelegramLimit(t *testing.T) {
+	tg, fake := newTestTelegram()
+	var paths []string
+	for i := 0; i < telegramMediaGroupMax+1; i++ {
+		paths = append(paths, writeTestImage(t, filepath.Join("batch", "img"+strconv.Itoa(i)+".png")))
+	}
+
+	err := tg.SendMessage(bus.OutboundMessage{
+		ChatID:     "42",
+		Text:       "batch caption",
+		MediaPaths: paths,
+	})
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+
+	if len(fake.mediaGroupCalls) != 1 {
+		t.Fatalf("expected 1 media group call, got %d", len(fake.mediaGroupCalls))
+	}
+	if len(fake.mediaGroupCalls[0].Media) != telegramMediaGroupMax {
+		t.Fatalf("expected first media group to contain %d items, got %d", telegramMediaGroupMax, len(fake.mediaGroupCalls[0].Media))
+	}
+	if len(fake.sendCalls) != 1 {
+		t.Fatalf("expected 1 trailing photo send, got %d", len(fake.sendCalls))
+	}
+
+	lastPhoto := fake.sendCalls[0].(tgbotapi.PhotoConfig)
+	if lastPhoto.Caption != "" {
+		t.Fatalf("expected trailing photo caption to be empty, got %q", lastPhoto.Caption)
+	}
+}
+
+func TestTelegramSendMessageRejectsButtonsWithMedia(t *testing.T) {
+	tg, fake := newTestTelegram()
+	path := writeTestImage(t, "one.png")
+
+	err := tg.SendMessage(bus.OutboundMessage{
+		ChatID:     "42",
+		Text:       "hello",
+		MediaPaths: []string{path},
+		Buttons: [][]bus.OutboundButton{
+			{{Text: "Open", URL: "https://example.com"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for media buttons, got nil")
+	}
+	if len(fake.sendCalls) != 0 || len(fake.mediaGroupCalls) != 0 {
+		t.Fatal("expected no Telegram API calls when media buttons are rejected")
+	}
+}
+
+func TestTelegramSendMessageRejectsEditWithMedia(t *testing.T) {
+	tg, fake := newTestTelegram()
+	path := writeTestImage(t, "one.png")
+
+	err := tg.SendMessage(bus.OutboundMessage{
+		ChatID:     "42",
+		EditMsgID:  "100",
+		MediaPaths: []string{path},
+	})
+	if err == nil {
+		t.Fatal("expected error for media edits, got nil")
+	}
+	if len(fake.sendCalls) != 0 || len(fake.mediaGroupCalls) != 0 {
+		t.Fatal("expected no Telegram API calls when media edit is rejected")
+	}
+}
+
+func TestTelegramSendMessageRejectsNonImagePath(t *testing.T) {
+	tg, _ := newTestTelegram()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "not-image.txt")
+	if err := os.WriteFile(path, []byte("plain text"), 0o644); err != nil {
+		t.Fatalf("write text file: %v", err)
+	}
+
+	err := tg.SendMessage(bus.OutboundMessage{
+		ChatID:     "42",
+		MediaPaths: []string{path},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-image media path, got nil")
+	}
+}
+
+func newTestTelegram() (*Telegram, *fakeTelegramBot) {
+	fake := &fakeTelegramBot{}
+	return &Telegram{bot: fake}, fake
+}
+
+func writeTestImage(t *testing.T, name string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create image dir: %v", err)
+	}
+	data := []byte{
+		0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n',
+		0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00,
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write test image: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
- support captions when sending Telegram images
- update Telegram channel handling for captioned media sends
- add tests covering caption behavior

## Testing
- not run locally