### PR TITLE
feat(agent): redesign agent loop with state-machine pattern

### DIFF
--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+)
+
+// AgentError is the base error type for all agent loop errors.
+// It carries structured RunErrorDetails so callers can inspect the full
+// context when something goes wrong.
+//
+// Mirrors the OpenAI Agents SDK's AgentsError pattern.
+type AgentError struct {
+	Err     error
+	RunData *RunErrorDetails
+}
+
+func (e *AgentError) Error() string { return e.Err.Error() }
+func (e *AgentError) Unwrap() error { return e.Err }
+
+// RunErrorDetails captures the full context at the point of failure.
+type RunErrorDetails struct {
+	Input                string            // original user input
+	Messages             []provider.Message // accumulated messages
+	ToolResults          []toolResult       // tool results produced so far
+	GuardrailResults     []GuardrailResult  // guardrail evaluations
+	TurnsCompleted       int                // how many turns ran
+}
+
+// MaxTurnsExceededError indicates the agent loop exceeded maxToolIterations.
+type MaxTurnsExceededError struct {
+	*AgentError
+	MaxTurns int
+}
+
+func NewMaxTurnsExceededError(maxTurns int, details *RunErrorDetails) *MaxTurnsExceededError {
+	return &MaxTurnsExceededError{
+		AgentError: &AgentError{
+			Err:     fmt.Errorf("max turns (%d) exceeded", maxTurns),
+			RunData: details,
+		},
+		MaxTurns: maxTurns,
+	}
+}
+
+// ModelBehaviorError indicates the LLM did something unexpected, such as
+// calling a non-existent tool or returning malformed JSON.
+type ModelBehaviorError struct {
+	*AgentError
+}
+
+func NewModelBehaviorError(msg string, details *RunErrorDetails) *ModelBehaviorError {
+	return &ModelBehaviorError{
+		AgentError: &AgentError{
+			Err:     fmt.Errorf("model behavior error: %s", msg),
+			RunData: details,
+		},
+	}
+}

