### PR TITLE
fix: cron jobs route to wrong agent (ignores agentId)

### DIFF
--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -12,8 +12,9 @@ type InboundMessage struct {
 	SenderName   string   // display name of the sender
 	Mentions     []string // @usernames mentioned in the message
 	IsBotMessage bool     // true if the message was sent by a bot
-	PhotoURL     string   // URL of attached photo (if any)
-	ReplyToMsgID string   // message ID being replied to
+	PhotoURL      string   // URL of attached photo (if any)
+	ReplyToMsgID  string   // message ID being replied to
+	TargetAgentID string   // if set, bypass bindings and route directly to this agent
 }
 
 // OutboundButton represents a button in an inline keyboard.

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -164,11 +164,12 @@ func (s *Scheduler) processDueJobs(ctx context.Context) {
 		}
 
 		s.bus.Inbound <- bus.InboundMessage{
-			Channel:  j.Channel,
-			ChatID:   j.ChatID,
-			UserID:   "cron",
-			Text:     text,
-			PeerKind: "dm",
+			Channel:       j.Channel,
+			ChatID:        j.ChatID,
+			UserID:        "cron",
+			Text:          text,
+			PeerKind:      "dm",
+			TargetAgentID: j.AgentID,
 		}
 
 		// Calculate next run (simple: add 60s for now; real implementation would parse schedule)
@@ -312,11 +313,12 @@ func (s *Scheduler) fireJob(job Job) {
 	}
 
 	s.bus.Inbound <- bus.InboundMessage{
-		Channel:  job.Channel,
-		ChatID:   job.ChatID,
-		UserID:   "cron",
-		Text:     text,
-		PeerKind: "dm",
+		Channel:       job.Channel,
+		ChatID:        job.ChatID,
+		UserID:        "cron",
+		Text:          text,
+		PeerKind:      "dm",
+		TargetAgentID: job.AgentID,
 	}
 }
 

--- a/internal/gateway/routing.go
+++ b/internal/gateway/routing.go
@@ -47,7 +47,16 @@ func (g *Gateway) processInbound(ctx context.Context) {
 
 // routeDM handles direct message routing (existing behavior).
 func (g *Gateway) routeDM(ctx context.Context, msg bus.InboundMessage) {
-	ag := g.matchAgent(msg)
+	var ag *agent.Agent
+	if msg.TargetAgentID != "" {
+		ag = g.agents.AgentByID(msg.TargetAgentID)
+		if ag != nil {
+			slog.Info("routing DM by TargetAgentID", "agent", ag.Name())
+		}
+	}
+	if ag == nil {
+		ag = g.matchAgent(msg)
+	}
 	if ag == nil {
 		slog.Warn("no agent matched for DM, dropping",
 			"channel", msg.Channel,


### PR DESCRIPTION
## Problem

Cron jobs configured with a specific `agentId` ignore that field and route messages through channel bindings instead. This causes cron messages to be delivered to the wrong agent.

**Root cause:** `fireJob()` and `processDueJobs()` construct `bus.InboundMessage` without passing through the job's `AgentID`. Since `InboundMessage` had no agent targeting field, all messages go through `matchAgent()` → bindings lookup, which can match a completely different agent.

**Impact:** In a multi-agent setup, one user's cron job consumes another user's token budget (44M tokens / $18.62 wasted in one month in our case).

## Fix

1. **`bus.InboundMessage`** — add `TargetAgentID` field (zero-value empty string = no change for existing callers)
2. **`cron/scheduler.go`** — set `TargetAgentID: job.AgentID` in both `fireJob()` and `processDueJobs()`
3. **`gateway/routing.go`** — `routeDM()` checks `TargetAgentID` first; falls back to bindings if empty or agent not found

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Cron with agentId set | Routed via bindings (wrong agent) | Routed directly to specified agent |
| Cron with agentId empty | Routed via bindings | Routed via bindings (unchanged) |
| Normal user messages | Routed via bindings | Routed via bindings (unchanged) |
| Cron agent deleted | N/A | Falls back to bindings |

3 files changed, 25 insertions(+), 13 deletions(-).