### PR TITLE
docs: add community plugins (WeChat, Mattermost)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ fastclaw plugins install @ollama/openclaw-web-search
 
 Browse available plugins at [FastClaw Hub](https://github.com/fastclaw-ai/fastclaw-hub).
 
+### Community Plugins
+
+| Plugin | Type | Description |
+|--------|------|-------------|
+| [fastclaw-plugin-weixin](https://github.com/videGavin/fastclaw-plugin-weixin) | Channel | WeChat messaging via ilink bot API (Node.js) |
+| [fastclaw-mattermost-plugin](https://github.com/cornking2020/fastclaw-mattermost-plugin) | Channel | Mattermost messaging via WebSocket API (Go) |
+
 ## 🖥 Web Dashboard
 
 Full management UI at `http://localhost:18953`:


### PR DESCRIPTION
## Summary

- Add a **Community Plugins** section to README.md listing third-party channel plugins
- Lists [fastclaw-plugin-weixin](https://github.com/videGavin/fastclaw-plugin-weixin) — WeChat messaging via ilink bot API (Node.js)
- Lists [fastclaw-mattermost-plugin](https://github.com/cornking2020/fastclaw-mattermost-plugin) — Mattermost via WebSocket API (Go)

## Context

The WeChat plugin was previously submitted as an in-tree plugin in #6. It has been refactored into a standalone repository following the same pattern as `fastclaw-mattermost-plugin`, making it independently versionable and installable.

Supersedes #6.

## Test plan

- [x] README renders correctly with the new Community Plugins table
- [x] All plugin repository links are valid and accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)