--- a/internal/agent/guardrail.go
+++ b/internal/agent/guardrail.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// GuardrailOutput is the result of a guardrail evaluation.
+type GuardrailOutput struct {
+	// Info contains guardrail-specific output data for debugging.
+	Info any
+
+	// TripwireTriggered halts execution immediately when true.
+	TripwireTriggered bool
+}
+
+// InputGuardrail validates user input before the agent processes it.
+// If TripwireTriggered is true, the agent loop returns immediately
+// with an InputGuardrailTrippedError.
+//
+// Inspired by the OpenAI Agents SDK guardrail pattern.
+type InputGuardrail struct {
+	Name string
+	Func func(ctx context.Context, agent *Agent, input string) (GuardrailOutput, error)
+}
+
+// OutputGuardrail validates the agent's final output before returning it.
+type OutputGuardrail struct {
+	Name string
+	Func func(ctx context.Context, agent *Agent, output string) (GuardrailOutput, error)
+}
+
+// GuardrailResult captures the outcome of a guardrail evaluation.
+type GuardrailResult struct {
+	Name    string
+	Output  GuardrailOutput
+	Error   error
+}
+
+// runInputGuardrails executes all input guardrails in parallel.
+// Returns the first tripwire-triggered result, or nil if all pass.
+func runInputGuardrails(ctx context.Context, agent *Agent, input string, guardrails []InputGuardrail) (*GuardrailResult, error) {
+	if len(guardrails) == 0 {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make([]GuardrailResult, len(guardrails))
+	var wg sync.WaitGroup
+	wg.Add(len(guardrails))
+
+	for i, g := range guardrails {
+		go func(idx int, gr InputGuardrail) {
+			defer wg.Done()
+			out, err := gr.Func(ctx, agent, input)
+			results[idx] = GuardrailResult{Name: gr.Name, Output: out, Error: err}
+			if err != nil || out.TripwireTriggered {
+				cancel() // stop other guardrails
+			}
+		}(i, g)
+	}
+	wg.Wait()
+
+	// Check results
+	for _, r := range results {
+		if r.Error != nil {
+			slog.Warn("input guardrail error", "name", r.Name, "error", r.Error)
+			return &r, r.Error
+		}
+		if r.Output.TripwireTriggered {
+			slog.Warn("input guardrail tripwire triggered", "name", r.Name)
+			return &r, nil
+		}
+	}
+	return nil, nil
+}
+
+// runOutputGuardrails executes all output guardrails in parallel.
+func runOutputGuardrails(ctx context.Context, agent *Agent, output string, guardrails []OutputGuardrail) (*GuardrailResult, error) {
+	if len(guardrails) == 0 {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make([]GuardrailResult, len(guardrails))
+	var wg sync.WaitGroup
+	wg.Add(len(guardrails))
+
+	for i, g := range guardrails {
+		go func(idx int, gr OutputGuardrail) {
+			defer wg.Done()
+			out, err := gr.Func(ctx, agent, output)
+			results[idx] = GuardrailResult{Name: gr.Name, Output: out, Error: err}
+			if err != nil || out.TripwireTriggered {
+				cancel()
+			}
+		}(i, g)
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		if r.Error != nil {
+			slog.Warn("output guardrail error", "name", r.Name, "error", r.Error)
+			return &r, r.Error
+		}
+		if r.Output.TripwireTriggered {
+			slog.Warn("output guardrail tripwire triggered", "name", r.Name)
+			return &r, nil
+		}
+	}
+	return nil, nil
+}
+
+// InputGuardrailTrippedError indicates an input guardrail rejected the input.
+type InputGuardrailTrippedError struct {
+	GuardrailName string
+	Output        GuardrailOutput
+}
+
+func (e *InputGuardrailTrippedError) Error() string {
+	return fmt.Sprintf("input guardrail %q tripwire triggered", e.GuardrailName)
+}
+
+// OutputGuardrailTrippedError indicates an output guardrail rejected the output.
+type OutputGuardrailTrippedError struct {
+	GuardrailName string
+	Output        GuardrailOutput
+}
+
+func (e *OutputGuardrailTrippedError) Error() string {
+	return fmt.Sprintf("output guardrail %q tripwire triggered", e.GuardrailName)
+}

--- a/internal/agent/heartbeat.go
+++ b/internal/agent/heartbeat.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -63,29 +62,11 @@ func (hb *Heartbeat) Start(ctx context.Context) {
 }
 
 func (hb *Heartbeat) tick(ctx context.Context) {
-	slog.Info("heartbeat tick", "agent", hb.agent.Name())
+	slog.Debug("heartbeat tick (keepalive)", "agent", hb.agent.Name())
 
-	// 1. Check HEARTBEAT.md for tasks
-	tasks := hb.loadHeartbeatTasks()
-	if tasks != "" {
-		now := time.Now()
-		heartbeatMsg := fmt.Sprintf(
-			"[Heartbeat — %s]\nCurrent tasks from HEARTBEAT.md:\n%s\n\nReview these tasks and take action on any that need attention based on the current date/time.",
-			now.Format("2006-01-02 15:04:05"),
-			tasks,
-		)
-
-		// Feed as an inbound message through the bus
-		hb.bus.Inbound <- bus.InboundMessage{
-			Channel:  "heartbeat",
-			ChatID:   "heartbeat_" + hb.agent.Name(),
-			UserID:   "system",
-			Text:     heartbeatMsg,
-			PeerKind: "dm",
-		}
-	}
-
-	// 2. Trigger memory update
+	// Heartbeat is a pure keepalive signal — it does NOT trigger LLM calls.
+	// Its only job is to maintain the app's background connection and
+	// periodically consolidate long-term memory from conversation logs.
 	hb.updateMemory()
 }
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -18,19 +18,22 @@ const (
 	AfterModelCall
 	BeforeToolCall
 	AfterToolCall
+	OnAgentStart // fired once at the beginning of the agent run
+	OnAgentEnd   // fired once when the agent produces a final output
 )
 
 // HookContext carries data available to hooks at each hook point.
 type HookContext struct {
-	AgentName  string
-	Point      HookPoint
-	Messages   []provider.Message
-	ToolName   string // for tool-related hooks
-	ToolArgs   string // for BeforeToolCall
-	ToolResult string // for AfterToolCall
-	Response   *provider.Response
-	Error      error
-	StartTime  time.Time // set at BeforeModelCall/BeforeToolCall for timing
+	AgentName   string
+	Point       HookPoint
+	Messages    []provider.Message
+	ToolName    string // for tool-related hooks
+	ToolArgs    string // for BeforeToolCall
+	ToolResult  string // for AfterToolCall
+	Response    *provider.Response
+	FinalOutput string // for OnAgentEnd
+	Error       error
+	StartTime   time.Time // set at BeforeModelCall/BeforeToolCall for timing
 }
 
 // HookFunc is a function that runs at a hook point.
@@ -94,6 +97,10 @@ func LoggingHook() HookFunc {
 			slog.Debug("hook: before system prompt", "agent", hc.AgentName)
 		case AfterSystemPrompt:
 			slog.Debug("hook: after system prompt", "agent", hc.AgentName)
+		case OnAgentStart:
+			slog.Info("hook: agent start", "agent", hc.AgentName)
+		case OnAgentEnd:
+			slog.Info("hook: agent end", "agent", hc.AgentName)
 		}
 	}
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -17,7 +16,8 @@ import (
 	"github.com/fastclaw-ai/fastclaw/internal/session"
 )
 
-// Agent is the ReAct agent loop.
+// Agent is the agentic loop, using a state-machine pattern inspired by the
+// OpenAI Agents SDK. Each iteration returns a NextStep that drives the loop.
 type Agent struct {
 	name              string
 	provider          provider.Provider
@@ -38,6 +38,14 @@ type Agent struct {
 	globalSkillsCfg   config.SkillsCfg
 	messageBus        *bus.MessageBus
 	subAgentSpawner   tools.SubAgentSpawner
+
+	// runConfig holds optional guardrails and loop behavior settings.
+	runConfig *RunConfig
+}
+
+// SetRunConfig sets optional per-agent run configuration (guardrails, etc.).
+func (a *Agent) SetRunConfig(rc *RunConfig) {
+	a.runConfig = rc
 }
 
 // NewAgent creates a new Agent from a resolved config.
@@ -53,6 +61,13 @@ func NewAgentWithSkillsCfg(rc config.ResolvedAgent, prov provider.Provider, mb *
 	tools.RegisterMemorySearch(registry, rc.Workspace)
 	tools.RegisterWebFetch(registry)
 	tools.RegisterLoadSkill(registry, homeDir, rc.Workspace, "")
+
+	// Register image generation tool if endpoint is configured
+	if imgURL := os.Getenv("IMAGE_GEN_URL"); imgURL != "" {
+		imgAuth := os.Getenv("IMAGE_GEN_AUTH")
+		tools.RegisterGenerateImage(registry, imgURL, imgAuth, rc.ID)
+		slog.Info("registered generate_image tool", "agent", rc.ID)
+	}
 
 	// Load skills with OpenClaw compatibility
 	loader := NewSkillsLoaderWithGlobal(homeDir, rc.Workspace, "", rc.Skills, globalSkillsCfg)
@@ -190,27 +205,117 @@ func (a *Agent) Model() string {
 	return a.model
 }
 
-// HandleMessage processes an inbound message through the ReAct loop.
+// HandleMessage processes an inbound message through the agent loop.
+// The loop uses a state-machine pattern inspired by the OpenAI Agents SDK:
+// each iteration returns a NextStep that determines whether to return a final
+// response, execute more tools, or stop due to a detected loop.
 func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) string {
-	// Check for slash commands first
 	if result := a.handleSlashCommand(msg); result.handled {
 		return result.reply
 	}
 
+	sess, messages, toolDefs := a.prepareContext(msg)
+
+	// ── Input guardrails (parallel) ──
+	if a.runConfig != nil && len(a.runConfig.InputGuardrails) > 0 {
+		result, err := runInputGuardrails(ctx, a, msg.Text, a.runConfig.InputGuardrails)
+		if err != nil {
+			slog.Error("input guardrail error", "agent", a.name, "error", err)
+			return "Sorry, I can't process that request."
+		}
+		if result != nil && result.Output.TripwireTriggered {
+			slog.Warn("input guardrail tripped", "agent", a.name, "guardrail", result.Name)
+			return "Sorry, I can't process that request."
+		}
+	}
+
+	ld := &loopDetector{}
+	tracker := &toolUseTracker{}
+
+	for turn := 1; turn <= a.maxToolIterations; turn++ {
+		slog.Info("agent loop iteration",
+			"agent", a.name, "turn", turn,
+			"channel", msg.Channel, "chat_id", msg.ChatID,
+		)
+
+		// ── ResetToolChoice: after tools were used, reset to "auto" ──
+		a.maybeResetToolChoice(tracker)
+
+		// ── Call LLM ──
+		hcBefore := &HookContext{AgentName: a.name, Point: BeforeModelCall, Messages: messages}
+		a.hooks.Run(ctx, hcBefore)
+
+		resp, err := a.provider.Chat(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
+
+		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime}
+		a.hooks.Run(ctx, hcAfter)
+
+		if err != nil {
+			slog.Error("LLM chat failed", "agent", a.name, "error", err)
+			return "Sorry, I encountered an error processing your request."
+		}
+
+		// ── Decide next step ──
+		step := a.processLLMResponse(ctx, resp, messages, sess, msg, ld, nil)
+
+		switch s := step.NextStep.(type) {
+		case NextStepFinalOutput:
+			// ── Output guardrails (parallel) ──
+			if a.runConfig != nil && len(a.runConfig.OutputGuardrails) > 0 {
+				result, err := runOutputGuardrails(ctx, a, s.Content, a.runConfig.OutputGuardrails)
+				if err != nil {
+					slog.Error("output guardrail error", "agent", a.name, "error", err)
+					return "Sorry, I encountered an error validating the response."
+				}
+				if result != nil && result.Output.TripwireTriggered {
+					slog.Warn("output guardrail tripped", "agent", a.name, "guardrail", result.Name)
+					return "Sorry, I can't provide that response."
+				}
+			}
+			return s.Content
+
+		case NextStepRunAgain:
+			tracker.markUsed()
+			messages = step.Messages
+			continue
+
+		case NextStepLoopDetected:
+			slog.Warn("breaking agent loop due to loop detection", "agent", a.name)
+		}
+		break
+	}
+
+	slog.Warn("max tool iterations reached", "agent", a.name, "max", a.maxToolIterations)
+	return "I've reached the maximum number of tool iterations. Here's what I have so far."
+}
+
+// maybeResetToolChoice resets tool_choice to "auto" after tools have been used,
+// preventing infinite tool-calling loops. Mirrors the OpenAI Agents SDK's
+// MaybeResetToolChoice behavior.
+func (a *Agent) maybeResetToolChoice(tracker *toolUseTracker) {
+	if !tracker.hasUsedTools() {
+		return
+	}
+	if a.runConfig != nil && !a.runConfig.shouldResetToolChoice() {
+		return
+	}
+	if tcp, ok := a.provider.(provider.ToolChoiceProvider); ok {
+		tcp.SetToolChoice("auto")
+	}
+}
+
+// prepareContext builds the session, messages array, and tool definitions
+// shared by both HandleMessage and HandleMessageStream.
+func (a *Agent) prepareContext(msg bus.InboundMessage) (*session.Session, []provider.Message, []provider.Tool) {
 	sess := a.sessions.Get(msg.Channel, msg.ChatID)
 
-	// Hook: BeforeSystemPrompt
-	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: BeforeSystemPrompt})
-
+	a.hooks.Run(context.Background(), &HookContext{AgentName: a.name, Point: BeforeSystemPrompt})
 	systemPrompt := a.ctxBuilder.BuildSystemPrompt()
-
-	// Hook: AfterSystemPrompt
-	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: AfterSystemPrompt})
+	a.hooks.Run(context.Background(), &HookContext{AgentName: a.name, Point: AfterSystemPrompt})
 
 	runtimeCtx := a.ctxBuilder.BuildRuntimeContext(msg.Channel, msg.ChatID)
 	userContent := runtimeCtx + "\n\n" + msg.Text
 
-	// Build user message - include image if present
 	userMsg := provider.Message{Role: "user", Content: userContent}
 	if msg.PhotoURL != "" {
 		userMsg.Content = ""
@@ -221,14 +326,13 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 	}
 	sess.Append(userMsg)
 
