### PR TITLE
fix(agent): pad orphan tool_use in stream path to avoid 400 on next turn

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1055,6 +1055,17 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 	a.refreshSkillsFromStore()
 	sess := a.sessions.Get(msg.Channel, msg.ChatID)
 	a.bindSession(ctx, msg.Channel, msg.ChatID)
+
+	// Same orphan-tool_use safety net as HandleMessage. The streaming path
+	// previously lacked this, so loop detection (which appends an assistant
+	// tool_use + a system warn and breaks without ever running tools) and
+	// any other premature exit between sess.Append(assistantMsg) and tool
+	// result append left orphaned tool_use ids in the session. The next
+	// turn's API request — especially against Anthropic-compat endpoints
+	// like DeepSeek's /anthropic — then 400s with "tool_use ids were found
+	// without tool_result blocks immediately after".
+	defer padOrphanToolResults(sess)
+
 	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: BeforeSystemPrompt, UserID: a.ownerUserID})
 	systemPrompt := a.ctxBuilder.BuildSystemPrompt()
 	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: AfterSystemPrompt, UserID: a.ownerUserID})


### PR DESCRIPTION
## Summary

`HandleMessage` already has `defer padOrphanToolResults(sess)` as a safety net for premature exits that leave an assistant `tool_use` in session without a paired `tool_result`. `HandleMessageStream` was missing this defer, so the same exits — most notably loop detection, which appends an assistant `tool_use` + a system warn and returns without ever running tools — leave orphan `tool_use` ids in the persisted session.

The next turn's API request then 400s. Easiest to reproduce against DeepSeek's Anthropic-compat (`/anthropic`) endpoint:

```
API error 400: messages.93: tool_use ids were found without tool_result
blocks immediately after: call_xxx. Each tool_use block must have a
corresponding tool_result block in the next message.
```

OpenAI-shape providers are also unhappy with orphan `tool_calls` in history — DeepSeek's Anthropic surface just makes the failure most visible.

## Fix

Add `defer padOrphanToolResults(sess)` to `HandleMessageStream` immediately after `bindSession`, mirroring `HandleMessage` (`internal/agent/loop.go:678`).

`padOrphanToolResults` is a no-op when no orphans exist, so this only changes behavior on the broken paths.

## Caveat (not in this PR)

This prevents **new** orphans but does not heal sessions that already contain one — `padOrphanToolResults` appends the stub at the session end rather than inserting it adjacent to the orphan assistant. Pre-existing damaged sessions still need to either be replaced (new chat) or get a load-time pad pass in `sess.Get(...)`. Happy to follow up with that if it's wanted.

## Test plan

- [x] `go build ./...` clean
- [ ] Reproduce loop detection in stream path; confirm session no longer leaves orphan `tool_use` and the next turn succeeds
- [ ] Confirm normal (no-orphan) sessions are unaffected — defer should be a no-op