### PR TITLE
feat: local agents management CLI (`fastclaw agents …`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,129 @@ Click an agent to enter its management panel:
 ./fastclaw gateway
 ```
 
+### Local agent instances
+
+For temporary local agents, run isolated gateway instances by name. Each
+instance has its own sqlite database, config, users, agents, workspaces, and
+logs.
+
+```bash
+# Create a local instance and seed its provider/model config.
+fastclaw agents init scratch \
+  --provider openai \
+  --model openai/gpt-4.1 \
+  --api-key-env OPENAI_API_KEY
+
+# Configure runtime settings directly from the CLI.
+fastclaw agents config scratch set sandbox.enabled true
+fastclaw agents config scratch set temperature 0.2
+
+# Customize identity files.
+fastclaw agents files put scratch SOUL.md ./SOUL.md
+fastclaw agents files put scratch IDENTITY.md ./IDENTITY.md
+
+# Run and inspect the instance.
+fastclaw agents start scratch
+fastclaw agents ls
+fastclaw agents status scratch
+fastclaw agents log scratch
+fastclaw agents log scratch -f -n 200
+fastclaw agents restart scratch
+fastclaw agents stop scratch
+
+# Tear it down. Default keeps the home dir + logs so a later `init` recovers.
+fastclaw agents rm scratch
+fastclaw agents rm scratch --purge   # also wipe ~/.fastclaw/local-agents/scratch and the log file
+fastclaw agents rm scratch --force   # stop the agent first if it is still running
+```
+
+`agents init` writes the local sqlite store directly, so provider/model
+defaults and system files can be configured without opening the dashboard.
+When the local DB has no users, it creates a super admin account. If
+`--password` is omitted, a password is generated and printed once. When the
+DB already has users, passing `--username` requires that account to exist —
+the command refuses to silently bind the agent to a different user.
+
+Re-running `agents init` against the same name is non-destructive: the agent
+record's `Config` map, the agent system files, and existing model entry
+metadata (context window, max tokens, cost) are preserved. Provider fields
+that are not explicitly overridden also keep their previous values.
+
+Provider presets are available for `openai`, `openrouter`, `anthropic`,
+`ollama`, `groq`, `deepseek`, and `mistral`. Use `--api-key-env` instead of
+placing API keys directly on the command line:
+
+```bash
+fastclaw agents init scratch --provider openai --model openai/gpt-4.1 --api-key-env OPENAI_API_KEY
+fastclaw agents init local-llama --provider ollama --model llama3.1
+```
+
+Configuration can be read or updated by key. Common keys include `model`,
+`temperature`, `maxTokens`, `thinking`, `policy`, `sandbox.enabled`,
+`sandbox.backend`, and provider fields such as `provider.openai.apiBase`,
+`provider.openai.apiType`, and `provider.openai.apiKeyEnv`.
+
+```bash
+fastclaw agents config scratch get
+fastclaw agents config scratch get model
+fastclaw agents config scratch get sandbox
+fastclaw agents config scratch set model openai/gpt-4.1-mini
+fastclaw agents config scratch set provider.openai.apiKeyEnv OPENAI_API_KEY
+fastclaw agents config scratch set sandbox '{"enabled":true,"backend":"docker"}'
+```
+
+System files are stored in the local instance database under the configured
+agent/user scope. Supported filenames are `SOUL.md`, `IDENTITY.md`, `USER.md`,
+`BOOTSTRAP.md`, `MEMORY.md`, `HEARTBEAT.md`, `AGENTS.md`, `TOOLS.md`, and
+`agent.json`:
+
+```bash
+fastclaw agents files ls scratch
+fastclaw agents files get scratch SOUL.md
+fastclaw agents files get scratch SOUL.md ./SOUL.md
+fastclaw agents files put scratch SOUL.md ./SOUL.md
+```
+
+Each instance gets its own `FASTCLAW_HOME` under `~/.fastclaw/local-agents/<name>`,
+with process metadata in `~/.fastclaw/agent-runs/` and logs in
+`~/.fastclaw/logs/agents/`. Use `--port` or `--home` on `agents start` when you
+need an explicit port or home directory. CLI config writes do not hot-reload a
+running gateway; use `agents restart <name>` after `agents init`, `agents
+config set`, or `agents files put` if the instance is already running.
+
+A few sharp edges worth knowing:
+
+- `agents start <name>` does not require `agents init` first. A bare `start`
+  boots a gateway with an empty database; the web setup wizard at the printed
+  URL will walk you through provider/admin configuration.
+- `agents rm` keeps `~/.fastclaw/local-agents/<name>/` and the log file by
+  default so a later `agents init <name>` can recover prior data. Pass
+  `--purge` to wipe them too. `--force` only stops a running agent before
+  removal — it does not imply `--purge`.
+- On Unix, `agents stop` SIGTERMs the whole gateway process group (sandbox
+  runners, plugin subprocesses, etc.) and escalates to SIGKILL after 5
+  seconds. On Windows, the gateway is detached with `CREATE_NEW_PROCESS_GROUP`
+  and `agents stop` sends `CTRL_BREAK_EVENT`, falling back to a hard kill if
+  the gateway does not handle it.
+- `agents init` reuse rules: re-running against the same `<name>` preserves
+  the agent record's `Config` map, system files, existing model entry
+  metadata, and provider fields not explicitly overridden. The agent is
+  bound to the existing owner — passing `--username` for a different
+  account refuses rather than silently rebinding.
+
+| Subcommand | Purpose |
+|---|---|
+| `agents init <name>` | Create or update an instance's sqlite config (provider, model, sandbox, admin user) |
+| `agents start <name>` | Launch the gateway as a detached background process |
+| `agents stop <name>` | SIGTERM (then SIGKILL after 5s) the running instance |
+| `agents restart <name>` | Stop (if running) and start, optionally with new `--port` / `--home` |
+| `agents ls` | List all known instances with status/PID/port/uptime |
+| `agents status <name>` | Show one instance's status, URL, log path, uptime |
+| `agents rm <name>` | Remove instance metadata; pass `--purge` to wipe sqlite + logs, `--force` to stop first |
+| `agents log <name> [-f] [-n N]` | Show / follow the instance's log file (no `tail` binary required) |
+| `agents config <name> get\|set [key] [value]` | Read or update saved provider/setting values |
+| `agents files ls\|put\|get <name>` | Read / write the agent's system files (SOUL.md, IDENTITY.md, …) |
+
 ### Docker
 ```bash
 cd deploy/docker && ./start.sh

--- a/cmd/fastclaw/cmd_agents.go
+++ b/cmd/fastclaw/cmd_agents.go
@@ -1,0 +1,542 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fastclaw-ai/fastclaw/internal/localagents"
+)
+
+func agentsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agents",
+		Short: "Manage local FastClaw agent instances",
+	}
+	addAgentsSubcommand(cmd, agentsListCmd())
+	addAgentsSubcommand(cmd, agentsInitCmd())
+	addAgentsSubcommand(cmd, agentsStartCmd())
+	addAgentsSubcommand(cmd, agentsStopCmd())
+	addAgentsSubcommand(cmd, agentsRestartCmd())
+	addAgentsSubcommand(cmd, agentsRemoveCmd())
+	addAgentsSubcommand(cmd, agentsStatusCmd())
+	addAgentsSubcommand(cmd, agentsLogCmd())
+	addAgentsSubcommand(cmd, agentsConfigCmd())
+	addAgentsSubcommand(cmd, agentsFilesCmd())
+	return cmd
+}
+
+// addAgentsSubcommand attaches a subcommand and silences cobra's usage dump
+// on every error throughout the agents tree (we keep error printing on).
+func addAgentsSubcommand(parent, child *cobra.Command) {
+	silenceTree(child)
+	parent.AddCommand(child)
+}
+
+func silenceTree(cmd *cobra.Command) {
+	cmd.SilenceUsage = true
+	for _, sub := range cmd.Commands() {
+		silenceTree(sub)
+	}
+}
+
+func agentsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List local agent instances",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agents, err := localagents.List()
+			if err != nil {
+				return err
+			}
+			if len(agents) == 0 {
+				fmt.Println("No local agents.")
+				return nil
+			}
+			fmt.Printf("%-20s %-8s %-8s %-7s %-12s %s\n", "NAME", "STATUS", "PID", "PORT", "UPTIME", "HOME")
+			for _, ag := range agents {
+				status := "stopped"
+				pid := "-"
+				uptime := "-"
+				if ag.Running {
+					status = "running"
+					pid = strconv.Itoa(ag.PID)
+					uptime = ag.Uptime.Round(time.Second).String()
+				}
+				port := "-"
+				if ag.Port > 0 {
+					port = strconv.Itoa(ag.Port)
+				}
+				fmt.Printf("%-20s %-8s %-8s %-7s %-12s %s\n", ag.Name, status, pid, port, uptime, ag.Home)
+			}
+			return nil
+		},
+	}
+}
+
+func agentsInitCmd() *cobra.Command {
+	var opts localagents.InitOptions
+	cmd := &cobra.Command{
+		Use:   "init <name>",
+		Short: "Configure a local agent instance without using the web UI",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			res, err := localagents.Init(args[0], opts)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Agent %q initialized\n", res.Instance.Name)
+			fmt.Printf("Agent ID: %s\n", res.Instance.AgentID)
+			fmt.Printf("User ID:  %s\n", res.Instance.UserID)
+			fmt.Printf("Home:     %s\n", res.Instance.Home)
+			if res.Instance.Port > 0 {
+				fmt.Printf("Port:     %d\n", res.Instance.Port)
+			}
+			if res.ProviderSaved {
+				fmt.Println("Provider: saved")
+			}
+			if res.ModelSaved {
+				fmt.Println("Model:    saved")
+			}
+			if !res.ModelSaved {
+				if model, _ := localagents.GetConfig(args[0], "model"); model == nil || model == "" {
+					fmt.Fprintln(os.Stderr, "Hint: no model is configured. Set one with:")
+					fmt.Fprintf(os.Stderr, "  fastclaw agents config %s set model <provider>/<model>\n", args[0])
+				}
+			}
+			if res.CreatedUser && res.GeneratedPassword != "" {
+				fmt.Printf("Generated admin password: %s\n", res.GeneratedPassword)
+			}
+			warnIfAgentRunning(res.Instance.Name)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.Home, "home", "", "FASTCLAW_HOME for this agent (default: ~/.fastclaw/local-agents/<name>)")
+	cmd.Flags().IntVar(&opts.Port, "port", 0, "default port to use when starting this agent")
+	cmd.Flags().StringVar(&opts.AgentName, "agent-name", "", "display name for the created agent")
+	cmd.Flags().StringVar(&opts.Description, "description", "", "description for the created agent")
+	cmd.Flags().StringVar(&opts.Provider, "provider", "", "provider name, e.g. openai, openrouter, anthropic, ollama")
+	cmd.Flags().StringVar(&opts.Model, "model", "", "default model, either <provider>/<model> or <model> with --provider")
+	cmd.Flags().StringVar(&opts.APIKeyEnv, "api-key-env", "", "environment variable containing the provider API key")
+	cmd.Flags().StringVar(&opts.APIBase, "api-base", "", "provider API base URL")
+	cmd.Flags().StringVar(&opts.APIType, "api-type", "", "provider API type (default from provider preset)")
+	cmd.Flags().StringVar(&opts.AuthType, "auth-type", "", "provider auth type (default from provider preset)")
+	cmd.Flags().StringVar(&opts.Username, "username", "", "admin username to create when the local DB has no users")
+	cmd.Flags().StringVar(&opts.Email, "email", "", "admin email to create when the local DB has no users")
+	cmd.Flags().StringVar(&opts.Password, "password", "", "admin password to create when the local DB has no users (default: generate)")
+	cmd.Flags().StringVar(&opts.DisplayName, "display-name", "", "admin display name")
+	cmd.Flags().BoolVar(&opts.SandboxEnabled, "sandbox", false, "enable sandbox for the local instance")
+	cmd.Flags().StringVar(&opts.SandboxBackend, "sandbox-backend", "", "sandbox backend, e.g. docker or e2b")
+	cmd.Flags().StringVar(&opts.SandboxImage, "sandbox-image", "", "sandbox image/template")
+	cmd.Flags().StringVar(&opts.SandboxNetwork, "sandbox-network", "", "sandbox network mode")
+	return cmd
+}
+
+func agentsStartCmd() *cobra.Command {
+	var port int
+	var home string
+	cmd := &cobra.Command{
+		Use:   "start <name>",
+		Short: "Start a local agent instance",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inst, err := localagents.Start(args[0], localagents.StartOptions{
+				Port: port,
+				Home: home,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Agent %q started (PID %d)\n", inst.Name, inst.PID)
+			fmt.Printf("URL:  %s\n", inst.URL)
+			fmt.Printf("Home: %s\n", inst.Home)
+			fmt.Printf("Logs: %s\n", inst.LogFile)
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&port, "port", 0, "port for this agent gateway (default: choose a free port)")
+	cmd.Flags().StringVar(&home, "home", "", "FASTCLAW_HOME for this agent (default: ~/.fastclaw/local-agents/<name>)")
+	return cmd
+}
+
+func agentsStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop <name>",
+		Short: "Stop a local agent instance",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inst, err := localagents.Stop(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Agent %q stopped\n", inst.Name)
+			return nil
+		},
+	}
+}
+
+func agentsRestartCmd() *cobra.Command {
+	var port int
+	var home string
+	cmd := &cobra.Command{
+		Use:   "restart <name>",
+		Short: "Stop and start a local agent instance",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			st, err := localagents.GetStatus(name)
+			if err != nil {
+				return err
+			}
+			if st.Running {
+				if _, err := localagents.Stop(name); err != nil {
+					return err
+				}
+			}
+			inst, err := localagents.Start(name, localagents.StartOptions{Port: port, Home: home})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Agent %q restarted (PID %d)\n", inst.Name, inst.PID)
+			fmt.Printf("URL:  %s\n", inst.URL)
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&port, "port", 0, "override port on restart (default: reuse previous)")
+	cmd.Flags().StringVar(&home, "home", "", "override FASTCLAW_HOME on restart (default: reuse previous)")
+	return cmd
+}
+
+func agentsRemoveCmd() *cobra.Command {
+	var force, purge bool
+	cmd := &cobra.Command{
+		Use:     "rm <name>",
+		Aliases: []string{"remove"},
+		Short:   "Remove a local agent instance",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inst, err := localagents.Remove(args[0], localagents.RemoveOptions{
+				Force: force,
+				Purge: purge,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Agent %q removed\n", inst.Name)
+			if !purge && inst.Home != "" {
+				fmt.Printf("Home preserved: %s\n", inst.Home)
+				fmt.Printf("Log preserved:  %s\n", inst.LogFile)
+				fmt.Println("Pass --purge to delete them too.")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "stop the agent first if it is still running")
+	cmd.Flags().BoolVar(&purge, "purge", false, "also delete the agent's home directory and log file")
+	return cmd
+}
+
+func agentsStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status <name>",
+		Short: "Show status for a single local agent instance",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			st, err := localagents.GetStatus(args[0])
+			if err != nil {
+				return err
+			}
+			running := "stopped"
+			if st.Running {
+				running = "running"
+			}
+			fmt.Printf("Name:    %s\n", st.Name)
+			fmt.Printf("Status:  %s\n", running)
+			if st.AgentID != "" {
+				fmt.Printf("AgentID: %s\n", st.AgentID)
+			}
+			if st.UserID != "" {
+				fmt.Printf("UserID:  %s\n", st.UserID)
+			}
+			if st.PID > 0 {
+				fmt.Printf("PID:     %d\n", st.PID)
+			}
+			if st.Port > 0 {
+				fmt.Printf("Port:    %d\n", st.Port)
+			}
+			if st.URL != "" {
+				fmt.Printf("URL:     %s\n", st.URL)
+			}
+			if st.Home != "" {
+				fmt.Printf("Home:    %s\n", st.Home)
+			}
+			if st.LogFile != "" {
+				fmt.Printf("Log:     %s\n", st.LogFile)
+			}
+			if st.Running && !st.StartedAt.IsZero() {
+				fmt.Printf("Uptime:  %s\n", st.Uptime.Round(time.Second))
+			}
+			return nil
+		},
+	}
+}
+
+func agentsConfigCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config <name> <get|set> [key] [value]",
+		Short: "Read or update a local agent instance config",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			switch args[1] {
+			case "get":
+				if len(args) > 3 {
+					return fmt.Errorf("usage: fastclaw agents config %s get [key]", name)
+				}
+				key := ""
+				if len(args) == 3 {
+					key = args[2]
+				}
+				value, err := localagents.GetConfig(name, key)
+				if err != nil {
+					return err
+				}
+				return printValue(value)
+			case "set":
+				if len(args) != 4 {
+					return fmt.Errorf("usage: fastclaw agents config %s set <key> <value>", name)
+				}
+				if err := localagents.SetConfig(name, args[2], args[3]); err != nil {
+					return err
+				}
+				fmt.Printf("Set %s\n", args[2])
+				warnIfAgentRunning(name)
+				return nil
+			default:
+				return fmt.Errorf("unknown config action %q; use get or set", args[1])
+			}
+		},
+	}
+}
+
+func agentsFilesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "files",
+		Short: "Manage local agent system files",
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:     "ls <name>",
+		Aliases: []string{"list"},
+		Short:   "List configured system files",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			files, err := localagents.ListFiles(args[0])
+			if err != nil {
+				return err
+			}
+			for _, file := range files {
+				fmt.Println(file)
+			}
+			return nil
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "put <name> <filename> <path>",
+		Short: "Write a system file from a local path",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := localagents.PutFile(args[0], args[1], args[2]); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote %s\n", args[1])
+			warnIfAgentRunning(args[0])
+			return nil
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "get <name> <filename> [path]",
+		Short: "Read a system file, or write it to a local path",
+		Args:  cobra.RangeArgs(2, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := localagents.GetFile(args[0], args[1])
+			if err != nil {
+				return err
+			}
+			if len(args) == 3 {
+				if err := os.WriteFile(args[2], data, 0o644); err != nil {
+					return err
+				}
+				fmt.Printf("Wrote %s\n", args[2])
+				return nil
+			}
+			_, err = os.Stdout.Write(data)
+			return err
+		},
+	})
+	return cmd
+}
+
+func agentsLogCmd() *cobra.Command {
+	var follow bool
+	var lines int
+	cmd := &cobra.Command{
+		Use:     "log <name>",
+		Aliases: []string{"logs"},
+		Short:   "Show local agent log output",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logFile, err := localagents.LogFile(args[0])
+			if err != nil {
+				return err
+			}
+			return tailLog(logFile, lines, follow, os.Stdout)
+		},
+	}
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow log output")
+	cmd.Flags().IntVarP(&lines, "lines", "n", 50, "Number of lines to show")
+	return cmd
+}
+
+// tailLog mirrors `tail -n LINES [-f] PATH` without depending on a system
+// `tail` binary, so the command works on Windows too.
+func tailLog(path string, lines int, follow bool, out io.Writer) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no log file found at %s", path)
+		}
+		return err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	start, err := lastNLineOffset(f, fi.Size(), lines)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, f); err != nil {
+		return err
+	}
+	if !follow {
+		return nil
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	pos, _ := f.Seek(0, io.SeekCurrent)
+	buf := make([]byte, 32*1024)
+	for {
+		select {
+		case <-sigCh:
+			return nil
+		case <-ticker.C:
+		}
+		fi, err := f.Stat()
+		if err != nil {
+			return err
+		}
+		if fi.Size() < pos {
+			// Log was truncated/rotated. Reopen and resume from the start.
+			f.Close()
+			f, err = os.Open(path)
+			if err != nil {
+				return err
+			}
+			pos = 0
+		}
+		for {
+			n, err := f.Read(buf)
+			if n > 0 {
+				if _, werr := out.Write(buf[:n]); werr != nil {
+					return werr
+				}
+				pos += int64(n)
+			}
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// lastNLineOffset returns the byte offset where the last `n` lines of the
+// file begin. Reads backward in 8KiB chunks until n newlines are found.
+func lastNLineOffset(f *os.File, size int64, n int) (int64, error) {
+	if n <= 0 || size == 0 {
+		return size, nil
+	}
+	const chunk = 8192
+	buf := make([]byte, chunk)
+	pos := size
+	count := 0
+	for pos > 0 {
+		readSize := int64(chunk)
+		if pos < readSize {
+			readSize = pos
+		}
+		pos -= readSize
+		if _, err := f.ReadAt(buf[:readSize], pos); err != nil && !errors.Is(err, io.EOF) {
+			return 0, err
+		}
+		for i := readSize - 1; i >= 0; i-- {
+			if buf[i] != '\n' {
+				continue
+			}
+			// The trailing newline at end-of-file does not count as a
+			// line boundary that hides a preceding line.
+			if pos+i+1 == size {
+				continue
+			}
+			count++
+			if count >= n {
+				return pos + i + 1, nil
+			}
+		}
+	}
+	return 0, nil
+}
+
+func printValue(value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		fmt.Println("null")
+	case string:
+		fmt.Println(v)
+	default:
+		data, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+	}
+	return nil
+}
+
+func warnIfAgentRunning(name string) {
+	st, err := localagents.GetStatus(name)
+	if err == nil && st.Running {
+		fmt.Fprintln(os.Stderr, "Warning: agent is running; restart it for config changes to take effect.")
+	}
+}

--- a/cmd/fastclaw/cmd_agents_test.go
+++ b/cmd/fastclaw/cmd_agents_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTailLogReturnsLastLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log")
+	body := strings.Builder{}
+	for i := 1; i <= 200; i++ {
+		body.WriteString("line-")
+		body.WriteString(itoa(i))
+		body.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(body.String()), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tailLog(path, 5, false, &buf); err != nil {
+		t.Fatalf("tailLog: %v", err)
+	}
+	got := strings.TrimRight(buf.String(), "\n")
+	want := "line-196\nline-197\nline-198\nline-199\nline-200"
+	if got != want {
+		t.Fatalf("tail output mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestTailLogHandlesShortFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log")
+	if err := os.WriteFile(path, []byte("only-line\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tailLog(path, 50, false, &buf); err != nil {
+		t.Fatalf("tailLog: %v", err)
+	}
+	if buf.String() != "only-line\n" {
+		t.Fatalf("unexpected output: %q", buf.String())
+	}
+}
+
+func TestTailLogHandlesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "log")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tailLog(path, 5, false, &buf); err != nil {
+		t.Fatalf("tailLog on empty file: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected empty output, got %q", buf.String())
+	}
+}
+
+func TestTailLogReportsMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	err := tailLog(filepath.Join(dir, "nope"), 5, false, &buf)
+	if err == nil {
+		t.Fatal("expected missing-file error")
+	}
+	if !strings.Contains(err.Error(), "no log file found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		b[pos] = '-'
+	}
+	return string(b[pos:])
+}

--- a/cmd/fastclaw/main.go
+++ b/cmd/fastclaw/main.go
@@ -84,6 +84,7 @@ func main() {
 	rootCmd.AddCommand(policyCmd())
 	rootCmd.AddCommand(daemonCmd())
 	rootCmd.AddCommand(adminCmd())
+	rootCmd.AddCommand(agentsCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -164,7 +165,7 @@ func runGateway(port int) error {
 	url := fmt.Sprintf("http://localhost:%d", port)
 	slog.Info("web UI available", "url", url)
 	// Auto-open the browser when this looks like a fresh install.
-	if n, _ := countUsersSafe(gw); n == 0 {
+	if n, _ := countUsersSafe(gw); n == 0 && os.Getenv("FASTCLAW_NO_OPEN") == "" && os.Getenv("FASTCLAW_NO_BROWSER") == "" {
 		go openBrowser(url)
 	}
 

--- a/internal/localagents/config.go
+++ b/internal/localagents/config.go
@@ -1,0 +1,832 @@
+package localagents
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/scope"
+	"github.com/fastclaw-ai/fastclaw/internal/store"
+	"github.com/fastclaw-ai/fastclaw/internal/users"
+)
+
+// InitOptions controls direct local agent configuration.
+type InitOptions struct {
+	Home        string
+	Port        int
+	AgentName   string
+	Description string
+
+	Provider  string
+	Model     string
+	APIKeyEnv string
+	APIBase   string
+	APIType   string
+	AuthType  string
+
+	Username    string
+	Email       string
+	Password    string
+	DisplayName string
+
+	SandboxEnabled bool
+	SandboxBackend string
+	SandboxImage   string
+	SandboxNetwork string
+}
+
+// InitResult describes what init created or updated.
+type InitResult struct {
+	Instance          Instance
+	CreatedUser       bool
+	GeneratedPassword string
+	ProviderSaved     bool
+	ModelSaved        bool
+}
+
+// Init creates or updates the sqlite-backed configuration for a local agent.
+func Init(name string, opts InitOptions) (*InitResult, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	p, err := instancePaths(name)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := loadInstance(p.metaFile)
+	if errors.Is(err, os.ErrNotExist) {
+		existing = nil
+	} else if err != nil {
+		return nil, err
+	}
+	if existing != nil && isProcessAlive(existing.PID) {
+		if opts.Home != "" && expandHome(opts.Home) != existing.Home {
+			return nil, fmt.Errorf("agent %q is running; stop it before changing --home", name)
+		}
+		if opts.Port > 0 && opts.Port != existing.Port {
+			return nil, fmt.Errorf("agent %q is running; stop it before changing --port", name)
+		}
+	}
+	home := opts.Home
+	if home == "" && existing != nil {
+		home = existing.Home
+	}
+	if home == "" {
+		home = p.homeDir
+	}
+	home = expandHome(home)
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		return nil, fmt.Errorf("create agent home: %w", err)
+	}
+
+	providerSaved := false
+	modelSaved := false
+	var providerName string
+	var modelID string
+	var fullModel string
+	if opts.Provider != "" || opts.Model != "" {
+		providerName, modelID, fullModel, err = normalizeProviderModel(opts.Provider, opts.Model)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	st, err := openInstanceStore(home)
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+	acct, created, generatedPassword, err := ensureAccount(ctx, st, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	agentID := "agt_" + name
+	if existing != nil && existing.AgentID != "" {
+		agentID = existing.AgentID
+	}
+	agentName := opts.AgentName
+	if agentName == "" && existing != nil {
+		agentName = existing.AgentName
+	}
+	if agentName == "" {
+		agentName = name
+	}
+	agentConfig := map[string]interface{}{}
+	ownerID := acct.ID
+	if rec, err := st.GetAgent(ctx, agentID); err == nil && rec != nil {
+		if rec.Config != nil {
+			agentConfig = rec.Config
+		}
+		// Re-init must not silently rebind an agent record onto a
+		// different user. Honour an explicit --username switch (which
+		// sets opts.Username) but otherwise keep the existing owner.
+		if rec.UserID != "" && rec.UserID != acct.ID {
+			if opts.Username == "" {
+				ownerID = rec.UserID
+			} else {
+				return nil, fmt.Errorf("agent %q is owned by user %s; pass --username matching that account or remove the agent first", name, rec.UserID)
+			}
+		}
+	} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return nil, err
+	}
+	agentRec := &store.AgentRecord{
+		ID:     agentID,
+		UserID: ownerID,
+		Name:   agentName,
+		Config: agentConfig,
+	}
+	if opts.Description != "" {
+		agentRec.Config["description"] = opts.Description
+	}
+	if err := st.SaveAgent(ctx, agentRec); err != nil {
+		return nil, err
+	}
+
+	if opts.Provider != "" || opts.Model != "" {
+		pcfg, err := providerConfigFromOptions(ctx, st, providerName, modelID, opts)
+		if err != nil {
+			return nil, err
+		}
+		if err := scope.SaveProvider(ctx, st, scope.System, "", providerName, pcfg); err != nil {
+			return nil, err
+		}
+		providerSaved = true
+		if fullModel != "" {
+			if err := saveSettingValue(ctx, st, "agents.defaults", []string{"model"}, fullModel); err != nil {
+				return nil, err
+			}
+			modelSaved = true
+		}
+	}
+	if opts.SandboxEnabled {
+		data, err := loadSettingMap(ctx, st, "sandbox")
+		if err != nil {
+			return nil, err
+		}
+		data["enabled"] = true
+		data["backend"] = defaultStr(opts.SandboxBackend, "docker")
+		if opts.SandboxImage != "" {
+			data["image"] = opts.SandboxImage
+		}
+		if opts.SandboxNetwork != "" {
+			data["network"] = opts.SandboxNetwork
+		}
+		if err := scope.SaveSetting(ctx, st, scope.System, "", "sandbox", data); err != nil {
+			return nil, err
+		}
+	}
+
+	port := opts.Port
+	if port <= 0 && existing != nil {
+		port = existing.Port
+	}
+	inst := &Instance{
+		Name:      name,
+		AgentID:   agentID,
+		AgentName: agentName,
+		UserID:    ownerID,
+		Port:      port,
+		Home:      home,
+		LogFile:   p.logFile,
+	}
+	if port > 0 {
+		inst.URL = fmt.Sprintf("http://localhost:%d", port)
+	}
+	if existing != nil {
+		inst.PID = existing.PID
+		inst.Command = existing.Command
+		inst.StoppedAt = existing.StoppedAt
+		if inst.StartedAt.IsZero() {
+			inst.StartedAt = existing.StartedAt
+		}
+	}
+	if err := saveInstance(p.metaFile, inst); err != nil {
+		return nil, err
+	}
+	return &InitResult{
+		Instance:          *inst,
+		CreatedUser:       created,
+		GeneratedPassword: generatedPassword,
+		ProviderSaved:     providerSaved,
+		ModelSaved:        modelSaved,
+	}, nil
+}
+
+// SetConfig writes a supported provider or setting key.
+func SetConfig(name, key, rawValue string) error {
+	st, _, err := storeForName(name)
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if strings.HasPrefix(key, "provider.") {
+		return setProviderField(ctx, st, key, rawValue)
+	}
+	namespace, path, err := settingKey(key)
+	if err != nil {
+		return err
+	}
+	if len(path) == 0 {
+		obj, ok := parseValue(rawValue).(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("config key %q expects a JSON object value", key)
+		}
+		return scope.SaveSetting(ctx, st, scope.System, "", namespace, obj)
+	}
+	data := map[string]interface{}{}
+	if rec, err := st.GetConfigByName(ctx, store.KindSetting, scope.System, "", namespace); err == nil && rec != nil {
+		data = rec.Data
+	} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return err
+	}
+	setNested(data, path, parseValue(rawValue))
+	if namespace == "sandbox" && len(path) > 0 && path[0] == "enabled" {
+		if enabled, _ := data["enabled"].(bool); enabled {
+			if _, ok := data["backend"].(string); !ok {
+				data["backend"] = "docker"
+			}
+		}
+	}
+	return scope.SaveSetting(ctx, st, scope.System, "", namespace, data)
+}
+
+// GetConfig returns one config value, or a redacted system config dump when key is empty.
+func GetConfig(name, key string) (interface{}, error) {
+	st, _, err := storeForName(name)
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if key == "" {
+		return configDump(ctx, st)
+	}
+	if strings.HasPrefix(key, "provider.") {
+		return getProviderField(ctx, st, key)
+	}
+	namespace, path, err := settingKey(key)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := st.GetConfigByName(ctx, store.KindSetting, scope.System, "", namespace)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(path) == 0 {
+		return rec.Data, nil
+	}
+	return getNested(rec.Data, path), nil
+}
+
+// PutFile writes an agent system file for the configured local agent.
+func PutFile(name, filename, srcPath string) error {
+	if err := validateSystemFilename(filename); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	st, inst, err := storeForName(name)
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+	if err := ensureConfigured(inst); err != nil {
+		return err
+	}
+	return st.SaveAgentFile(context.Background(), inst.AgentID, inst.UserID, filename, data)
+}
+
+// GetFile reads an agent system file.
+func GetFile(name, filename string) ([]byte, error) {
+	if err := validateSystemFilename(filename); err != nil {
+		return nil, err
+	}
+	st, inst, err := storeForName(name)
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close()
+	if err := ensureConfigured(inst); err != nil {
+		return nil, err
+	}
+	return st.GetAgentFile(context.Background(), inst.AgentID, inst.UserID, filename)
+}
+
+// ListFiles lists agent system files stored for the configured local agent.
+func ListFiles(name string) ([]string, error) {
+	st, inst, err := storeForName(name)
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close()
+	if err := ensureConfigured(inst); err != nil {
+		return nil, err
+	}
+	files, err := st.ListAgentFiles(context.Background(), inst.AgentID, inst.UserID)
+	if err != nil {
+		return nil, err
+	}
+	out := files[:0]
+	for _, file := range files {
+		if systemFileAllowlist[file] {
+			out = append(out, file)
+		}
+	}
+	return out, nil
+}
+
+func openInstanceStore(home string) (store.Store, error) {
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	defer slog.SetDefault(prevLogger)
+	return store.New(&store.StorageConfig{
+		Type:        store.StorageSQLite,
+		AutoMigrate: true,
+	}, home)
+}
+
+func storeForName(name string) (store.Store, *Instance, error) {
+	if err := validateName(name); err != nil {
+		return nil, nil, err
+	}
+	p, err := instancePaths(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	inst, err := loadInstance(p.metaFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("agent %q is not initialized; run `fastclaw agents init %s` first", name, name)
+	}
+	if inst.Home == "" {
+		inst.Home = p.homeDir
+	}
+	st, err := openInstanceStore(inst.Home)
+	if err != nil {
+		return nil, nil, err
+	}
+	return st, inst, nil
+}
+
+func ensureAccount(ctx context.Context, st store.Store, opts InitOptions) (*users.Account, bool, string, error) {
+	accts, err := users.NewAccounts(st)
+	if err != nil {
+		return nil, false, "", err
+	}
+	n, err := st.CountUsers(ctx)
+	if err != nil {
+		return nil, false, "", err
+	}
+	if opts.Username != "" {
+		rec, err := st.GetUserByLogin(ctx, opts.Username)
+		if err == nil {
+			acct, err := accts.Get(ctx, rec.ID)
+			return acct, false, "", err
+		}
+		if !errors.Is(err, store.ErrNotFound) {
+			return nil, false, "", err
+		}
+		// Refusing the silent fallback: when the local DB already has
+		// users, --username pointing at a missing account must fail loudly
+		// instead of bonding the agent to whichever super-admin we find.
+		if n > 0 {
+			return nil, false, "", fmt.Errorf("user %q not found in local database", opts.Username)
+		}
+	}
+	if n > 0 {
+		usersList, err := accts.List(ctx)
+		if err != nil {
+			return nil, false, "", err
+		}
+		if len(usersList) == 0 {
+			return nil, false, "", errors.New("users list is empty despite nonzero count")
+		}
+		for _, acct := range usersList {
+			if acct.Role == users.RoleSuperAdmin {
+				return acct, false, "", nil
+			}
+		}
+		return usersList[0], false, "", nil
+	}
+
+	username := defaultStr(opts.Username, "admin")
+	email := defaultStr(opts.Email, "admin@local.fastclaw")
+	password := opts.Password
+	generated := ""
+	if password == "" {
+		var err error
+		password, err = randomPassword()
+		if err != nil {
+			return nil, false, "", err
+		}
+		generated = password
+	}
+	acct, err := accts.Create(ctx, username, email, password, opts.DisplayName, users.RoleSuperAdmin)
+	return acct, err == nil, generated, err
+}
+
+func normalizeProviderModel(providerName, model string) (string, string, string, error) {
+	providerName = strings.TrimSpace(providerName)
+	model = strings.TrimSpace(model)
+	modelID := model
+	if strings.Contains(model, "/") {
+		parts := strings.SplitN(model, "/", 2)
+		if parts[0] == "" || parts[1] == "" {
+			return "", "", "", fmt.Errorf("invalid model %q: expected <provider>/<model>", model)
+		}
+		if providerName != "" && providerName != parts[0] {
+			return "", "", "", fmt.Errorf("--provider %q does not match model provider prefix %q", providerName, parts[0])
+		}
+		if providerName == "" {
+			providerName = parts[0]
+		}
+		modelID = parts[1]
+	}
+	if providerName == "" {
+		return "", "", "", errors.New("--provider is required when --model does not include a provider prefix")
+	}
+	fullModel := ""
+	if modelID != "" {
+		fullModel = providerName + "/" + modelID
+	}
+	return providerName, modelID, fullModel, nil
+}
+
+func providerConfigFromOptions(ctx context.Context, st store.Store, providerName, modelID string, opts InitOptions) (config.ProviderConfig, error) {
+	preset := providerPreset(providerName)
+	existing := config.ProviderConfig{}
+	if rec, err := st.GetConfigByName(ctx, store.KindProvider, scope.System, "", providerName); err == nil && rec != nil {
+		blob, _ := json.Marshal(rec.Data)
+		_ = json.Unmarshal(blob, &existing)
+	} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return config.ProviderConfig{}, err
+	}
+	apiBase := firstNonEmpty(opts.APIBase, existing.APIBase, preset.apiBase)
+	apiType := firstNonEmpty(opts.APIType, existing.APIType, preset.apiType)
+	authType := firstNonEmpty(opts.AuthType, existing.AuthType, preset.authType)
+	apiKeyEnv := opts.APIKeyEnv
+	if apiKeyEnv == "" {
+		apiKeyEnv = preset.apiKeyEnv
+	}
+	apiKey := existing.APIKey
+	if opts.APIKeyEnv != "" || (apiKey == "" && apiKeyEnv != "") {
+		apiKey = os.Getenv(apiKeyEnv)
+		if apiKey == "" && providerName != "ollama" {
+			return config.ProviderConfig{}, fmt.Errorf("environment variable %s is empty", apiKeyEnv)
+		}
+	}
+	if apiKey == "" && providerName == "ollama" {
+		apiKey = "ollama"
+	}
+	cfg := config.ProviderConfig{
+		APIKey:   apiKey,
+		APIBase:  apiBase,
+		APIType:  apiType,
+		AuthType: authType,
+		Models:   existing.Models,
+	}
+	if modelID != "" {
+		cfg.Models = appendModel(cfg.Models, modelID)
+	}
+	return cfg, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+type providerDefaults struct {
+	apiBase   string
+	apiType   string
+	authType  string
+	apiKeyEnv string
+}
+
+func providerPreset(name string) providerDefaults {
+	switch strings.ToLower(name) {
+	case "anthropic":
+		return providerDefaults{"https://api.anthropic.com", "anthropic-messages", "api-key", "ANTHROPIC_API_KEY"}
+	case "openrouter":
+		return providerDefaults{"https://openrouter.ai/api/v1", "openai-chat", "bearer-token", "OPENROUTER_API_KEY"}
+	case "ollama":
+		return providerDefaults{"http://localhost:11434/v1", "openai-chat", "bearer-token", ""}
+	case "groq":
+		return providerDefaults{"https://api.groq.com/openai/v1", "openai-chat", "bearer-token", "GROQ_API_KEY"}
+	case "deepseek":
+		return providerDefaults{"https://api.deepseek.com/v1", "openai-chat", "bearer-token", "DEEPSEEK_API_KEY"}
+	case "mistral":
+		return providerDefaults{"https://api.mistral.ai/v1", "openai-chat", "bearer-token", "MISTRAL_API_KEY"}
+	case "openai":
+		fallthrough
+	default:
+		return providerDefaults{"https://api.openai.com/v1", "openai-chat", "bearer-token", "OPENAI_API_KEY"}
+	}
+}
+
+func setProviderField(ctx context.Context, st store.Store, key, rawValue string) error {
+	parts := strings.Split(strings.TrimPrefix(key, "provider."), ".")
+	if len(parts) != 2 {
+		return errors.New("provider config key must look like provider.<name>.<field>")
+	}
+	name, field := parts[0], parts[1]
+	pc := config.ProviderConfig{}
+	if rec, err := st.GetConfigByName(ctx, store.KindProvider, scope.System, "", name); err == nil && rec != nil {
+		blob, _ := json.Marshal(rec.Data)
+		_ = json.Unmarshal(blob, &pc)
+	} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return err
+	} else {
+		pc = providerConfigFromPreset(name)
+	}
+	switch field {
+	case "apiKeyEnv":
+		pc.APIKey = os.Getenv(rawValue)
+		if pc.APIKey == "" {
+			return fmt.Errorf("environment variable %s is empty", rawValue)
+		}
+	case "apiKey":
+		pc.APIKey = rawValue
+	case "apiBase":
+		pc.APIBase = rawValue
+	case "apiType":
+		pc.APIType = rawValue
+	case "authType":
+		pc.AuthType = rawValue
+	case "model":
+		if rawValue == "" {
+			return errors.New("provider model id is required; pass `provider.<name>.models` (note the s) with an empty array to clear the list")
+		}
+		pc.Models = appendModel(pc.Models, rawValue)
+	case "models":
+		if rawValue == "[]" {
+			pc.Models = nil
+		} else {
+			return errors.New(`only "[]" is accepted for provider.<name>.models — use provider.<name>.model <id> to add entries`)
+		}
+	default:
+		return fmt.Errorf("unsupported provider field %q", field)
+	}
+	return scope.SaveProvider(ctx, st, scope.System, "", name, pc)
+}
+
+func providerConfigFromPreset(providerName string) config.ProviderConfig {
+	preset := providerPreset(providerName)
+	return config.ProviderConfig{
+		APIBase:  preset.apiBase,
+		APIType:  preset.apiType,
+		AuthType: preset.authType,
+	}
+}
+
+func getProviderField(ctx context.Context, st store.Store, key string) (interface{}, error) {
+	parts := strings.Split(strings.TrimPrefix(key, "provider."), ".")
+	if len(parts) != 2 {
+		return nil, errors.New("provider config key must look like provider.<name>.<field>")
+	}
+	rec, err := st.GetConfigByName(ctx, store.KindProvider, scope.System, "", parts[0])
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	data := redactProviderData(rec.Data)
+	return data[parts[1]], nil
+}
+
+func appendModel(models []config.ModelEntry, id string) []config.ModelEntry {
+	for _, m := range models {
+		if m.ID == id {
+			return models
+		}
+	}
+	return append(models, config.ModelEntry{ID: id, Name: id})
+}
+
+var knownSettingNamespaces = []string{
+	"agents.defaults",
+	"skills.install",
+	"skills.entries",
+	"tools.providers",
+	"tools.categories",
+	"skillsLearner",
+	"objectstore",
+	"taskqueue",
+	"sandbox",
+	"heartbeat",
+	"plugins",
+	"memory",
+	"privacy",
+	"hooks",
+	"teams",
+	"bindings",
+}
+
+func settingKey(key string) (string, []string, error) {
+	switch key {
+	case "model":
+		return "agents.defaults", []string{"model"}, nil
+	case "maxTokens":
+		return "agents.defaults", []string{"maxTokens"}, nil
+	case "temperature":
+		return "agents.defaults", []string{"temperature"}, nil
+	case "thinking":
+		return "agents.defaults", []string{"thinking"}, nil
+	case "policy":
+		return "agents.defaults", []string{"policy"}, nil
+	}
+	for _, ns := range knownSettingNamespaces {
+		if key == ns {
+			return ns, nil, nil
+		}
+		prefix := ns + "."
+		if strings.HasPrefix(key, prefix) {
+			path := strings.Split(strings.TrimPrefix(key, prefix), ".")
+			if len(path) == 0 || path[0] == "" {
+				break
+			}
+			return ns, path, nil
+		}
+	}
+	return "", nil, fmt.Errorf("unsupported config key %q", key)
+}
+
+func configDump(ctx context.Context, st store.Store) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+	settings, err := st.ListConfigs(ctx, store.KindSetting, scope.System, "")
+	if err != nil {
+		return nil, err
+	}
+	for _, rec := range settings {
+		out[rec.Name] = rec.Data
+	}
+	providers, err := st.ListConfigs(ctx, store.KindProvider, scope.System, "")
+	if err != nil {
+		return nil, err
+	}
+	provOut := map[string]interface{}{}
+	for _, rec := range providers {
+		provOut[rec.Name] = redactProviderData(rec.Data)
+	}
+	if len(provOut) > 0 {
+		out["providers"] = provOut
+	}
+	agents, err := st.ListAllAgents(ctx)
+	if err == nil && len(agents) > 0 {
+		sort.Slice(agents, func(i, j int) bool { return agents[i].Name < agents[j].Name })
+		out["agents"] = agents
+	}
+	return out, nil
+}
+
+func redactProviderData(data map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(data))
+	for k, v := range data {
+		if k == "apiKey" {
+			if s, _ := v.(string); s != "" {
+				out[k] = "<set>"
+			} else {
+				out[k] = ""
+			}
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func setNested(data map[string]interface{}, path []string, value interface{}) {
+	cur := data
+	for _, p := range path[:len(path)-1] {
+		next, _ := cur[p].(map[string]interface{})
+		if next == nil {
+			next = map[string]interface{}{}
+			cur[p] = next
+		}
+		cur = next
+	}
+	cur[path[len(path)-1]] = value
+}
+
+func loadSettingMap(ctx context.Context, st store.Store, namespace string) (map[string]interface{}, error) {
+	if rec, err := st.GetConfigByName(ctx, store.KindSetting, scope.System, "", namespace); err == nil && rec != nil {
+		if rec.Data != nil {
+			return rec.Data, nil
+		}
+		return map[string]interface{}{}, nil
+	} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return nil, err
+	}
+	return map[string]interface{}{}, nil
+}
+
+func saveSettingValue(ctx context.Context, st store.Store, namespace string, path []string, value interface{}) error {
+	data, err := loadSettingMap(ctx, st, namespace)
+	if err != nil {
+		return err
+	}
+	if len(path) == 0 {
+		obj, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("config namespace %q expects a JSON object value", namespace)
+		}
+		data = obj
+	} else {
+		setNested(data, path, value)
+	}
+	return scope.SaveSetting(ctx, st, scope.System, "", namespace, data)
+}
+
+func getNested(data map[string]interface{}, path []string) interface{} {
+	var cur interface{} = data
+	for _, p := range path {
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		cur = m[p]
+	}
+	return cur
+}
+
+func parseValue(raw string) interface{} {
+	var v interface{}
+	if err := json.Unmarshal([]byte(raw), &v); err == nil {
+		return v
+	}
+	if b, err := strconv.ParseBool(raw); err == nil {
+		return b
+	}
+	if i, err := strconv.Atoi(raw); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(raw, 64); err == nil {
+		return f
+	}
+	return raw
+}
+
+func ensureConfigured(inst *Instance) error {
+	if inst == nil || inst.AgentID == "" || inst.UserID == "" {
+		return errors.New("agent is not initialized; run `fastclaw agents init <name>` first")
+	}
+	return nil
+}
+
+var systemFileAllowlist = map[string]bool{
+	"SOUL.md":      true,
+	"IDENTITY.md":  true,
+	"USER.md":      true,
+	"BOOTSTRAP.md": true,
+	"MEMORY.md":    true,
+	"HEARTBEAT.md": true,
+	"AGENTS.md":    true,
+	"TOOLS.md":     true,
+	"agent.json":   true,
+}
+
+func validateSystemFilename(filename string) error {
+	if !systemFileAllowlist[filename] {
+		return fmt.Errorf("filename %q is not a supported agent system file", filename)
+	}
+	return nil
+}
+
+func randomPassword() (string, error) {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func defaultStr(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}

--- a/internal/localagents/config_test.go
+++ b/internal/localagents/config_test.go
@@ -1,0 +1,561 @@
+package localagents
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/scope"
+	"github.com/fastclaw-ai/fastclaw/internal/store"
+	"github.com/fastclaw-ai/fastclaw/internal/users"
+)
+
+func setupTestHome(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "fastclaw")
+	t.Setenv("FASTCLAW_HOME", root)
+	return root
+}
+
+func TestInitPreservesAgentConfigAndSettings(t *testing.T) {
+	setupTestHome(t)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	if _, err := Init("scratch", InitOptions{
+		Description: "initial",
+		Provider:    "openai",
+		Model:       "openai/gpt-4.1",
+		APIKeyEnv:   "OPENAI_API_KEY",
+	}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := SetConfig("scratch", "temperature", "0.2"); err != nil {
+		t.Fatalf("set temperature: %v", err)
+	}
+
+	st, inst, err := storeForName("scratch")
+	if err != nil {
+		t.Fatalf("storeForName: %v", err)
+	}
+	rec, err := st.GetAgent(context.Background(), inst.AgentID)
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	rec.Config["workspace"] = "/tmp/workspace"
+	if err := st.SaveAgent(context.Background(), rec); err != nil {
+		t.Fatalf("save agent: %v", err)
+	}
+	st.Close()
+
+	if _, err := Init("scratch", InitOptions{
+		Provider:  "openai",
+		Model:     "openai/gpt-4.1-mini",
+		APIKeyEnv: "OPENAI_API_KEY",
+	}); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+
+	st, inst, err = storeForName("scratch")
+	if err != nil {
+		t.Fatalf("storeForName after re-init: %v", err)
+	}
+	defer st.Close()
+	rec, err = st.GetAgent(context.Background(), inst.AgentID)
+	if err != nil {
+		t.Fatalf("get agent after re-init: %v", err)
+	}
+	if got := rec.Config["description"]; got != "initial" {
+		t.Fatalf("description not preserved: got %#v", got)
+	}
+	if got := rec.Config["workspace"]; got != "/tmp/workspace" {
+		t.Fatalf("workspace not preserved: got %#v", got)
+	}
+
+	temp, err := GetConfig("scratch", "temperature")
+	if err != nil {
+		t.Fatalf("get temperature: %v", err)
+	}
+	if got, ok := temp.(float64); !ok || got != 0.2 {
+		t.Fatalf("temperature not preserved: got %#v", temp)
+	}
+	model, err := GetConfig("scratch", "model")
+	if err != nil {
+		t.Fatalf("get model: %v", err)
+	}
+	if model != "openai/gpt-4.1-mini" {
+		t.Fatalf("model not updated: got %#v", model)
+	}
+}
+
+func TestSetProviderFieldUsesPresetForNewProvider(t *testing.T) {
+	setupTestHome(t)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	if _, err := Init("scratch", InitOptions{}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := SetConfig("scratch", "provider.openai.apiKeyEnv", "OPENAI_API_KEY"); err != nil {
+		t.Fatalf("set provider apiKeyEnv: %v", err)
+	}
+
+	base, err := GetConfig("scratch", "provider.openai.apiBase")
+	if err != nil {
+		t.Fatalf("get provider apiBase: %v", err)
+	}
+	if base != "https://api.openai.com/v1" {
+		t.Fatalf("apiBase preset missing: got %#v", base)
+	}
+	apiType, err := GetConfig("scratch", "provider.openai.apiType")
+	if err != nil {
+		t.Fatalf("get provider apiType: %v", err)
+	}
+	if apiType != "openai-chat" {
+		t.Fatalf("apiType preset missing: got %#v", apiType)
+	}
+}
+
+func TestInitRejectsMismatchedProviderModel(t *testing.T) {
+	setupTestHome(t)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	_, err := Init("scratch", InitOptions{
+		Provider:  "openai",
+		Model:     "anthropic/claude-3-5-sonnet",
+		APIKeyEnv: "OPENAI_API_KEY",
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected provider/model mismatch error, got %v", err)
+	}
+}
+
+func TestPutFileRejectsUnsupportedSystemFilename(t *testing.T) {
+	setupTestHome(t)
+	if _, err := Init("scratch", InitOptions{}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "NOTES.md")
+	if err := os.WriteFile(path, []byte("notes"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	err := PutFile("scratch", "NOTES.md", path)
+	if err == nil {
+		t.Fatal("expected unsupported filename error")
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected validation before store lookup, got %v", err)
+	}
+}
+
+func TestInitRejectsRunningPortChange(t *testing.T) {
+	root := setupTestHome(t)
+	p, err := instancePaths("scratch")
+	if err != nil {
+		t.Fatalf("instance paths: %v", err)
+	}
+	if err := saveInstance(p.metaFile, &Instance{
+		Name: "scratch",
+		PID:  os.Getpid(),
+		Port: 34567,
+		Home: filepath.Join(root, "local-agents", "scratch"),
+	}); err != nil {
+		t.Fatalf("save instance: %v", err)
+	}
+
+	_, err = Init("scratch", InitOptions{Port: 34568})
+	if err == nil || !strings.Contains(err.Error(), "stop it before changing --port") {
+		t.Fatalf("expected running port-change error, got %v", err)
+	}
+}
+
+func TestStartRejectsUnavailablePort(t *testing.T) {
+	setupTestHome(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	_, portText, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	_, err = Start("scratch", StartOptions{Port: port})
+	if err == nil || !strings.Contains(err.Error(), "not available") {
+		t.Fatalf("expected unavailable port error, got %v", err)
+	}
+}
+
+func TestInitPreservesExistingModelEntryFields(t *testing.T) {
+	setupTestHome(t)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	if _, err := Init("scratch", InitOptions{
+		Provider:  "openai",
+		Model:     "openai/gpt-4.1",
+		APIKeyEnv: "OPENAI_API_KEY",
+	}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Simulate the dashboard enriching the model entry with cost/context.
+	st, _, err := storeForName("scratch")
+	if err != nil {
+		t.Fatalf("storeForName: %v", err)
+	}
+	rec, err := st.GetConfigByName(context.Background(), store.KindProvider, scope.System, "", "openai")
+	if err != nil {
+		t.Fatalf("get provider: %v", err)
+	}
+	models, _ := rec.Data["models"].([]interface{})
+	if len(models) == 0 {
+		st.Close()
+		t.Fatal("expected at least one model entry")
+	}
+	first, _ := models[0].(map[string]interface{})
+	first["contextWindow"] = float64(128000)
+	first["maxTokens"] = float64(4096)
+	first["cost"] = map[string]interface{}{"input": 0.01, "output": 0.03}
+	rec.Data["models"] = models
+	if err := scope.SaveProvider(context.Background(), st, scope.System, "", "openai", providerConfigFromMap(rec.Data)); err != nil {
+		st.Close()
+		t.Fatalf("save provider: %v", err)
+	}
+	st.Close()
+
+	// Re-init with the same model — metadata must survive.
+	if _, err := Init("scratch", InitOptions{
+		Provider:  "openai",
+		Model:     "openai/gpt-4.1",
+		APIKeyEnv: "OPENAI_API_KEY",
+	}); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+
+	st, _, err = storeForName("scratch")
+	if err != nil {
+		t.Fatalf("storeForName after re-init: %v", err)
+	}
+	defer st.Close()
+	rec, err = st.GetConfigByName(context.Background(), store.KindProvider, scope.System, "", "openai")
+	if err != nil {
+		t.Fatalf("get provider after re-init: %v", err)
+	}
+	models, _ = rec.Data["models"].([]interface{})
+	if len(models) == 0 {
+		t.Fatal("models cleared after re-init")
+	}
+	first, _ = models[0].(map[string]interface{})
+	if got := first["contextWindow"]; got != float64(128000) {
+		t.Fatalf("contextWindow not preserved: got %#v", got)
+	}
+	if got := first["maxTokens"]; got != float64(4096) {
+		t.Fatalf("maxTokens not preserved: got %#v", got)
+	}
+	cost, _ := first["cost"].(map[string]interface{})
+	if cost["input"] != 0.01 || cost["output"] != 0.03 {
+		t.Fatalf("cost not preserved: got %#v", cost)
+	}
+}
+
+// providerConfigFromMap is a test helper that bridges the loose map shape
+// the store returns back into a typed ProviderConfig for SaveProvider.
+func providerConfigFromMap(data map[string]interface{}) config.ProviderConfig {
+	pc := config.ProviderConfig{
+		APIKey:   stringField(data, "apiKey"),
+		APIBase:  stringField(data, "apiBase"),
+		APIType:  stringField(data, "apiType"),
+		AuthType: stringField(data, "authType"),
+	}
+	models, _ := data["models"].([]interface{})
+	for _, m := range models {
+		entry, _ := m.(map[string]interface{})
+		me := config.ModelEntry{
+			ID:            stringField(entry, "id"),
+			Name:          stringField(entry, "name"),
+			ContextWindow: int(numField(entry, "contextWindow")),
+			MaxTokens:     int(numField(entry, "maxTokens")),
+		}
+		if c, ok := entry["cost"].(map[string]interface{}); ok {
+			me.Cost.Input = numField(c, "input")
+			me.Cost.Output = numField(c, "output")
+			me.Cost.CacheRead = numField(c, "cacheRead")
+			me.Cost.CacheWrite = numField(c, "cacheWrite")
+		}
+		pc.Models = append(pc.Models, me)
+	}
+	return pc
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+func numField(m map[string]interface{}, key string) float64 {
+	switch v := m[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	}
+	return 0
+}
+
+func TestEnsureAccountRejectsMissingExplicitUser(t *testing.T) {
+	setupTestHome(t)
+
+	// Seed the store with a real super-admin user so the count > 0.
+	if _, err := Init("scratch", InitOptions{}); err != nil {
+		t.Fatalf("init seed: %v", err)
+	}
+
+	_, err := Init("scratch", InitOptions{Username: "ghost"})
+	if err == nil {
+		t.Fatal("expected error when --username does not exist")
+	}
+	if !strings.Contains(err.Error(), `"ghost"`) {
+		t.Fatalf("expected error to name the missing user, got %v", err)
+	}
+}
+
+func TestEnsureAccountResolvesExistingExplicitUser(t *testing.T) {
+	setupTestHome(t)
+
+	res1, err := Init("scratch", InitOptions{Username: "alice"})
+	if err != nil {
+		t.Fatalf("seed alice: %v", err)
+	}
+	if !res1.CreatedUser {
+		t.Fatal("first init should create alice")
+	}
+
+	res2, err := Init("scratch", InitOptions{Username: "alice"})
+	if err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+	if res2.CreatedUser {
+		t.Fatal("alice already existed; expected reuse, not re-create")
+	}
+	if res1.Instance.UserID != res2.Instance.UserID {
+		t.Fatalf("UserID changed across re-init: %q -> %q", res1.Instance.UserID, res2.Instance.UserID)
+	}
+
+	st, _, err := storeForName("scratch")
+	if err != nil {
+		t.Fatalf("storeForName: %v", err)
+	}
+	defer st.Close()
+	accts, err := users.NewAccounts(st)
+	if err != nil {
+		t.Fatalf("accounts: %v", err)
+	}
+	acct, err := accts.Get(context.Background(), res2.Instance.UserID)
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	if acct.Username != "alice" {
+		t.Fatalf("expected alice, got %q", acct.Username)
+	}
+}
+
+func TestRemoveAgentDefaultPreservesHomeAndLog(t *testing.T) {
+	setupTestHome(t)
+
+	if _, err := Init("scratch", InitOptions{}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	p, err := instancePaths("scratch")
+	if err != nil {
+		t.Fatalf("instance paths: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p.logFile), 0o755); err != nil {
+		t.Fatalf("create log dir: %v", err)
+	}
+	if err := os.WriteFile(p.logFile, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	if _, err := Remove("scratch", RemoveOptions{}); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := os.Stat(p.metaFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("metadata still present: %v", err)
+	}
+	if _, err := os.Stat(p.homeDir); err != nil {
+		t.Fatalf("home should be preserved: %v", err)
+	}
+	if _, err := os.Stat(p.logFile); err != nil {
+		t.Fatalf("log should be preserved: %v", err)
+	}
+
+	// Removing a missing agent must error rather than silently succeed.
+	if _, err := Remove("scratch", RemoveOptions{}); err == nil {
+		t.Fatal("expected error removing unknown agent")
+	}
+}
+
+func TestRemoveAgentPurgeWipesHomeAndLog(t *testing.T) {
+	setupTestHome(t)
+
+	if _, err := Init("scratch", InitOptions{}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	p, err := instancePaths("scratch")
+	if err != nil {
+		t.Fatalf("instance paths: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p.logFile), 0o755); err != nil {
+		t.Fatalf("create log dir: %v", err)
+	}
+	if err := os.WriteFile(p.logFile, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	if _, err := Remove("scratch", RemoveOptions{Purge: true}); err != nil {
+		t.Fatalf("remove --purge: %v", err)
+	}
+	if _, err := os.Stat(p.homeDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("home not removed: %v", err)
+	}
+	if _, err := os.Stat(p.logFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("log not removed: %v", err)
+	}
+}
+
+func TestRemoveAgentRefusesRunningWithoutForce(t *testing.T) {
+	root := setupTestHome(t)
+	p, err := instancePaths("scratch")
+	if err != nil {
+		t.Fatalf("instance paths: %v", err)
+	}
+	if err := saveInstance(p.metaFile, &Instance{
+		Name: "scratch",
+		PID:  os.Getpid(),
+		Home: filepath.Join(root, "local-agents", "scratch"),
+	}); err != nil {
+		t.Fatalf("save instance: %v", err)
+	}
+
+	_, err = Remove("scratch", RemoveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "stop it first") {
+		t.Fatalf("expected refusal for running agent, got %v", err)
+	}
+	// Metadata must remain so the user can still stop the agent.
+	if _, err := os.Stat(p.metaFile); err != nil {
+		t.Fatalf("metadata vanished on refused remove: %v", err)
+	}
+}
+
+func TestInitRefusesUserSwitchOnExistingAgent(t *testing.T) {
+	setupTestHome(t)
+
+	if _, err := Init("scratch", InitOptions{Username: "alice"}); err != nil {
+		t.Fatalf("seed alice: %v", err)
+	}
+	// Manually create a second user. Init resolves --username to that user
+	// and would re-save the agent record under a new owner if we let it.
+	st, _, err := storeForName("scratch")
+	if err != nil {
+		t.Fatalf("storeForName: %v", err)
+	}
+	accts, err := users.NewAccounts(st)
+	if err != nil {
+		t.Fatalf("accounts: %v", err)
+	}
+	bob, err := accts.Create(context.Background(), "bob", "bob@local", "secret-bob", "Bob", users.RoleUser)
+	if err != nil {
+		st.Close()
+		t.Fatalf("create bob: %v", err)
+	}
+	st.Close()
+
+	_, err = Init("scratch", InitOptions{Username: "bob"})
+	if err == nil || !strings.Contains(err.Error(), "is owned by user") {
+		t.Fatalf("expected refusal to rebind, got %v", err)
+	}
+
+	// Without --username the existing owner must be preserved (not
+	// silently rebound to whichever super-admin we land on).
+	res, err := Init("scratch", InitOptions{})
+	if err != nil {
+		t.Fatalf("re-init without username: %v", err)
+	}
+	if res.Instance.UserID == bob.ID {
+		t.Fatalf("re-init silently rebound owner to bob")
+	}
+}
+
+func TestSetProviderModelRejectsEmptyValue(t *testing.T) {
+	setupTestHome(t)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	if _, err := Init("scratch", InitOptions{
+		Provider:  "openai",
+		Model:     "openai/gpt-4.1",
+		APIKeyEnv: "OPENAI_API_KEY",
+	}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := SetConfig("scratch", "provider.openai.model", ""); err == nil {
+		t.Fatal("empty model id must be rejected, not silently wipe the list")
+	}
+	if got := loadProviderModelCount(t, "scratch", "openai"); got == 0 {
+		t.Fatal("models list was wiped despite the rejection")
+	}
+
+	// Explicit clear is allowed via the plural key with [].
+	if err := SetConfig("scratch", "provider.openai.models", "[]"); err != nil {
+		t.Fatalf("explicit clear: %v", err)
+	}
+	if got := loadProviderModelCount(t, "scratch", "openai"); got != 0 {
+		t.Fatalf("expected models cleared, still have %d", got)
+	}
+}
+
+func loadProviderModelCount(t *testing.T, name, provider string) int {
+	t.Helper()
+	st, _, err := storeForName(name)
+	if err != nil {
+		t.Fatalf("storeForName: %v", err)
+	}
+	defer st.Close()
+	rec, err := st.GetConfigByName(context.Background(), store.KindProvider, scope.System, "", provider)
+	if err != nil {
+		t.Fatalf("get provider %q: %v", provider, err)
+	}
+	models, _ := rec.Data["models"].([]interface{})
+	return len(models)
+}
+
+func TestCorruptMetadataIsNotOverwritten(t *testing.T) {
+	setupTestHome(t)
+	p, err := instancePaths("scratch")
+	if err != nil {
+		t.Fatalf("instance paths: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p.metaFile), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	if err := os.WriteFile(p.metaFile, []byte("{bad json"), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	if _, err := Init("scratch", InitOptions{}); err == nil {
+		t.Fatal("expected init to reject corrupt metadata")
+	}
+	if _, err := Start("scratch", StartOptions{}); err == nil {
+		t.Fatal("expected start to reject corrupt metadata")
+	}
+}

--- a/internal/localagents/manager.go
+++ b/internal/localagents/manager.go
@@ -1,0 +1,483 @@
+package localagents
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+)
+
+var validName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+
+// Instance is the persisted process metadata for a local agent instance.
+type Instance struct {
+	Name      string     `json:"name"`
+	AgentID   string     `json:"agentId,omitempty"`
+	AgentName string     `json:"agentName,omitempty"`
+	UserID    string     `json:"userId,omitempty"`
+	PID       int        `json:"pid,omitempty"`
+	Port      int        `json:"port,omitempty"`
+	Home      string     `json:"home"`
+	LogFile   string     `json:"logFile"`
+	URL       string     `json:"url,omitempty"`
+	Command   []string   `json:"command,omitempty"`
+	StartedAt time.Time  `json:"startedAt"`
+	StoppedAt *time.Time `json:"stoppedAt,omitempty"`
+}
+
+// Status combines persisted metadata with live process state.
+type Status struct {
+	Instance
+	Running bool
+	Uptime  time.Duration
+}
+
+// StartOptions controls how a local agent instance is launched.
+type StartOptions struct {
+	Port int
+	Home string
+}
+
+type paths struct {
+	stateDir string
+	logDir   string
+	homeDir  string
+	metaFile string
+	pidFile  string
+	logFile  string
+}
+
+// Start launches a named local FastClaw gateway instance in the background.
+func Start(name string, opts StartOptions) (*Instance, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	st, err := GetStatus(name)
+	if err != nil {
+		return nil, err
+	}
+	if st.Running {
+		return nil, fmt.Errorf("agent %q already running (PID %d)", name, st.PID)
+	}
+
+	p, err := instancePaths(name)
+	if err != nil {
+		return nil, err
+	}
+	existing := Instance{Name: name}
+	if st != nil {
+		existing = st.Instance
+	}
+	home := opts.Home
+	if home == "" {
+		home = existing.Home
+	}
+	if home == "" {
+		home = p.homeDir
+	}
+	home = expandHome(home)
+
+	port := opts.Port
+	if port <= 0 {
+		port = existing.Port
+	}
+	if port <= 0 {
+		port, err = freePort()
+		if err != nil {
+			return nil, err
+		}
+	} else if err := ensurePortAvailable(port); err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(p.stateDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create state dir: %w", err)
+	}
+	if err := os.MkdirAll(p.logDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		return nil, fmt.Errorf("create agent home: %w", err)
+	}
+
+	bin, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("find executable: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(bin); err == nil {
+		bin = resolved
+	}
+
+	lf, err := os.OpenFile(p.logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+	defer lf.Close()
+
+	args := []string{"gateway", "--port", strconv.Itoa(port)}
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout = lf
+	cmd.Stderr = lf
+	// Keep temporary instances isolated even when the operator's shell has
+	// FASTCLAW_STORAGE_* set for a shared gateway.
+	cmd.Env = withEnv(os.Environ(), map[string]string{
+		"FASTCLAW_HOME":                 home,
+		"FASTCLAW_AGENT_NAME":           name,
+		"FASTCLAW_NO_OPEN":              "1",
+		"FASTCLAW_PORT":                 strconv.Itoa(port),
+		"FASTCLAW_STORAGE_TYPE":         "sqlite",
+		"FASTCLAW_STORAGE_DSN":          "",
+		"FASTCLAW_STORAGE_AUTO_MIGRATE": "true",
+	})
+	setSysProcAttr(cmd)
+
+	if _, err := fmt.Fprintf(lf, "\n[agents] starting %q at %s\n", name, time.Now().Format(time.RFC3339)); err != nil {
+		return nil, fmt.Errorf("write log banner: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start agent %q: %w", name, err)
+	}
+
+	now := time.Now()
+	inst := &Instance{
+		Name:      name,
+		AgentID:   existing.AgentID,
+		AgentName: existing.AgentName,
+		UserID:    existing.UserID,
+		PID:       cmd.Process.Pid,
+		Port:      port,
+		Home:      home,
+		LogFile:   p.logFile,
+		URL:       fmt.Sprintf("http://localhost:%d", port),
+		Command:   append([]string{bin}, args...),
+		StartedAt: now,
+	}
+	if err := writePID(p.pidFile, cmd.Process.Pid); err != nil {
+		_ = signalPID(cmd.Process.Pid, "KILL")
+		return nil, fmt.Errorf("write PID file: %w", err)
+	}
+	if err := saveInstance(p.metaFile, inst); err != nil {
+		_ = signalPID(cmd.Process.Pid, "KILL")
+		_ = os.Remove(p.pidFile)
+		return nil, err
+	}
+	_ = cmd.Process.Release()
+	return inst, nil
+}
+
+// Stop terminates a named local agent instance.
+func Stop(name string) (*Instance, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	p, err := instancePaths(name)
+	if err != nil {
+		return nil, err
+	}
+	inst, err := loadInstance(p.metaFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("agent %q is not known", name)
+		}
+		return nil, err
+	}
+	if inst.PID <= 0 || !isProcessAlive(inst.PID) {
+		markStopped(p, inst)
+		return inst, fmt.Errorf("agent %q is not running", name)
+	}
+
+	pid := inst.PID
+	if err := signalPID(pid, "TERM"); err != nil {
+		return inst, fmt.Errorf("signal agent %q (PID %d): %w", name, pid, err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !isProcessAlive(pid) {
+			markStopped(p, inst)
+			return inst, nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	if err := signalPID(pid, "KILL"); err != nil && isProcessAlive(pid) {
+		return inst, fmt.Errorf("kill agent %q (PID %d): %w", name, pid, err)
+	}
+	markStopped(p, inst)
+	return inst, nil
+}
+
+// RemoveOptions controls how local agent state is reclaimed.
+type RemoveOptions struct {
+	// Force stops the agent first if it is still running.
+	Force bool
+	// Purge also removes the agent's FASTCLAW_HOME directory (sqlite DB and all).
+	Purge bool
+}
+
+// Remove deletes persisted state for a local agent instance. By default it
+// keeps the agent's home directory and log file untouched so a later
+// `agents init <name>` can recover prior data; pass Purge to wipe them.
+func Remove(name string, opts RemoveOptions) (*Instance, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	p, err := instancePaths(name)
+	if err != nil {
+		return nil, err
+	}
+	inst, err := loadInstance(p.metaFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("agent %q is not known", name)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if isProcessAlive(inst.PID) {
+		if !opts.Force {
+			return inst, fmt.Errorf("agent %q is running; stop it first or pass --force", name)
+		}
+		if _, err := Stop(name); err != nil {
+			return inst, err
+		}
+	}
+	_ = os.Remove(p.metaFile)
+	_ = os.Remove(p.pidFile)
+	if opts.Purge {
+		_ = os.Remove(p.logFile)
+		if inst.Home != "" {
+			_ = os.RemoveAll(inst.Home)
+		}
+	}
+	return inst, nil
+}
+
+// List returns all known local agent instances.
+func List() ([]Status, error) {
+	base, err := basePaths()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(base.stateDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Status, 0, len(entries))
+	for _, ent := range entries {
+		if ent.IsDir() || filepath.Ext(ent.Name()) != ".json" {
+			continue
+		}
+		inst, err := loadInstance(filepath.Join(base.stateDir, ent.Name()))
+		if err != nil {
+			continue
+		}
+		st := statusFromInstance(*inst)
+		if !st.Running && inst.PID > 0 {
+			p, err := instancePaths(inst.Name)
+			if err == nil {
+				markStopped(p, inst)
+				st.Instance = *inst
+			}
+		}
+		out = append(out, st)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// GetStatus returns the current status for one local agent instance.
+func GetStatus(name string) (*Status, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	p, err := instancePaths(name)
+	if err != nil {
+		return nil, err
+	}
+	inst, err := loadInstance(p.metaFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return &Status{Instance: Instance{Name: name}, Running: false}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	st := statusFromInstance(*inst)
+	if !st.Running && inst.PID > 0 {
+		markStopped(p, inst)
+		st.Instance = *inst
+	}
+	return &st, nil
+}
+
+// LogFile returns the expected log file path for a local agent.
+func LogFile(name string) (string, error) {
+	if err := validateName(name); err != nil {
+		return "", err
+	}
+	p, err := instancePaths(name)
+	if err != nil {
+		return "", err
+	}
+	return p.logFile, nil
+}
+
+func statusFromInstance(inst Instance) Status {
+	running := inst.PID > 0 && isProcessAlive(inst.PID)
+	st := Status{Instance: inst, Running: running}
+	if running && !inst.StartedAt.IsZero() {
+		st.Uptime = time.Since(inst.StartedAt)
+	}
+	return st
+}
+
+func markStopped(p paths, inst *Instance) {
+	now := time.Now()
+	inst.PID = 0
+	inst.StoppedAt = &now
+	_ = os.Remove(p.pidFile)
+	_ = saveInstance(p.metaFile, inst)
+}
+
+func validateName(name string) error {
+	if name == "" {
+		return errors.New("agent name is required")
+	}
+	if !validName.MatchString(name) {
+		return fmt.Errorf("invalid agent name %q: use letters, numbers, dot, dash, or underscore", name)
+	}
+	return nil
+}
+
+func basePaths() (paths, error) {
+	base, err := config.HomeDir()
+	if err != nil {
+		return paths{}, err
+	}
+	return paths{
+		stateDir: filepath.Join(base, "agent-runs"),
+		logDir:   filepath.Join(base, "logs", "agents"),
+		homeDir:  filepath.Join(base, "local-agents"),
+	}, nil
+}
+
+func instancePaths(name string) (paths, error) {
+	base, err := basePaths()
+	if err != nil {
+		return paths{}, err
+	}
+	base.homeDir = filepath.Join(base.homeDir, name)
+	base.metaFile = filepath.Join(base.stateDir, name+".json")
+	base.pidFile = filepath.Join(base.stateDir, name+".pid")
+	base.logFile = filepath.Join(base.logDir, name+".log")
+	return base, nil
+}
+
+func loadInstance(path string) (*Instance, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var inst Instance
+	if err := json.Unmarshal(data, &inst); err != nil {
+		return nil, err
+	}
+	return &inst, nil
+}
+
+func saveInstance(path string, inst *Instance) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(inst, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func writePID(path string, pid int) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func freePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer ln.Close()
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected listener address %q", ln.Addr())
+	}
+	return addr.Port, nil
+}
+
+func ensurePortAvailable(port int) error {
+	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return fmt.Errorf("port %d is not available: %w", port, err)
+	}
+	return ln.Close()
+}
+
+func expandHome(path string) string {
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+func withEnv(base []string, values map[string]string) []string {
+	out := make([]string, 0, len(base)+len(values))
+	seen := make(map[string]bool, len(values))
+	for _, kv := range base {
+		key, _, ok := strings.Cut(kv, "=")
+		if ok {
+			if v, exists := values[key]; exists {
+				out = append(out, key+"="+v)
+				seen[key] = true
+				continue
+			}
+		}
+		out = append(out, kv)
+	}
+	for k, v := range values {
+		if !seen[k] {
+			out = append(out, k+"="+v)
+		}
+	}
+	return out
+}

--- a/internal/localagents/proc_unix.go
+++ b/internal/localagents/proc_unix.go
@@ -1,0 +1,56 @@
+//go:build !windows
+
+package localagents
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// signalPID delivers a signal. TERM and KILL go to the entire process
+// group (negative PID) so children spawned by the gateway — sandbox
+// runners, plugin subprocesses — get torn down too. CHECK uses signal 0
+// to probe the leader only; that's enough for liveness.
+func signalPID(pid int, sig string) error {
+	switch sig {
+	case "TERM":
+		if err := syscall.Kill(-pid, syscall.SIGTERM); err == nil {
+			return nil
+		}
+		// Fallback when the leader is not its own pgid (e.g. a process
+		// started without Setsid that we picked up from a stale pidfile).
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return err
+		}
+		return proc.Signal(syscall.SIGTERM)
+	case "KILL":
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil {
+			return nil
+		}
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return err
+		}
+		return proc.Signal(syscall.SIGKILL)
+	case "CHECK":
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return err
+		}
+		return proc.Signal(syscall.Signal(0))
+	}
+	return nil
+}
+
+func isProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return signalPID(pid, "CHECK") == nil
+}

--- a/internal/localagents/proc_windows.go
+++ b/internal/localagents/proc_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package localagents
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// setSysProcAttr detaches the gateway from the launching console so it
+// survives the parent shell closing and can receive a graceful CTRL_BREAK
+// from Stop(). DETACHED_PROCESS prevents the child from inheriting the
+// console; CREATE_NEW_PROCESS_GROUP gives it its own group id so we can
+// signal it later.
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
+	}
+}
+
+// signalPID maps the platform-neutral signal names onto Windows
+// primitives. TERM sends CTRL_BREAK_EVENT (handled by Go runtimes the
+// same as SIGTERM); KILL terminates immediately; CHECK probes liveness.
+func signalPID(pid int, sig string) error {
+	switch sig {
+	case "TERM":
+		if err := windows.GenerateConsoleCtrlEvent(syscall.CTRL_BREAK_EVENT, uint32(pid)); err == nil {
+			return nil
+		}
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return err
+		}
+		return proc.Kill()
+	case "KILL":
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return err
+		}
+		return proc.Kill()
+	case "CHECK":
+		if isProcessAlive(pid) {
+			return nil
+		}
+		return os.ErrProcessDone
+	}
+	return nil
+}
+
+func isProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h)
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	const stillActive = 259
+	return code == stillActive
+}


### PR DESCRIPTION
Adds a `fastclaw agents` subcommand tree for managing isolated local FastClaw gateway instances entirely from the CLI, without opening the dashboard.

```bash
fastclaw agents init scratch \
  --provider openai --model openai/gpt-4.1 --api-key-env OPENAI_API_KEY
fastclaw agents config scratch set sandbox.enabled true
fastclaw agents files put scratch SOUL.md ./SOUL.md
fastclaw agents start scratch
fastclaw agents ls / status / log [-f] / restart / stop / rm [--purge|--force]
```

Each instance gets its own `FASTCLAW_HOME` (`~/.fastclaw/local-agents/<name>`), sqlite database, users, agents, workspace, and logs.

## Subcommands

| Subcommand | Purpose |
|---|---|
| `agents init <name>` | Create or update an instance's sqlite config (provider, model, sandbox, admin user). Re-running is non-destructive. |
| `agents start <name>` | Launch the gateway as a detached background process. Picks a free port if `--port` is not given. |
| `agents stop <name>` | Graceful shutdown (SIGTERM / `CTRL_BREAK_EVENT`) → SIGKILL after 5s. |
| `agents restart <name>` | Stop (if running) and start, optionally with new `--port` / `--home`. |
| `agents ls` / `status <name>` | List or inspect instance status, URL, log path, uptime. |
| `agents rm <name>` | Remove instance metadata; `--force` stops first, `--purge` also wipes home + log. |
| `agents log <name> [-f] [-n N]` | Native Go tailer — no `tail` binary required, works on Windows. |
| `agents config <name> get\|set [key] [value]` | Read or update saved provider/setting values. Provider presets (openai, openrouter, anthropic, ollama, groq, deepseek, mistral) ship built-in. |
| `agents files ls\|put\|get <name>` | Read / write the agent's system files (allowlist: SOUL.md, IDENTITY.md, USER.md, BOOTSTRAP.md, MEMORY.md, HEARTBEAT.md, AGENTS.md, TOOLS.md, agent.json). |

## Design notes

- **Re-init is non-destructive.** The agent record's `Config` map, system files, existing model-entry metadata (`contextWindow`, `maxTokens`, `cost`), and unspecified provider fields are all preserved. `--model` calls append to the model list rather than replacing it.
- **Owner is preserved across re-init.** When the saved `AgentRecord.UserID` doesn't match the resolved account, the prior owner is kept; `--username` for a different account refuses with an explicit error rather than silently rebinding.
- **Process supervision is platform-aware.**
  - Unix: child runs in its own session via `Setsid`; `stop` SIGTERMs the whole process group so sandbox runners and plugin subprocesses are torn down with the leader, escalating to SIGKILL after 5s.
  - Windows: child is launched with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` so it survives the parent shell closing; `stop` sends `CTRL_BREAK_EVENT` with a hard-kill fallback.
  - Liveness check uses `signal(0)` on Unix and `OpenProcess + GetExitCodeProcess` on Windows.
- **No shellouts.** `agents log -f` is a pure-Go tailer (read-backward-for-N + 200ms poll), so the CLI does not depend on `tail` being on `PATH` and works on Windows.
- **Cobra `SilenceUsage`** is set on the agents subtree so a failed command prints just the error, no usage banner.
- **No new top-level dependencies.** `<golang.org/x/sys/windows`> is already transitive.

## Test plan

- [x] `go build ./...` (linux/amd64)
- [x] `GOOS=windows go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...` — 19/19 pass
- [x] End-to-end smoke: init → config get/set → files put/get/ls → start → status → log -n / -f → restart → stop → rm → re-init recovers data → rm --purge wipes
- [x] Error paths: missing API key env, mismatched provider/model, unsupported filename, unsupported config key, busy port, unknown agent name, `--username` for missing user
- [x] Unix process group teardown verified by inspecting `pgid` of running gateway

+2,766 / -1, 9 files (1 squashed commit on top of `dev`).