-	// Context compaction: check if session messages are too large
+	// Context compaction
 	sessionMsgs := sess.GetMessages()
 	compactResult, err := CompactMessages(sessionMsgs, a.workspacePath, a.provider, a.model)
 	if err != nil {
 		slog.Warn("compaction error", "agent", a.name, "error", err)
 	}
 	if compactResult != nil && compactResult.Pruned {
-		// Replace session messages with compacted version
 		sess.ReplaceMessages(compactResult.Messages)
 		sessionMsgs = compactResult.Messages
 		slog.Info("context compacted", "agent", a.name, "log_file", compactResult.LogFile)
@@ -238,221 +342,119 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 	messages = append(messages, provider.Message{Role: "system", Content: systemPrompt})
 	messages = append(messages, sessionMsgs...)
 
-	toolDefs := a.registry.Definitions()
-
-	// Loop detection: track consecutive identical tool calls
-	type toolCallSig struct {
-		name string
-		hash [32]byte
-	}
-	var lastSig toolCallSig
-	consecutiveCount := 0
-
-	// ReAct loop
-	for i := 0; i < a.maxToolIterations; i++ {
-		slog.Info("agent loop iteration",
-			"agent", a.name,
-			"iteration", i+1,
-			"channel", msg.Channel,
-			"chat_id", msg.ChatID,
-		)
-
-		// Hook: BeforeModelCall
-		hcBefore := &HookContext{AgentName: a.name, Point: BeforeModelCall, Messages: messages}
-		a.hooks.Run(ctx, hcBefore)
-
-		resp, err := a.provider.Chat(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
-
-		// Hook: AfterModelCall
-		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime}
-		a.hooks.Run(ctx, hcAfter)
-
-		if err != nil {
-			slog.Error("LLM chat failed", "agent", a.name, "error", err)
-			return "Sorry, I encountered an error processing your request."
-		}
-
-		if !resp.HasToolCalls() {
-			sess.Append(provider.Message{Role: "assistant", Content: resp.Content})
-			return resp.Content
-		}
-
-		assistantMsg := provider.Message{
-			Role:      "assistant",
-			Content:   resp.Content,
-			ToolCalls: resp.ToolCalls,
-		}
-		sess.Append(assistantMsg)
-		messages = append(messages, assistantMsg)
-
-		loopDetected := false
-		for _, tc := range resp.ToolCalls {
-			// Loop detection
-			sig := toolCallSig{
-				name: tc.Function.Name,
-				hash: sha256.Sum256([]byte(tc.Function.Arguments)),
-			}
-			if sig.name == lastSig.name && sig.hash == lastSig.hash {
-				consecutiveCount++
-			} else {
-				consecutiveCount = 1
-				lastSig = sig
-			}
-			if consecutiveCount >= 3 {
-				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
-				warnMsg := provider.Message{
-					Role:    "system",
-					Content: "Loop detected: you called the same tool with the same arguments 3 times. Please try a different approach.",
-				}
-				sess.Append(warnMsg)
-				messages = append(messages, warnMsg)
-				loopDetected = true
-				break
-			}
-
-			// Hook: BeforeToolCall
-			hcToolBefore := &HookContext{
-				AgentName: a.name,
-				Point:     BeforeToolCall,
-				ToolName:  tc.Function.Name,
-				ToolArgs:  tc.Function.Arguments,
-			}
-			a.hooks.Run(ctx, hcToolBefore)
-
-			slog.Info("executing tool",
-				"agent", a.name,
-				"name", tc.Function.Name,
-				"id", tc.ID,
-			)
-
-			result, err := a.registry.Execute(ctx, tc.Function.Name, tc.Function.Arguments)
-
-			// Hook: AfterToolCall
-			hcToolAfter := &HookContext{
-				AgentName:  a.name,
-				Point:      AfterToolCall,
-				ToolName:   tc.Function.Name,
-				ToolResult: result,
-				Error:      err,
-				StartTime:  hcToolBefore.StartTime,
-			}
-			a.hooks.Run(ctx, hcToolAfter)
-
-			if err != nil {
-				slog.Warn("tool execution error",
-					"agent", a.name,
-					"name", tc.Function.Name,
-					"error", err,
-				)
-			}
-
-			// Check for MEDIA: protocol in tool output
-			if mediaPaths := extractMediaPaths(result); len(mediaPaths) > 0 {
-				a.sendMediaFiles(msg, mediaPaths)
-			}
-
-			toolMsg := provider.Message{
-				Role:       "tool",
-				Content:    result,
-				ToolCallID: tc.ID,
-				Name:       tc.Function.Name,
-			}
-			sess.Append(toolMsg)
-			messages = append(messages, toolMsg)
-		}
-		if loopDetected {
-			break
-		}
-	}
-
-	slog.Warn("max tool iterations reached", "agent", a.name, "max", a.maxToolIterations)
-	return "I've reached the maximum number of tool iterations. Here's what I have so far."
+	return sess, messages, a.registry.Definitions()
 }
 
-// HandleMessageStream processes a message through the ReAct loop and returns
-// a StreamReader for the final response. Tool call iterations use non-streaming Chat;
-// the final text response uses ChatStream for true SSE streaming.
+// processLLMResponse examines the LLM response and returns a stepResult:
+//   - No tool calls → NextStepFinalOutput
+//   - Tool calls present → execute them (parallel/serial), return NextStepRunAgain
+//   - Loop detected → NextStepLoopDetected
+func (a *Agent) processLLMResponse(
+	ctx context.Context,
+	resp *provider.Response,
+	messages []provider.Message,
+	sess *session.Session,
+	msg bus.InboundMessage,
+	ld *loopDetector,
+	sendEvent func(provider.ToolEvent),
+) stepResult {
+	// No tool calls → final output
+	if !resp.HasToolCalls() {
+		sess.Append(provider.Message{Role: "assistant", Content: resp.Content})
+		return stepResult{
+			NextStep: NextStepFinalOutput{Content: resp.Content},
+			Messages: messages,
+		}
+	}
+
+	// Append assistant message with tool calls
+	assistantMsg := provider.Message{
+		Role:      "assistant",
+		Content:   resp.Content,
+		ToolCalls: resp.ToolCalls,
+	}
+	sess.Append(assistantMsg)
+	messages = append(messages, assistantMsg)
+
+	// Execute tools — stateless in parallel, stateful serially
+	messages, next := a.processToolCalls(ctx, resp.ToolCalls, messages, sess, msg, ld, sendEvent)
+
+	return stepResult{NextStep: next, Messages: messages}
+}
+
+// HandleMessageStream processes a message through the agent loop and returns
+// a StreamReader for the final response. Tool call iterations use non-streaming
+// Chat; tool_event chunks are emitted so SSE consumers can show real-time
+// progress. The final text response uses ChatStream for true SSE streaming.
 func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage) *provider.StreamReader {
-	// Reuse setup logic from HandleMessage
 	if result := a.handleSlashCommand(msg); result.handled {
-		ch := make(chan provider.StreamChunk, 2)
-		go func() {
-			ch <- provider.StreamChunk{Content: result.reply, Done: true}
-			close(ch)
-		}()
-		return provider.NewStreamReader(ch)
+		return a.stringStream(result.reply)
 	}
 
-	sess := a.sessions.Get(msg.Channel, msg.ChatID)
-	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: BeforeSystemPrompt})
-	systemPrompt := a.ctxBuilder.BuildSystemPrompt()
-	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: AfterSystemPrompt})
+	sess, messages, toolDefs := a.prepareContext(msg)
 
-	runtimeCtx := a.ctxBuilder.BuildRuntimeContext(msg.Channel, msg.ChatID)
-	userContent := runtimeCtx + "\n\n" + msg.Text
+	outCh := make(chan provider.StreamChunk, 64)
+	outReader := provider.NewStreamReader(outCh)
 
