### PR TITLE
feat: add mem0 long-term memory hook

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -124,6 +124,18 @@ func newContextBuilderWithThinking(workspace string, memory *Memory, skillsSumma
 	return cb
 }
 
+// RegisterMem0Hook registers the mem0 before/after model call hooks for
+// long-term memory search (sync) and storage (async).
+func (a *Agent) RegisterMem0Hook(cfg config.Mem0Cfg) {
+	if !cfg.Enabled {
+		return
+	}
+	state := NewMem0HookState(cfg)
+	a.hooks.Register(BeforeModelCall, state.BeforeModelCallHook())
+	a.hooks.Register(AfterModelCall, state.AfterModelCallHook())
+	slog.Info("mem0 hook registered", "agent", a.name, "url", cfg.URL)
+}
+
 // Name returns the agent's name.
 func (a *Agent) Name() string {
 	return a.name

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -16,6 +16,11 @@ type Manager struct {
 
 // NewManager creates agents from resolved configs.
 func NewManager(resolved []config.ResolvedAgent, prov provider.Provider, mb *bus.MessageBus) (*Manager, error) {
+	return NewManagerWithMem0(resolved, prov, mb, config.Mem0Cfg{})
+}
+
+// NewManagerWithMem0 creates agents with optional mem0 memory integration.
+func NewManagerWithMem0(resolved []config.ResolvedAgent, prov provider.Provider, mb *bus.MessageBus, mem0Cfg config.Mem0Cfg) (*Manager, error) {
 	m := &Manager{
 		agents: make(map[string]*Agent),
 	}
@@ -27,6 +32,12 @@ func NewManager(resolved []config.ResolvedAgent, prov provider.Provider, mb *bus
 
 	for _, rc := range resolved {
 		ag := NewAgent(rc, prov, mb, homeDir)
+
+		// Register mem0 hooks if enabled
+		if mem0Cfg.Enabled {
+			ag.RegisterMem0Hook(mem0Cfg)
+		}
+
 		m.agents[rc.ID] = ag
 
 		slog.Info("loaded agent",

--- a/internal/agent/mem0_hook.go
+++ b/internal/agent/mem0_hook.go
@@ -1,0 +1,263 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+)
+
+// mem0SearchResult is a single memory entry from the Mem0 search API.
+type mem0SearchResult struct {
+	ID     string  `json:"id"`
+	Memory string  `json:"memory"`
+	Score  float64 `json:"score"`
+}
+
+// mem0SearchResponse is the response from POST /search.
+type mem0SearchResponse struct {
+	Results []mem0SearchResult `json:"results"`
+}
+
+// mem0AddRequest is the request body for POST /memories.
+type mem0AddRequest struct {
+	Messages []mem0Message      `json:"messages"`
+	UserID   string             `json:"user_id"`
+}
+
+type mem0Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Mem0HookState holds per-request state for the mem0 hook pair.
+// BeforeModelCall stores the user message; AfterModelCall uses it for async storage.
+type Mem0HookState struct {
+	cfg    config.Mem0Cfg
+	client *http.Client
+}
+
+// NewMem0HookState creates a new mem0 hook state.
+func NewMem0HookState(cfg config.Mem0Cfg) *Mem0HookState {
+	url := cfg.URL
+	if url == "" {
+		url = "http://127.0.0.1:8100"
+	}
+	cfg.URL = url
+	if cfg.TopK <= 0 {
+		cfg.TopK = 5
+	}
+	return &Mem0HookState{
+		cfg:    cfg,
+		client: &http.Client{Timeout: 3 * time.Second},
+	}
+}
+
+// BeforeModelCallHook searches mem0 for relevant memories and injects them
+// into the message list as a system message before the first model call.
+func (m *Mem0HookState) BeforeModelCallHook() HookFunc {
+	return func(ctx context.Context, hc *HookContext) {
+		if hc.Messages == nil || len(hc.Messages) < 2 {
+			return
+		}
+
+		// Only inject on the first model call (when there's exactly one user message
+		// at the end, no assistant messages yet).
+		hasAssistant := false
+		for _, msg := range hc.Messages {
+			if msg.Role == "assistant" {
+				hasAssistant = true
+				break
+			}
+		}
+		if hasAssistant {
+			return // not first turn, skip
+		}
+
+		// Extract user message (last message should be user)
+		lastMsg := hc.Messages[len(hc.Messages)-1]
+		if lastMsg.Role != "user" {
+			return
+		}
+		userText := lastMsg.Content
+
+		// Derive user_id from chat context in the runtime context line
+		userID := extractUserID(hc.Messages)
+		if userID == "" {
+			return
+		}
+
+		// Search mem0
+		memories, err := m.searchMemories(ctx, userID, userText)
+		if err != nil {
+			slog.Debug("mem0: search error", "error", err, "agent", hc.AgentName)
+			return
+		}
+		if len(memories) == 0 {
+			return
+		}
+
+		// Build memory injection
+		var sb strings.Builder
+		sb.WriteString("# User Memories (from long-term memory store)\n")
+		sb.WriteString("The following facts were previously learned about this user:\n")
+		for _, mem := range memories {
+			sb.WriteString(fmt.Sprintf("- %s\n", mem.Memory))
+		}
+		sb.WriteString("\nUse these memories to personalize your response when relevant.")
+
+		// Inject as a system message right before the last user message
+		injected := make([]provider.Message, 0, len(hc.Messages)+1)
+		injected = append(injected, hc.Messages[:len(hc.Messages)-1]...)
+		injected = append(injected, provider.Message{
+			Role:    "system",
+			Content: sb.String(),
+		})
+		injected = append(injected, lastMsg)
+		hc.Messages = injected
+
+		slog.Info("mem0: injected memories",
+			"agent", hc.AgentName,
+			"user_id", userID,
+			"count", len(memories),
+		)
+	}
+}
+
+// AfterModelCallHook asynchronously stores the conversation turn in mem0
+// when the model produces a final response (no tool calls).
+func (m *Mem0HookState) AfterModelCallHook() HookFunc {
+	return func(ctx context.Context, hc *HookContext) {
+		if hc.Response == nil || hc.Response.HasToolCalls() {
+			return // only store on final text response
+		}
+		if hc.Error != nil {
+			return
+		}
+
+		// Find last user message
+		var userText string
+		for i := len(hc.Messages) - 1; i >= 0; i-- {
+			if hc.Messages[i].Role == "user" {
+				userText = hc.Messages[i].Content
+				break
+			}
+		}
+		if userText == "" {
+			return
+		}
+
+		userID := extractUserID(hc.Messages)
+		if userID == "" {
+			return
+		}
+
+		assistantText := hc.Response.Content
+
+		// Store async — don't block the response
+		go func() {
+			storeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := m.storeMemory(storeCtx, userID, userText, assistantText); err != nil {
+				slog.Debug("mem0: store error", "error", err, "user_id", userID)
+			} else {
+				slog.Info("mem0: stored memory", "user_id", userID)
+			}
+		}()
+	}
+}
+
+// searchMemories calls POST /search on the mem0 server.
+func (m *Mem0HookState) searchMemories(ctx context.Context, userID, query string) ([]mem0SearchResult, error) {
+	body, _ := json.Marshal(map[string]interface{}{
+		"query":   query,
+		"user_id": userID,
+		"limit":   m.cfg.TopK,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, "POST", m.cfg.URL+"/search", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if m.cfg.APIKey != "" {
+		req.Header.Set("X-API-Key", m.cfg.APIKey)
+	}
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("mem0 search HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result mem0SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return result.Results, nil
+}
+
+// storeMemory calls POST /memories on the mem0 server.
+func (m *Mem0HookState) storeMemory(ctx context.Context, userID, userText, assistantText string) error {
+	body, _ := json.Marshal(mem0AddRequest{
+		Messages: []mem0Message{
+			{Role: "user", Content: userText},
+			{Role: "assistant", Content: assistantText},
+		},
+		UserID: userID,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, "POST", m.cfg.URL+"/memories", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if m.cfg.APIKey != "" {
+		req.Header.Set("X-API-Key", m.cfg.APIKey)
+	}
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("mem0 store HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// extractUserID derives a user identifier from the messages.
+// It looks for the "Chat ID:" line in the runtime context message.
+func extractUserID(messages []provider.Message) string {
+	for _, msg := range messages {
+		if msg.Role != "user" {
+			continue
+		}
+		for _, line := range strings.Split(msg.Content, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "Chat ID:") {
+				chatID := strings.TrimSpace(strings.TrimPrefix(line, "Chat ID:"))
+				if chatID != "" && chatID != "web-ui" {
+					return chatID
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,6 +114,14 @@ type GatewayCfg struct {
 	HTTP GatewayHTTP  `json:"http,omitempty"`
 }
 
+// Mem0Cfg configures the Mem0 memory integration.
+type Mem0Cfg struct {
+	Enabled  bool   `json:"enabled"`
+	URL      string `json:"url,omitempty"`      // default "http://127.0.0.1:8100"
+	APIKey   string `json:"apiKey,omitempty"`
+	TopK     int    `json:"topK,omitempty"`     // max memories to inject, default 5
+}
+
 // Config is the top-level configuration loaded from ~/.fastclaw/fastclaw.json.
 type Config struct {
 	Providers  map[string]ProviderConfig  `json:"providers"`
@@ -131,6 +139,7 @@ type Config struct {
 	Gateway    GatewayCfg                 `json:"gateway,omitempty"`
 	TaskQueue  TaskQueueCfg               `json:"taskQueue,omitempty"`
 	Skills     SkillsCfg                  `json:"skills,omitempty"`
+	Mem0       Mem0Cfg                    `json:"mem0,omitempty"`
 }
 
 // ProviderConfig holds API credentials for an LLM provider.

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -64,8 +64,8 @@ func New(cfg *config.Config) (*Gateway, error) {
 	// Resolve agent configs
 	resolved := config.ResolveAgents(cfg)
 
-	// Create agent manager
-	agentMgr, err := agent.NewManager(resolved, llm, mb)
+	// Create agent manager (with optional mem0 integration)
+	agentMgr, err := agent.NewManagerWithMem0(resolved, llm, mb, cfg.Mem0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Add native mem0 integration via FastClaw's hook system
- **BeforeModelCall**: searches mem0 for relevant memories, injects as system message (~50ms sync)
- **AfterModelCall**: stores conversation turns asynchronously (non-blocking)
- Per-user isolation via chat ID as user_id
- Works with any channel (WeChat, Telegram, Web Chat, etc.)

## Config

```json
{
  "mem0": {
    "enabled": true,
    "url": "http://127.0.0.1:8100",
    "apiKey": "your-mem0-api-key",
    "topK": 5
  }
}
```

## Files Changed

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `Mem0Cfg` struct |
| `internal/agent/mem0_hook.go` | New — mem0 search/store hook implementation |
| `internal/agent/manager.go` | Add `NewManagerWithMem0` constructor |
| `internal/agent/loop.go` | Add `RegisterMem0Hook` method |
| `internal/gateway/gateway.go` | Pass mem0 config to agent manager |

## Test Plan

- [x] Compiles successfully
- [x] Hook registered on gateway startup
- [x] mem0 search called before first model call
- [x] mem0 store called async after final response
- [ ] Memory injection visible in agent responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)