-	userMsg := provider.Message{Role: "user", Content: userContent}
-	if msg.PhotoURL != "" {
-		userMsg.Content = ""
-		userMsg.ContentParts = []provider.ContentPart{
-			{Type: "text", Text: userContent},
-			{Type: "image_url", ImageURL: &provider.ImageURL{URL: msg.PhotoURL, Detail: "auto"}},
+	sendEvent := func(te provider.ToolEvent) {
+		select {
+		case outCh <- provider.StreamChunk{ToolEvent: &te}:
+		case <-ctx.Done():
 		}
 	}
-	sess.Append(userMsg)
 
-	sessionMsgs := sess.GetMessages()
-	compactResult, err := CompactMessages(sessionMsgs, a.workspacePath, a.provider, a.model)
-	if err != nil {
-		slog.Warn("compaction error", "agent", a.name, "error", err)
-	}
-	if compactResult != nil && compactResult.Pruned {
-		sess.ReplaceMessages(compactResult.Messages)
-		sessionMsgs = compactResult.Messages
-	}
+	go func() {
+		defer close(outCh)
 
-	messages := make([]provider.Message, 0, len(sessionMsgs)+1)
-	messages = append(messages, provider.Message{Role: "system", Content: systemPrompt})
-	messages = append(messages, sessionMsgs...)
-
-	toolDefs := a.registry.Definitions()
-
-	type toolCallSig struct {
-		name string
-		hash [32]byte
-	}
-	var lastSig toolCallSig
-	consecutiveCount := 0
-
-	// ReAct loop - use Chat for tool iterations
-	for i := 0; i < a.maxToolIterations; i++ {
-		hcBefore := &HookContext{AgentName: a.name, Point: BeforeModelCall, Messages: messages}
-		a.hooks.Run(ctx, hcBefore)
-
-		resp, err := a.provider.Chat(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
-
-		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime}
-		a.hooks.Run(ctx, hcAfter)
-
-		if err != nil {
-			slog.Error("LLM chat failed", "agent", a.name, "error", err)
-			return a.stringStream("Sorry, I encountered an error processing your request.")
+		// ── Input guardrails (parallel) ──
+		if a.runConfig != nil && len(a.runConfig.InputGuardrails) > 0 {
+			result, err := runInputGuardrails(ctx, a, msg.Text, a.runConfig.InputGuardrails)
+			if err != nil || (result != nil && result.Output.TripwireTriggered) {
+				outCh <- provider.StreamChunk{Content: "Sorry, I can't process that request.", Done: true}
+				return
+			}
 		}
 
-		if !resp.HasToolCalls() {
-			// Final response - use streaming
-			sr, err := a.provider.ChatStream(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
+		ld := &loopDetector{}
+		tracker := &toolUseTracker{}
+
+		for turn := 1; turn <= a.maxToolIterations; turn++ {
+			// ── ResetToolChoice ──
+			a.maybeResetToolChoice(tracker)
+
+			// ── Call LLM (non-streaming) to check for tool calls ──
+			hcBefore := &HookContext{AgentName: a.name, Point: BeforeModelCall, Messages: messages}
+			a.hooks.Run(ctx, hcBefore)
+
+			resp, err := a.provider.Chat(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
+
+			hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime}
+			a.hooks.Run(ctx, hcAfter)
+
 			if err != nil {
-				slog.Error("LLM stream failed, falling back", "agent", a.name, "error", err)
-				sess.Append(provider.Message{Role: "assistant", Content: resp.Content})
-				return a.stringStream(resp.Content)
+				slog.Error("LLM chat failed", "agent", a.name, "error", err)
+				outCh <- provider.StreamChunk{Content: "Sorry, I encountered an error processing your request.", Done: true}
+				return
 			}
 
-			// Collect content in background for session storage
-			outCh := make(chan provider.StreamChunk, 64)
-			outReader := provider.NewStreamReader(outCh)
-			go func() {
-				defer close(outCh)
+			// ── No tool calls → stream the final text response ──
+			if !resp.HasToolCalls() {
+				// ── Output guardrails ──
+				if a.runConfig != nil && len(a.runConfig.OutputGuardrails) > 0 {
+					result, gErr := runOutputGuardrails(ctx, a, resp.Content, a.runConfig.OutputGuardrails)
+					if gErr != nil || (result != nil && result.Output.TripwireTriggered) {
+						outCh <- provider.StreamChunk{Content: "Sorry, I can't provide that response.", Done: true}
+						return
+					}
+				}
+
+				sr, err := a.provider.ChatStream(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
+				if err != nil {
+					slog.Error("LLM stream failed, falling back", "agent", a.name, "error", err)
+					sess.Append(provider.Message{Role: "assistant", Content: resp.Content})
+					outCh <- provider.StreamChunk{Content: resp.Content, Done: true}
+					return
+				}
 				var full strings.Builder
 				for {
 					chunk, ok := sr.Next()
@@ -469,70 +471,27 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 					}
 				}
 				sess.Append(provider.Message{Role: "assistant", Content: full.String()})
-			}()
-			return outReader
-		}
-
-		// Tool calls - process synchronously
-		assistantMsg := provider.Message{
-			Role:      "assistant",
-			Content:   resp.Content,
-			ToolCalls: resp.ToolCalls,
-		}
-		sess.Append(assistantMsg)
-		messages = append(messages, assistantMsg)
-
-		loopDetected := false
-		for _, tc := range resp.ToolCalls {
-			sig := toolCallSig{
-				name: tc.Function.Name,
-				hash: sha256.Sum256([]byte(tc.Function.Arguments)),
+				return
 			}
-			if sig.name == lastSig.name && sig.hash == lastSig.hash {
-				consecutiveCount++
-			} else {
-				consecutiveCount = 1
-				lastSig = sig
-			}
-			if consecutiveCount >= 3 {
-				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
-				warnMsg := provider.Message{
-					Role:    "system",
-					Content: "Loop detected: you called the same tool with the same arguments 3 times. Please try a different approach.",
-				}
-				sess.Append(warnMsg)
-				messages = append(messages, warnMsg)
-				loopDetected = true
+
+			// ── Tool calls → process via state machine ──
+			step := a.processLLMResponse(ctx, resp, messages, sess, msg, ld, sendEvent)
+
+			switch step.NextStep.(type) {
+			case NextStepRunAgain:
+				tracker.markUsed()
+				messages = step.Messages
+				continue
+			default:
 				break
 			}
-
-			hcToolBefore := &HookContext{AgentName: a.name, Point: BeforeToolCall, ToolName: tc.Function.Name, ToolArgs: tc.Function.Arguments}
-			a.hooks.Run(ctx, hcToolBefore)
-
-			result, execErr := a.registry.Execute(ctx, tc.Function.Name, tc.Function.Arguments)
-
-			hcToolAfter := &HookContext{AgentName: a.name, Point: AfterToolCall, ToolName: tc.Function.Name, ToolResult: result, Error: execErr, StartTime: hcToolBefore.StartTime}
-			a.hooks.Run(ctx, hcToolAfter)
-
-			if execErr != nil {
-				slog.Warn("tool execution error", "agent", a.name, "name", tc.Function.Name, "error", execErr)
-			}
-
-			// Check for MEDIA: protocol in tool output
-			if mediaPaths := extractMediaPaths(result); len(mediaPaths) > 0 {
-				a.sendMediaFiles(msg, mediaPaths)
-			}
-
-			toolMsg := provider.Message{Role: "tool", Content: result, ToolCallID: tc.ID, Name: tc.Function.Name}
-			sess.Append(toolMsg)
-			messages = append(messages, toolMsg)
-		}
-		if loopDetected {
 			break
 		}
-	}
 
-	return a.stringStream("I've reached the maximum number of tool iterations. Here's what I have so far.")
+		outCh <- provider.StreamChunk{Content: "I've reached the maximum number of tool iterations. Here's what I have so far.", Done: true}
+	}()
+
+	return outReader
 }
 
 // stringStream creates a StreamReader that yields a single string.

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -88,6 +88,8 @@ func NewAgentWithSkillsCfg(rc config.ResolvedAgent, prov provider.Provider, mb *
 	hooks.Register(AfterModelCall, LoggingHook())
 	hooks.Register(BeforeToolCall, LoggingHook())
 	hooks.Register(AfterToolCall, LoggingHook())
+	hooks.Register(OnAgentStart, LoggingHook())
+	hooks.Register(OnAgentEnd, LoggingHook())
 
 	ag := &Agent{
 		name:              rc.ID,
@@ -205,27 +207,49 @@ func (a *Agent) Model() string {
 	return a.model
 }
 
-// HandleMessage processes an inbound message through the agent loop.
-// The loop uses a state-machine pattern inspired by the OpenAI Agents SDK:
-// each iteration returns a NextStep that determines whether to return a final
-// response, execute more tools, or stop due to a detected loop.
+// HandleMessage processes an inbound message and returns the final text.
+// It is a convenience wrapper around HandleMessageFull.
 func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) string {
 	if result := a.handleSlashCommand(msg); result.handled {
 		return result.reply
 	}
+	r := a.HandleMessageFull(ctx, msg)
+	return r.FinalOutput
+}
+
+// HandleMessageFull processes an inbound message through the agent loop and
+// returns a full RunResult with all intermediate data.
+//
+// The loop uses a state-machine pattern inspired by the OpenAI Agents SDK:
+// each iteration returns a NextStep that determines whether to return a final
+// response, execute more tools, or stop due to a detected loop.
+func (a *Agent) HandleMessageFull(ctx context.Context, msg bus.InboundMessage) *RunResult {
+	rr := &RunResult{Input: msg.Text}
 
 	sess, messages, toolDefs := a.prepareContext(msg)
+
+	// ── Hook: OnAgentStart ──
+	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: OnAgentStart})
 
 	// ── Input guardrails (parallel) ──
 	if a.runConfig != nil && len(a.runConfig.InputGuardrails) > 0 {
 		result, err := runInputGuardrails(ctx, a, msg.Text, a.runConfig.InputGuardrails)
+		if result != nil {
+			rr.InputGuardrailResults = append(rr.InputGuardrailResults, *result)
+		}
 		if err != nil {
 			slog.Error("input guardrail error", "agent", a.name, "error", err)
-			return "Sorry, I can't process that request."
+			rr.FinalOutput = "Sorry, I can't process that request."
+			rr.Error = &InputGuardrailTrippedError{GuardrailName: result.Name, Output: result.Output}
+			rr.Messages = messages
+			return rr
 		}
 		if result != nil && result.Output.TripwireTriggered {
 			slog.Warn("input guardrail tripped", "agent", a.name, "guardrail", result.Name)
-			return "Sorry, I can't process that request."
+			rr.FinalOutput = "Sorry, I can't process that request."
+			rr.Error = &InputGuardrailTrippedError{GuardrailName: result.Name, Output: result.Output}
+			rr.Messages = messages
+			return rr
 		}
 	}
 
@@ -233,12 +257,14 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 	tracker := &toolUseTracker{}
 
 	for turn := 1; turn <= a.maxToolIterations; turn++ {
+		rr.TurnsUsed = turn
+
 		slog.Info("agent loop iteration",
 			"agent", a.name, "turn", turn,
 			"channel", msg.Channel, "chat_id", msg.ChatID,
 		)
 
-		// ── ResetToolChoice: after tools were used, reset to "auto" ──
+		// ── ResetToolChoice ──
 		a.maybeResetToolChoice(tracker)
 
 		// ── Call LLM ──
@@ -252,7 +278,10 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 
 		if err != nil {
 			slog.Error("LLM chat failed", "agent", a.name, "error", err)
-			return "Sorry, I encountered an error processing your request."
+			rr.FinalOutput = "Sorry, I encountered an error processing your request."
+			rr.Error = err
+			rr.Messages = messages
+			return rr
 		}
 
 		// ── Decide next step ──
@@ -263,16 +292,30 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 			// ── Output guardrails (parallel) ──
 			if a.runConfig != nil && len(a.runConfig.OutputGuardrails) > 0 {
 				result, err := runOutputGuardrails(ctx, a, s.Content, a.runConfig.OutputGuardrails)
+				if result != nil {
+					rr.OutputGuardrailResults = append(rr.OutputGuardrailResults, *result)
+				}
 				if err != nil {
 					slog.Error("output guardrail error", "agent", a.name, "error", err)
-					return "Sorry, I encountered an error validating the response."
+					rr.FinalOutput = "Sorry, I encountered an error validating the response."
+					rr.Error = err
+					rr.Messages = step.Messages
+					return rr
 				}
 				if result != nil && result.Output.TripwireTriggered {
 					slog.Warn("output guardrail tripped", "agent", a.name, "guardrail", result.Name)
-					return "Sorry, I can't provide that response."
+					rr.FinalOutput = "Sorry, I can't provide that response."
+					rr.Error = &OutputGuardrailTrippedError{GuardrailName: result.Name, Output: result.Output}
+					rr.Messages = step.Messages
+					return rr
 				}
 			}
-			return s.Content
+
+			rr.FinalOutput = s.Content
+			rr.Messages = step.Messages
+			// ── Hook: OnAgentEnd ──
+			a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: OnAgentEnd, FinalOutput: s.Content})
+			return rr
 
 		case NextStepRunAgain:
 			tracker.markUsed()
@@ -285,8 +328,26 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 		break
 	}
 
+	// ── Max turns exceeded ──
 	slog.Warn("max tool iterations reached", "agent", a.name, "max", a.maxToolIterations)
-	return "I've reached the maximum number of tool iterations. Here's what I have so far."
+
+	// Allow custom handling via OnMaxTurns callback
+	fallback := "I've reached the maximum number of tool iterations. Here's what I have so far."
+	if a.runConfig != nil && a.runConfig.OnMaxTurns != nil {
+		if custom := a.runConfig.OnMaxTurns(ctx, messages); custom != "" {
+			fallback = custom
+		}
+	}
+
+	rr.FinalOutput = fallback
+	rr.Error = NewMaxTurnsExceededError(a.maxToolIterations, &RunErrorDetails{
+		Input:          msg.Text,
+		Messages:       messages,
+		TurnsCompleted: rr.TurnsUsed,
+	})
+	rr.Messages = messages
+	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: OnAgentEnd, FinalOutput: fallback})
+	return rr
 }
 
 // maybeResetToolChoice resets tool_choice to "auto" after tools have been used,

--- a/internal/agent/result.go
+++ b/internal/agent/result.go
@@ -1,0 +1,45 @@
+package agent
+
+import "github.com/fastclaw-ai/fastclaw/internal/provider"
+
+// RunResult is the complete outcome of an agent run, providing full visibility
+// into every step the agent took. Callers can use this for auditing, logging,
+// analytics, or replaying the conversation.
+//
+// Mirrors the OpenAI Agents SDK's RunResult pattern.
+type RunResult struct {
+	// FinalOutput is the agent's final text response (empty if the run errored).
+	FinalOutput string
+
+	// Input is the original user input text.
+	Input string
+
+	// Messages is the complete message history including system, user,
+	// assistant, and tool messages produced during the run.
+	Messages []provider.Message
+
+	// ToolCalls records every tool call made during the run, in order.
+	ToolCalls []ToolCallRecord
+
+	// TurnsUsed is the number of LLM invocations (turns) that occurred.
+	TurnsUsed int
+
+	// InputGuardrailResults captures the outcome of each input guardrail.
+	InputGuardrailResults []GuardrailResult
+
+	// OutputGuardrailResults captures the outcome of each output guardrail.
+	OutputGuardrailResults []GuardrailResult
+
+	// Error is non-nil if the run ended due to an error (max turns, guardrail
+	// tripwire, LLM failure, etc.). FinalOutput may still contain a fallback
+	// message in this case.
+	Error error
+}
+
+// ToolCallRecord captures a single tool invocation for the RunResult.
+type ToolCallRecord struct {
+	Name      string
+	Arguments string
+	Result    string
+	Error     error
+}

--- a/internal/agent/step.go
+++ b/internal/agent/step.go
@@ -1,0 +1,264 @@
+package agent
+
+import (
+	"context"
+	"crypto/sha256"
+	"log/slog"
+	"sync"
+
+	"github.com/fastclaw-ai/fastclaw/internal/bus"
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+	"github.com/fastclaw-ai/fastclaw/internal/session"
+)
+
+// NextStep represents the decision after processing one LLM turn.
+// Inspired by OpenAI Agents SDK's state machine pattern.
+type NextStep interface{ nextStep() }
+
+// NextStepFinalOutput indicates the agent produced a final text response.
+type NextStepFinalOutput struct {
+	Content string
+}
+
+// NextStepRunAgain indicates tool calls were executed; the LLM should be
+// invoked again with the updated message history.
+type NextStepRunAgain struct{}
+
+// NextStepLoopDetected indicates a tool loop was detected and the agent
+// should stop iterating.
+type NextStepLoopDetected struct{}
+
+func (NextStepFinalOutput) nextStep()  {}
+func (NextStepRunAgain) nextStep()     {}
+func (NextStepLoopDetected) nextStep() {}
+
+// stepResult bundles the next-step decision with the updated message history.
+type stepResult struct {
+	NextStep NextStep
+	Messages []provider.Message
+}
+
+// RunConfig holds per-run configuration for the agent loop.
+type RunConfig struct {
+	InputGuardrails  []InputGuardrail
+	OutputGuardrails []OutputGuardrail
+
+	// ResetToolChoice resets tool_choice to nil after tools are used,
+	// preventing infinite tool-calling loops. Default: true.
+	// Mirrors OpenAI Agents SDK's ResetToolChoice behavior.
+	ResetToolChoice *bool
+}
+
+// shouldResetToolChoice returns whether tool_choice should be reset after use.
+func (rc *RunConfig) shouldResetToolChoice() bool {
+	if rc == nil || rc.ResetToolChoice == nil {
+		return true // default: reset
+	}
+	return *rc.ResetToolChoice
+}
+
+// toolUseTracker tracks whether tools have been used in the current run,
+// used to decide when to reset tool_choice (OpenAI Agents SDK pattern).
+type toolUseTracker struct {
+	used bool
+}
+
+func (t *toolUseTracker) markUsed()    { t.used = true }
+func (t *toolUseTracker) hasUsedTools() bool { return t.used }
+
+// loopDetector tracks consecutive identical tool calls to break infinite loops.
+type loopDetector struct {
+	lastName string
+	lastHash [32]byte
+	count    int
+}
+
+func (ld *loopDetector) check(name, args string) bool {
+	hash := sha256.Sum256([]byte(args))
+	if name == ld.lastName && hash == ld.lastHash {
+		ld.count++
+	} else {
+		ld.count = 1
+		ld.lastName = name
+		ld.lastHash = hash
+	}
+	return ld.count >= 3
+}
+
+// toolResult holds the output of a single tool execution.
+type toolResult struct {
+	ToolCallID string
+	Name       string
+	Content    string
+	Error      error
+}
+
+// statefulTools are tools that mutate state and must execute serially.
+// All other tools are considered stateless and may execute in parallel.
+var statefulTools = map[string]bool{
+	"exec":            true,
+	"write_file":      true,
+	"message":         true,
+	"generate_image":  true,
+	"spawn_subagent":  true,
+	"create_cron_job": true,
+	"delete_cron_job": true,
+}
+
+// processToolCalls classifies, executes, and appends tool results.
+// Stateless tools (read_file, list_dir, web_fetch, web_search, memory_search,
+// load_skill, list_cron_jobs) run in parallel via goroutines.
+// Stateful tools (exec, write_file, message, …) run serially to avoid
+// race conditions on mutable state.
+//
+// sendEvent is optional — pass nil for non-streaming callers.
+func (a *Agent) processToolCalls(
+	ctx context.Context,
+	toolCalls []provider.ToolCall,
+	messages []provider.Message,
+	sess *session.Session,
+	msg bus.InboundMessage,
+	ld *loopDetector,
+	sendEvent func(provider.ToolEvent),
+) ([]provider.Message, NextStep) {
+
+	// ── Classify ──
+	type classified struct {
+		tc       provider.ToolCall
+		stateful bool
+	}
+	var plan []classified
+	for _, tc := range toolCalls {
+		// Loop detection — check before execution
+		if ld.check(tc.Function.Name, tc.Function.Arguments) {
+			slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
+			warnMsg := provider.Message{
+				Role:    "system",
+				Content: "Loop detected: you called the same tool with the same arguments 3 times. Please try a different approach.",
+			}
+			sess.Append(warnMsg)
+			messages = append(messages, warnMsg)
+			return messages, NextStepLoopDetected{}
+		}
+		plan = append(plan, classified{tc: tc, stateful: statefulTools[tc.Function.Name]})
+	}
+
+	// ── Execute stateless tools in parallel ──
+	var stateless, stateful []classified
+	for _, c := range plan {
+		if c.stateful {
+			stateful = append(stateful, c)
+		} else {
+			stateless = append(stateless, c)
+		}
+	}
+
+	var results []toolResult
+
+	if len(stateless) > 0 {
+		parallel := make([]toolResult, len(stateless))
+		var wg sync.WaitGroup
+		wg.Add(len(stateless))
+		for i, c := range stateless {
+			go func(idx int, tc provider.ToolCall) {
+				defer wg.Done()
+				parallel[idx] = a.executeTool(ctx, tc, sendEvent)
+			}(i, c.tc)
+		}
+		wg.Wait()
+		results = append(results, parallel...)
+	}
+
+	// ── Execute stateful tools serially ──
+	for _, c := range stateful {
+		results = append(results, a.executeTool(ctx, c.tc, sendEvent))
+	}
+
+	// ── Append all results to messages & handle MEDIA: protocol ──
+	for _, r := range results {
+		toolMsg := provider.Message{
+			Role:       "tool",
+			Content:    r.Content,
+			ToolCallID: r.ToolCallID,
+			Name:       r.Name,
+		}
+		sess.Append(toolMsg)
+		messages = append(messages, toolMsg)
+
+		if mediaPaths := extractMediaPaths(r.Content); len(mediaPaths) > 0 {
+			a.sendMediaFiles(msg, mediaPaths)
+		}
+	}
+
+	return messages, NextStepRunAgain{}
+}
+
+// executeTool runs a single tool call with hooks and event emission.
+func (a *Agent) executeTool(
+	ctx context.Context,
+	tc provider.ToolCall,
+	sendEvent func(provider.ToolEvent),
+) toolResult {
+	// Emit "calling" event
+	if sendEvent != nil {
+		sendEvent(provider.ToolEvent{
+			Tool:   tc.Function.Name,
+			Status: "calling",
+			Params: tc.Function.Arguments,
+		})
+	}
+
+	// Hook: BeforeToolCall
+	hcBefore := &HookContext{
+		AgentName: a.name,
+		Point:     BeforeToolCall,
+		ToolName:  tc.Function.Name,
+		ToolArgs:  tc.Function.Arguments,
+	}
+	a.hooks.Run(ctx, hcBefore)
+
+	slog.Info("executing tool", "agent", a.name, "name", tc.Function.Name, "id", tc.ID)
+
+	result, execErr := a.registry.Execute(ctx, tc.Function.Name, tc.Function.Arguments)
+
+	// Hook: AfterToolCall
+	hcAfter := &HookContext{
+		AgentName:  a.name,
+		Point:      AfterToolCall,
+		ToolName:   tc.Function.Name,
+		ToolResult: result,
+		Error:      execErr,
+		StartTime:  hcBefore.StartTime,
+	}
+	a.hooks.Run(ctx, hcAfter)
+
+	if execErr != nil {
+		slog.Warn("tool execution error", "agent", a.name, "name", tc.Function.Name, "error", execErr)
+	}
+
+	// Emit "completed" or "error" event
+	if sendEvent != nil {
+		status := "completed"
+		eventResult := result
+		if execErr != nil {
+			status = "error"
+			eventResult = execErr.Error()
+		}
+		if len(eventResult) > 2000 {
+			eventResult = eventResult[:2000] + "…"
+		}
+		sendEvent(provider.ToolEvent{
+			Tool:   tc.Function.Name,
+			Status: status,
+			Params: tc.Function.Arguments,
+			Result: eventResult,
+		})
+	}
+
+	return toolResult{
+		ToolCallID: tc.ID,
+		Name:       tc.Function.Name,
+		Content:    result,
+		Error:      execErr,
+	}
+}

--- a/internal/agent/step.go
+++ b/internal/agent/step.go
@@ -47,6 +47,17 @@ type RunConfig struct {
 	// preventing infinite tool-calling loops. Default: true.
 	// Mirrors OpenAI Agents SDK's ResetToolChoice behavior.
 	ResetToolChoice *bool
+
+	// ToolUseBehavior controls what happens after tools are executed.
+	// Default: RunLLMAgainBehavior() — feed results back to the LLM.
+	// Alternatives: StopOnFirstToolBehavior(), StopAtToolsBehavior("tool1", "tool2").
+	ToolUseBehavior ToolUseBehavior
+
+	// OnMaxTurns is called when the agent loop reaches maxToolIterations.
+	// If it returns a non-empty string, that string is used as the final
+	// response instead of the default error message.
+	// The callback receives the accumulated messages for context.
+	OnMaxTurns func(ctx context.Context, messages []provider.Message) string
 }
 
 // shouldResetToolChoice returns whether tool_choice should be reset after use.
@@ -188,6 +199,19 @@ func (a *Agent) processToolCalls(
 		if mediaPaths := extractMediaPaths(r.Content); len(mediaPaths) > 0 {
 			a.sendMediaFiles(msg, mediaPaths)
 		}
+	}
+
+	// ── Check ToolUseBehavior: should tool results be the final output? ──
+	behavior := RunLLMAgainBehavior()
+	if a.runConfig != nil && a.runConfig.ToolUseBehavior != nil {
+		behavior = a.runConfig.ToolUseBehavior
+	}
+	br, err := behavior.ToolsToFinalOutput(ctx, results)
+	if err != nil {
+		slog.Warn("tool use behavior error", "agent", a.name, "error", err)
+	} else if br.IsFinalOutput {
+		sess.Append(provider.Message{Role: "assistant", Content: br.FinalOutput})
+		return messages, NextStepFinalOutput{Content: br.FinalOutput}
 	}
 
 	return messages, NextStepRunAgain{}

--- a/internal/agent/tool_behavior.go
+++ b/internal/agent/tool_behavior.go
@@ -1,0 +1,84 @@
+package agent
+
+import "context"
+
+// ToolUseBehavior controls what happens after tool calls are executed.
+// By default (RunLLMAgain), results are fed back to the LLM for further
+// reasoning. Alternative behaviors let you short-circuit the loop and
+// use tool output directly as the final response.
+//
+// Mirrors the OpenAI Agents SDK's ToolUseBehavior pattern.
+type ToolUseBehavior interface {
+	// ToolsToFinalOutput examines tool results and decides whether to
+	// treat them as the final output or continue the loop.
+	ToolsToFinalOutput(ctx context.Context, results []toolResult) (ToolBehaviorResult, error)
+}
+
+// ToolBehaviorResult is the decision from a ToolUseBehavior.
+type ToolBehaviorResult struct {
+	// IsFinalOutput is true when the tool output should be returned
+	// directly without another LLM call.
+	IsFinalOutput bool
+
+	// FinalOutput is the content to return. Only meaningful when
+	// IsFinalOutput is true.
+	FinalOutput string
+}
+
+var notFinalOutput = ToolBehaviorResult{IsFinalOutput: false}
+
+// ── Built-in behaviors ──────────────────────────────────────────────
+
+// RunLLMAgainBehavior is the default: always feed tool results back to the LLM.
+func RunLLMAgainBehavior() ToolUseBehavior { return runLLMAgain{} }
+
+type runLLMAgain struct{}
+
+func (runLLMAgain) ToolsToFinalOutput(context.Context, []toolResult) (ToolBehaviorResult, error) {
+	return notFinalOutput, nil
+}
+
+// StopOnFirstToolBehavior uses the first tool's output as the final response,
+// skipping the LLM summarization step. Useful for tools like get_weather
+// where the raw result is already user-facing.
+func StopOnFirstToolBehavior() ToolUseBehavior { return stopOnFirstTool{} }
+
+type stopOnFirstTool struct{}
+
+func (stopOnFirstTool) ToolsToFinalOutput(_ context.Context, results []toolResult) (ToolBehaviorResult, error) {
+	if len(results) == 0 {
+		return notFinalOutput, nil
+	}
+	return ToolBehaviorResult{IsFinalOutput: true, FinalOutput: results[0].Content}, nil
+}
+
+// StopAtToolsBehavior stops the loop if any of the named tools are called,
+// using that tool's output as the final response.
+func StopAtToolsBehavior(toolNames ...string) ToolUseBehavior {
+	nameSet := make(map[string]bool, len(toolNames))
+	for _, n := range toolNames {
+		nameSet[n] = true
+	}
+	return stopAtTools{names: nameSet}
+}
+
+type stopAtTools struct {
+	names map[string]bool
+}
+
+func (s stopAtTools) ToolsToFinalOutput(_ context.Context, results []toolResult) (ToolBehaviorResult, error) {
+	for _, r := range results {
+		if s.names[r.Name] {
+			return ToolBehaviorResult{IsFinalOutput: true, FinalOutput: r.Content}, nil
+		}
+	}
+	return notFinalOutput, nil
+}
+
+// ToolsToFinalOutputFunc is a custom function-based ToolUseBehavior.
+// Use this when the built-in behaviors don't fit your needs.
+type ToolsToFinalOutputFunc func(ctx context.Context, results []toolResult) (ToolBehaviorResult, error)
+
+func (f ToolsToFinalOutputFunc) ToolsToFinalOutput(ctx context.Context, results []toolResult) (ToolBehaviorResult, error) {
+	return f(ctx, results)
+}

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -163,6 +163,11 @@ func (s *Scheduler) processDueJobs(ctx context.Context) {
 			text = fmt.Sprintf("[Cron Job: %s] This is a scheduled task trigger.", j.Name)
 		}
 
+		// Append self-reflection prompt and job metadata
+		text += fmt.Sprintf("\n\n[Cron Job ID: %s | Name: %s | Type: %s | Schedule: %s]",
+			j.ID, j.Name, j.Type, j.Schedule)
+		text += cronReflectionPrompt
+
 		s.bus.Inbound <- bus.InboundMessage{
 			Channel:  j.Channel,
 			ChatID:   j.ChatID,
@@ -194,11 +199,21 @@ func (s *Scheduler) runJob(ctx context.Context, job Job) {
 	}
 }
 
+// MinInterval is the minimum allowed interval for cron jobs (60 seconds).
+// Anything shorter is clamped to prevent runaway jobs from flooding the agent.
+const MinInterval = 60 * time.Second
+
 func (s *Scheduler) runInterval(ctx context.Context, job Job) {
 	dur, err := time.ParseDuration(job.Schedule)
 	if err != nil {
 		slog.Error("invalid interval duration", "name", job.Name, "schedule", job.Schedule, "error", err)
 		return
+	}
+
+	if dur < MinInterval {
+		slog.Warn("cron interval too short, clamping to minimum",
+			"name", job.Name, "requested", dur, "minimum", MinInterval)
+		dur = MinInterval
 	}
 
 	ticker := time.NewTicker(dur)
@@ -303,6 +318,22 @@ func fieldMatch(field string, value int) bool {
 	return n == value
 }
 
+// cronReflectionPrompt is appended to every cron-triggered message so the
+// agent evaluates whether the job is still needed after executing the task.
+const cronReflectionPrompt = `
+
+---
+[System: Cron Self-Check]
+This message was triggered by a scheduled cron job. After completing the task above, you MUST evaluate:
+
+1. Was this task still relevant? (e.g., is the meeting/event still in the future?)
+2. Is this a one-time task that is now done? If yes, delete this cron job using delete_cron_job.
+3. Does this cron job seem like a mistake? (e.g., recurring every hour for a one-time reminder)
+   If yes, delete it and briefly tell the user what you cleaned up.
+4. If the task is still valid and recurring, just complete it normally.
+
+Be proactive: clean up stale or incorrect cron jobs rather than letting them keep firing.`
+
 func (s *Scheduler) fireJob(job Job) {
 	slog.Info("cron job firing", "name", job.Name, "agent", job.AgentID)
 
@@ -310,6 +341,11 @@ func (s *Scheduler) fireJob(job Job) {
 	if text == "" {
 		text = fmt.Sprintf("[Cron Job: %s] This is a scheduled task trigger.", job.Name)
 	}
+
+	// Append self-reflection prompt so the agent can audit this cron job
+	text += fmt.Sprintf("\n\n[Cron Job ID: %s | Name: %s | Type: %s | Schedule: %s]",
+		"config", job.Name, string(job.Type), job.Schedule)
+	text += cronReflectionPrompt
 
 	s.bus.Inbound <- bus.InboundMessage{
 		Channel:  job.Channel,

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -12,11 +12,13 @@ import (
 	"strings"
 )
 
-// OpenAIProvider implements the Provider interface for OpenAI-compatible APIs.
+// OpenAIProvider implements the Provider and ToolChoiceProvider interfaces
+// for OpenAI-compatible APIs.
 type OpenAIProvider struct {
-	apiKey  string
-	apiBase string
-	client  *http.Client
+	apiKey     string
+	apiBase    string
+	client     *http.Client
+	toolChoice string // "", "auto", "none", "required"
 }
 
 // NewOpenAI creates a new OpenAI-compatible provider.
@@ -43,12 +45,19 @@ type apiMessage struct {
 }
 
 type chatRequest struct {
-	Model       string       `json:"model"`
-	Messages    []apiMessage `json:"messages"`
-	Tools       []Tool       `json:"tools,omitempty"`
-	MaxTokens   int          `json:"max_tokens,omitempty"`
-	Temperature float64      `json:"temperature,omitempty"`
-	Stream      bool         `json:"stream"`
+	Model              string       `json:"model"`
+	Messages           []apiMessage `json:"messages"`
+	Tools              []Tool       `json:"tools,omitempty"`
+	MaxTokens          int          `json:"max_tokens,omitempty"`
+	Temperature        float64      `json:"temperature,omitempty"`
+	Stream             bool         `json:"stream"`
+	ParallelToolCalls  *bool        `json:"parallel_tool_calls,omitempty"`
+	ToolChoice         string       `json:"tool_choice,omitempty"`
+}
+
+// SetToolChoice implements ToolChoiceProvider.
+func (p *OpenAIProvider) SetToolChoice(choice string) {
+	p.toolChoice = choice
 }
 
 // toAPIMessages converts provider Messages to wire-format apiMessages,
@@ -107,6 +116,16 @@ func (p *OpenAIProvider) buildRequest(ctx context.Context, messages []Message, t
 	}
 	if len(tools) > 0 {
 		req.Tools = tools
+		// Prefer sequential tool calls so the model can reason about each
+		// result before deciding the next action (ReAct pattern). The code
+		// in step.go still handles multiple tool calls gracefully if the
+		// provider ignores this parameter.
+		f := false
+		req.ParallelToolCalls = &f
+		// Apply dynamic tool_choice if set (used by ResetToolChoice)
+		if p.toolChoice != "" {
+			req.ToolChoice = p.toolChoice
+		}
 	}
 
 	body, err := json.Marshal(req)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -62,10 +62,20 @@ func (r *Response) HasToolCalls() bool {
 	return len(r.ToolCalls) > 0
 }
 
+// ToolEvent is emitted during the ReAct loop so SSE consumers can show
+// real-time tool execution status (calling → completed/error).
+type ToolEvent struct {
+	Tool   string `json:"tool"`
+	Status string `json:"status"` // "calling", "completed", "error"
+	Params string `json:"params,omitempty"`
+	Result string `json:"result,omitempty"`
+}
+
 // StreamChunk represents a single chunk from a streaming response.
 type StreamChunk struct {
 	Content   string
 	ToolCalls []ToolCall
+	ToolEvent *ToolEvent // non-nil = this chunk is a tool event, not text
 	Done      bool
 }
 
@@ -100,4 +110,13 @@ func (r *StreamReader) SetErr(err error) {
 type Provider interface {
 	Chat(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64) (*Response, error)
 	ChatStream(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64) (*StreamReader, error)
+}
+
+// ToolChoiceProvider is an optional interface that providers can implement
+// to support dynamic tool_choice control. The agent loop uses this to reset
+// tool_choice after tools are used (OpenAI Agents SDK ResetToolChoice pattern).
+type ToolChoiceProvider interface {
+	// SetToolChoice sets tool_choice for subsequent Chat calls.
+	// Valid values: "auto", "none", "required", or "" (provider default).
+	SetToolChoice(choice string)
 }


### PR DESCRIPTION
## Summary

Redesign the agent loop architecture inspired by the [OpenAI Agents SDK](https://github.com/nlpodyssey/openai-agents-go), replacing the simple for-loop with a proper state-machine pattern for better reasoning quality and extensibility.

### Problems with the current agent loop

1. **Blind parallel tool calling**: When the LLM returns multiple `tool_calls` in one response, all are executed before returning to the LLM — the model doesn't see intermediate results.
2. **Flat loop structure**: A single `for` loop with nested `if/else` makes it hard to extend.
3. **No tool_choice control**: The model defaults to parallel tool calling with no guidance toward sequential reasoning.
4. **No structured results**: `HandleMessage` returns a plain string — callers have no visibility into what happened.
5. **No guardrails**: No input/output validation mechanism.
6. **No error handling callbacks**: Max turns exceeded always returns a hardcoded string.

---

## What this PR implements

### 1. State-machine loop control (`step.go`)
- `NextStep` interface with typed variants: `FinalOutput`, `RunAgain`, `LoopDetected`
- Each iteration returns a typed decision — clean separation of loop control from business logic
- Foundation for future `NextStepHandoff` when multi-agent support is added

### 2. Smart tool execution (`step.go`)
- Classify tools into **stateless** vs **stateful**
- Stateless tools (`read_file`, `list_dir`, `web_fetch`, `web_search`, `memory_search`, `load_skill`, `list_cron_jobs`) → **parallel** execution via goroutines
- Stateful tools (`exec`, `write_file`, `message`, `generate_image`, `spawn_subagent`, `create_cron_job`, `delete_cron_job`) → **serial** execution
- Matches the OpenAI Agents SDK pattern: function tools parallel, computer/shell serial

### 3. Guardrails (`guardrail.go`)
- **Input guardrails**: Validate user input before processing (run in parallel)
- **Output guardrails**: Validate agent output before returning (run in parallel)
- **Tripwire mechanism**: Immediate halt on policy violations
- Structured error types: `InputGuardrailTrippedError`, `OutputGuardrailTrippedError`

### 4. ToolUseBehavior (`tool_behavior.go`)
Controls what happens after tool execution — 4 modes matching the OpenAI SDK:
- `RunLLMAgainBehavior()` (default): feed results back to LLM for summarization
- `StopOnFirstToolBehavior()`: use first tool's output directly as final response
- `StopAtToolsBehavior("tool1", "tool2")`: stop if specific tools are called
- `ToolsToFinalOutputFunc`: custom function for complex logic

### 5. RunResult (`result.go`)
Full structured outcome replacing the plain string return:
- `FinalOutput`, `Input`, `Messages`, `ToolCalls`, `TurnsUsed`
- `InputGuardrailResults`, `OutputGuardrailResults`
- `Error` (typed: `MaxTurnsExceededError`, guardrail errors, etc.)
- New `HandleMessageFull()` → `*RunResult`; existing `HandleMessage()` wraps it

### 6. Structured errors (`errors.go`)
- `AgentError` base type with `RunErrorDetails` context (input, messages, turns, guardrail results)
- `MaxTurnsExceededError` — loop exceeded max iterations
- `ModelBehaviorError` — LLM did something unexpected

### 7. Error handler callback (`RunConfig.OnMaxTurns`)
- Custom handler when max iterations reached
- Receives accumulated messages, returns custom fallback text
- Falls back to default message if callback is nil

### 8. Lifecycle hooks (`hooks.go`)
- `OnAgentStart`: fired once at the beginning of a run
- `OnAgentEnd`: fired when agent produces final output (with content in `HookContext.FinalOutput`)

### 9. ResetToolChoice (`loop.go`, `provider.go`)
- Reset `tool_choice` to `"auto"` after tools are used, preventing infinite tool-calling loops
- `ToolChoiceProvider` optional interface for providers

### 10. parallel_tool_calls: false (`openai.go`)
- Guide the model to prefer sequential tool calls for better reasoning
- Code still handles multiple tool calls gracefully as fallback

### 11. Code deduplication
- `prepareContext()` shared by `HandleMessage` / `HandleMessageStream`
- `processLLMResponse()` unified decision function
- `processToolCalls()` with classification and parallel/serial execution
- `executeTool()` single-tool execution with hooks and SSE events

---

## Architecture comparison

| Feature | Before | After | OpenAI Agents SDK |
|---------|--------|-------|-------------------|
| Loop control | `for` + `if/else` | `NextStep` state machine | `NextStep` state machine |
| Tool parallelism | All sequential | Stateless ∥, stateful serial | Function ∥, computer/shell serial |
| Guardrails | None | Input + output, parallel + tripwire | Input + output, parallel + tripwire |
| ToolUseBehavior | Always re-run LLM | 4 modes (RunLLM/StopFirst/StopAt/Custom) | 4 modes (identical) |
| RunResult | Returns `string` | Full `*RunResult` struct | Full `*RunResult` struct |
| Error types | `slog` + hardcoded string | `AgentError` + `RunErrorDetails` | `AgentsError` + `RunErrorDetails` |
| Error callbacks | None | `OnMaxTurns` callback | Error handler map |
| Lifecycle hooks | Before/AfterToolCall only | + `OnAgentStart`, `OnAgentEnd` | Full lifecycle |
| ResetToolChoice | None | After tool use → "auto" | After tool use → nil |
| parallel_tool_calls | Not set | `false` | Configurable |

## Files changed

| File | Change |
|------|--------|
| `internal/agent/step.go` | **NEW** — NextStep types, RunConfig, loopDetector, toolUseTracker, processToolCalls, executeTool |
| `internal/agent/guardrail.go` | **NEW** — Input/output guardrails, parallel execution, tripwire |
| `internal/agent/tool_behavior.go` | **NEW** — ToolUseBehavior interface + 4 built-in implementations |
| `internal/agent/result.go` | **NEW** — RunResult struct, ToolCallRecord |
| `internal/agent/errors.go` | **NEW** — AgentError, RunErrorDetails, MaxTurnsExceededError, ModelBehaviorError |
| `internal/agent/hooks.go` | Enhanced — OnAgentStart, OnAgentEnd, FinalOutput in HookContext |
| `internal/agent/loop.go` | Refactored — HandleMessageFull, state-machine loop, guardrails, ToolUseBehavior |
| `internal/provider/provider.go` | Added `ToolChoiceProvider` interface |
| `internal/provider/openai.go` | Added `ParallelToolCalls`, `ToolChoice`, `SetToolChoice` |

## Not included (future work)

- **Handoff**: Agent-to-agent control transfer (`NextStepHandoff` — architecture ready)
- **Structured Output**: OutputType with JSON schema validation

## Test plan

- [ ] Verify `go build ./...` passes
- [ ] Test single tool call (e.g., "read README.md")
- [ ] Test parallel stateless tools (e.g., "read both README.md and SOUL.md")
- [ ] Test serial stateful tools (e.g., "create file then read it back")
- [ ] Test ToolUseBehavior: StopOnFirstTool with a simple tool
- [ ] Test loop detection (trigger 3+ identical tool calls)
- [ ] Test SSE streaming with tool events
- [ ] Test OnMaxTurns callback
- [ ] Verify HandleMessageFull returns complete RunResult
- [ ] Test input/output guardrails with tripwire

🤖 Generated with [Claude Code](https://claude.com/claude-code)