### PR TITLE
feat(providers): add DeepSeek preset

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1141,6 +1141,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 				defer close(outCh)
 				var full strings.Builder
 				var thinking, thinkingSig string
+				var rawAssistant json.RawMessage
 				for {
 					chunk, ok := sr.Next()
 					if !ok {
@@ -1155,6 +1156,9 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 					if chunk.ThinkingSignature != "" {
 						thinkingSig = chunk.ThinkingSignature
 					}
+					if len(chunk.RawAssistant) > 0 {
+						rawAssistant = chunk.RawAssistant
+					}
 					select {
 					case outCh <- chunk:
 					case <-ctx.Done():
@@ -1162,10 +1166,17 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 					}
 				}
 				msg := provider.Message{Role: "assistant", Content: full.String(), Thinking: thinking}
-				if thinking != "" {
-					// Pack {thinking, signature} into RawAssistant so the next
-					// turn can echo content[].thinking back to extended-
-					// thinking providers that require it.
+				switch {
+				case len(rawAssistant) > 0:
+					// Provider already serialized the assistant message
+					// in its wire format (e.g. OpenAI/DeepSeek with
+					// reasoning_content). Persist verbatim so the next
+					// turn replays it byte-identically — required for
+					// DeepSeek thinking mode.
+					msg.RawAssistant = rawAssistant
+				case thinking != "":
+					// Anthropic extended thinking: pack {thinking, signature}
+					// as a content-block so the next turn can echo it back.
 					if raw, err := json.Marshal(map[string]string{
 						"type":      "thinking",
 						"thinking":  thinking,

--- a/internal/agentcli/agentcli.go
+++ b/internal/agentcli/agentcli.go
@@ -558,7 +558,7 @@ func providerPreset(name string) providerDefaults {
 	case "groq":
 		return providerDefaults{"https://api.groq.com/openai/v1", "openai-chat", "bearer-token", "GROQ_API_KEY"}
 	case "deepseek":
-		return providerDefaults{"https://api.deepseek.com/v1", "openai-chat", "bearer-token", "DEEPSEEK_API_KEY"}
+		return providerDefaults{"https://api.deepseek.com", "openai-chat", "bearer-token", "DEEPSEEK_API_KEY"}
 	case "mistral":
 		return providerDefaults{"https://api.mistral.ai/v1", "openai-chat", "bearer-token", "MISTRAL_API_KEY"}
 	case "openai":

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -205,6 +205,19 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, too
 				// turn (or the API rejects with 400), so we serialize
 				// the assistant message in the OpenAI wire format here
 				// and let callers persist it verbatim.
+				//
+				// Note: RawAssistant intentionally omits tool_calls.
+				// ChatStream is only used by the agent loop's
+				// "no-more-tools, stream the final reply" branch
+				// (loop.go:1130) — if the model belatedly emits
+				// tool_calls there, FastClaw deliberately ignores them
+				// and never executes them, so persisting them would
+				// leave the session with an assistant.tool_calls that
+				// has no following tool response, causing the next
+				// turn to be rejected with `An assistant message with
+				// 'tool_calls' must be followed by tool messages`.
+				// tool_calls round-tripping happens through the
+				// non-stream Chat path (parseSSE) in the ReAct loop.
 				var tcs []ToolCall
 				for i := 0; i < len(toolCalls); i++ {
 					if tc, ok := toolCalls[i]; ok {
@@ -214,7 +227,6 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, too
 				reasoning := reasoningBuilder.String()
 				rawMsg := apiMessage{
 					Role:             "assistant",
-					ToolCalls:        tcs,
 					ReasoningContent: reasoning,
 				}
 				rawMsg.Content, _ = json.Marshal(contentBuilder.String())

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -63,30 +63,136 @@ type chatRequest struct {
 
 // toAPIMessages converts provider Messages to wire-format apiMessages,
 // handling ContentParts for multimodal messages.
+//
+// Defensive sanitization: OpenAI/DeepSeek reject any request where an
+// assistant message with `tool_calls` is not immediately followed by a
+// `tool` message answering each tool_call_id. Dirty sessions can land
+// us in that state — e.g. the agent's tool-loop detector at
+// loop.go:1218 appends the assistant's tool_calls then breaks out
+// without executing the tools, leaving orphans behind. Old sessions
+// from before the streamed-RawAssistant fix can also carry orphan
+// tool_calls inside the persisted RawAssistant. Either case used to
+// surface as `An assistant message with 'tool_calls' must be followed
+// by tool messages`. We strip the offending tool_calls (and any
+// orphan tool replies) at wire-build time so the request goes through
+// — the session keeps its historical record untouched.
 func toAPIMessages(msgs []Message) []json.RawMessage {
-	out := make([]json.RawMessage, len(msgs))
+	orphanAssistant, orphanTool := findOrphanToolCalls(msgs)
+	out := make([]json.RawMessage, 0, len(msgs))
 	for i, m := range msgs {
+		if orphanTool[i] {
+			continue
+		}
+
 		// For assistant messages with cached raw JSON, use it directly
-		// to guarantee prompt cache hits (byte-identical prefix).
-		if m.Role == "assistant" && len(m.RawAssistant) > 0 {
-			out[i] = m.RawAssistant
+		// to guarantee prompt cache hits (byte-identical prefix) —
+		// unless the cached message has orphan tool_calls, in which
+		// case rebuild it without them.
+		if m.Role == "assistant" && len(m.RawAssistant) > 0 && !orphanAssistant[i] {
+			out = append(out, m.RawAssistant)
 			continue
 		}
 
 		am := apiMessage{
 			Role:       m.Role,
-			ToolCalls:  m.ToolCalls,
 			ToolCallID: m.ToolCallID,
 			Name:       m.Name,
+		}
+		if !orphanAssistant[i] {
+			am.ToolCalls = m.ToolCalls
 		}
 		if len(m.ContentParts) > 0 {
 			am.Content, _ = json.Marshal(m.ContentParts)
 		} else {
 			am.Content, _ = json.Marshal(m.Content)
 		}
-		out[i], _ = json.Marshal(am)
+		raw, _ := json.Marshal(am)
+		out = append(out, raw)
 	}
 	return out
+}
+
+// findOrphanToolCalls walks msgs and flags assistant messages whose
+// declared tool_calls are not fully answered by immediately-following
+// tool messages, plus the tool messages that would dangle after the
+// strip. Both `m.ToolCalls` and tool_calls embedded in
+// `m.RawAssistant` are considered, since old sessions only stored
+// them in the raw JSON.
+func findOrphanToolCalls(msgs []Message) (orphanAssistant, orphanTool map[int]bool) {
+	orphanAssistant = map[int]bool{}
+	orphanTool = map[int]bool{}
+	for i, m := range msgs {
+		if m.Role != "assistant" {
+			continue
+		}
+		want := assistantToolCallIDs(m)
+		if len(want) == 0 {
+			continue
+		}
+		// Collect IDs from the run of tool messages immediately following.
+		got := map[string]bool{}
+		j := i + 1
+		for j < len(msgs) && msgs[j].Role == "tool" {
+			if id := msgs[j].ToolCallID; id != "" {
+				got[id] = true
+			}
+			j++
+		}
+		missing := false
+		for _, id := range want {
+			if !got[id] {
+				missing = true
+				break
+			}
+		}
+		if !missing {
+			continue
+		}
+		orphanAssistant[i] = true
+		// Drop any tool messages that referenced this assistant's
+		// (now-removed) tool_calls so the API doesn't reject them as
+		// dangling tool replies.
+		wantSet := map[string]bool{}
+		for _, id := range want {
+			wantSet[id] = true
+		}
+		for k := i + 1; k < j; k++ {
+			if wantSet[msgs[k].ToolCallID] {
+				orphanTool[k] = true
+			}
+		}
+	}
+	return
+}
+
+// assistantToolCallIDs extracts tool_call IDs from a stored assistant
+// Message, checking both the parsed ToolCalls field and tool_calls
+// embedded in the raw JSON (older sessions that streamed the message
+// only carry the IDs inside RawAssistant).
+func assistantToolCallIDs(m Message) []string {
+	if len(m.ToolCalls) > 0 {
+		ids := make([]string, 0, len(m.ToolCalls))
+		for _, tc := range m.ToolCalls {
+			ids = append(ids, tc.ID)
+		}
+		return ids
+	}
+	if len(m.RawAssistant) == 0 {
+		return nil
+	}
+	var raw struct {
+		ToolCalls []struct {
+			ID string `json:"id"`
+		} `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(m.RawAssistant, &raw); err != nil || len(raw.ToolCalls) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(raw.ToolCalls))
+	for _, tc := range raw.ToolCalls {
+		ids = append(ids, tc.ID)
+	}
+	return ids
 }
 
 // sseDelta mirrors the OpenAI streaming delta structure including tool call index.

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -37,12 +37,19 @@ func NewOpenAI(apiKey, apiBase string) *OpenAIProvider {
 
 // apiMessage is the wire format for a message sent to the OpenAI API.
 // It uses json.RawMessage for Content to support both string and array formats.
+//
+// ReasoningContent is DeepSeek's thinking-mode field. DeepSeek requires
+// it to be echoed back on subsequent turns or it returns
+// `invalid_request_error: The reasoning_content in the thinking mode
+// must be passed back to the API.` Pure OpenAI ignores unknown fields,
+// so omitempty keeps non-DeepSeek providers unaffected.
 type apiMessage struct {
-	Role       string          `json:"role"`
-	Content    json.RawMessage `json:"content,omitempty"`
-	ToolCalls  []ToolCall      `json:"tool_calls,omitempty"`
-	ToolCallID string          `json:"tool_call_id,omitempty"`
-	Name       string          `json:"name,omitempty"`
+	Role             string          `json:"role"`
+	Content          json.RawMessage `json:"content,omitempty"`
+	ReasoningContent string          `json:"reasoning_content,omitempty"`
+	ToolCalls        []ToolCall      `json:"tool_calls,omitempty"`
+	ToolCallID       string          `json:"tool_call_id,omitempty"`
+	Name             string          `json:"name,omitempty"`
 }
 
 type chatRequest struct {
@@ -91,9 +98,10 @@ type sseToolCallDelta struct {
 }
 
 type sseDelta struct {
-	Role      string             `json:"role,omitempty"`
-	Content   string             `json:"content,omitempty"`
-	ToolCalls []sseToolCallDelta `json:"tool_calls,omitempty"`
+	Role             string             `json:"role,omitempty"`
+	Content          string             `json:"content,omitempty"`
+	ReasoningContent string             `json:"reasoning_content,omitempty"`
+	ToolCalls        []sseToolCallDelta `json:"tool_calls,omitempty"`
 }
 
 type sseChoice struct {
@@ -182,6 +190,7 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, too
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 		toolCalls := make(map[int]*ToolCall)
+		var contentBuilder, reasoningBuilder strings.Builder
 
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -190,15 +199,33 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, too
 			}
 			data := strings.TrimPrefix(line, "data: ")
 			if data == "[DONE]" {
-				// Send final chunk with accumulated tool calls
+				// Send final chunk with accumulated tool calls and a
+				// fully-formed RawAssistant. DeepSeek thinking mode
+				// requires reasoning_content to round-trip on the next
+				// turn (or the API rejects with 400), so we serialize
+				// the assistant message in the OpenAI wire format here
+				// and let callers persist it verbatim.
 				var tcs []ToolCall
 				for i := 0; i < len(toolCalls); i++ {
 					if tc, ok := toolCalls[i]; ok {
 						tcs = append(tcs, *tc)
 					}
 				}
+				reasoning := reasoningBuilder.String()
+				rawMsg := apiMessage{
+					Role:             "assistant",
+					ToolCalls:        tcs,
+					ReasoningContent: reasoning,
+				}
+				rawMsg.Content, _ = json.Marshal(contentBuilder.String())
+				raw, _ := json.Marshal(rawMsg)
 				select {
-				case ch <- StreamChunk{ToolCalls: tcs, Done: true}:
+				case ch <- StreamChunk{
+					ToolCalls:    tcs,
+					Done:         true,
+					Thinking:     reasoning,
+					RawAssistant: raw,
+				}:
 				case <-ctx.Done():
 				}
 				return
@@ -242,8 +269,13 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, too
 				}
 			}
 
+			if delta.ReasoningContent != "" {
+				reasoningBuilder.WriteString(delta.ReasoningContent)
+			}
+
 			// Yield content chunks
 			if delta.Content != "" {
+				contentBuilder.WriteString(delta.Content)
 				select {
 				case ch <- StreamChunk{Content: delta.Content}:
 				case <-ctx.Done():
@@ -266,6 +298,7 @@ func (p *OpenAIProvider) parseSSE(reader io.Reader) (*Response, error) {
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 	var contentBuilder strings.Builder
+	var reasoningBuilder strings.Builder
 	toolCalls := make(map[int]*ToolCall)
 
 	for scanner.Scan() {
@@ -292,6 +325,9 @@ func (p *OpenAIProvider) parseSSE(reader io.Reader) (*Response, error) {
 
 		if delta.Content != "" {
 			contentBuilder.WriteString(delta.Content)
+		}
+		if delta.ReasoningContent != "" {
+			reasoningBuilder.WriteString(delta.ReasoningContent)
 		}
 
 		for _, tc := range delta.ToolCalls {
@@ -324,8 +360,10 @@ func (p *OpenAIProvider) parseSSE(reader io.Reader) (*Response, error) {
 		return nil, fmt.Errorf("read stream: %w", err)
 	}
 
+	reasoning := reasoningBuilder.String()
 	result := &Response{
-		Content: contentBuilder.String(),
+		Content:  contentBuilder.String(),
+		Thinking: reasoning,
 	}
 	for i := 0; i < len(toolCalls); i++ {
 		if tc, ok := toolCalls[i]; ok {
@@ -335,9 +373,13 @@ func (p *OpenAIProvider) parseSSE(reader io.Reader) (*Response, error) {
 
 	// Capture raw assistant message for cache-safe replay.
 	// Reconstruct the exact message format the API would expect back.
+	// reasoning_content must round-trip for DeepSeek's thinking mode
+	// (otherwise the next turn fails with `The reasoning_content in
+	// the thinking mode must be passed back to the API.`).
 	rawMsg := apiMessage{
-		Role:      "assistant",
-		ToolCalls: result.ToolCalls,
+		Role:             "assistant",
+		ToolCalls:        result.ToolCalls,
+		ReasoningContent: reasoning,
 	}
 	rawMsg.Content, _ = json.Marshal(result.Content)
 	result.RawAssistant, _ = json.Marshal(rawMsg)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -138,6 +138,13 @@ type StreamChunk struct {
 	// extended-thinking providers (Anthropic + DeepSeek /anthropic compat).
 	Thinking          string
 	ThinkingSignature string
+	// RawAssistant is the fully-serialized assistant message in the
+	// provider's wire format, emitted on the final (Done) chunk. When
+	// set, callers should persist it verbatim onto Message.RawAssistant
+	// instead of reconstructing — required so DeepSeek (OpenAI-compat
+	// thinking mode) sees the correct top-level `reasoning_content` on
+	// replay, which it does not auto-generate.
+	RawAssistant json.RawMessage
 }
 
 // StreamReader reads streaming chunks from an LLM response.

--- a/web/src/app/agents/[id]/models/page.tsx
+++ b/web/src/app/agents/[id]/models/page.tsx
@@ -55,16 +55,20 @@ import { useAgentName } from "@/hooks/use-agent-name";
 //   - Agent-scope `agents.defaults.model` overrides system default.
 // Empty override here => inherit system default.
 
+// `models` are common model IDs pre-filled into the form when the
+// preset is selected. The user can keep, edit, or remove them. Empty
+// list means "no sensible default" (custom / openrouter / ollama all
+// vary too much to ship a baked-in suggestion).
 const PROVIDER_PRESETS: Record<
   string,
-  { apiBase: string; apiType: string; authType: string }
+  { apiBase: string; apiType: string; authType: string; models: string[] }
 > = {
-  openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token" },
-  openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token" },
-  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key" },
-  deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token" },
-  ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token" },
-  custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token" },
+  openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token", models: ["gpt-5.5"] },
+  openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
+  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-sonnet-4.7"] },
+  deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token", models: ["deepseek-v4-pro", "deepseek-v4-flash"] },
+  ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
+  custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token", models: [] },
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -113,6 +117,14 @@ function emptyModel(): ModelEntry {
     contextWindow: 200000,
     maxTokens: 8192,
   };
+}
+
+// presetModelRows produces ready-to-edit ModelEntry rows for the IDs
+// declared on a preset, so the dialog opens with common models already
+// filled in instead of an empty list.
+function presetModelRows(preset: string): ModelEntry[] {
+  const ids = PROVIDER_PRESETS[preset]?.models || [];
+  return ids.map((id) => ({ ...emptyModel(), id, name: id }));
 }
 
 export default function AgentModelsPage() {
@@ -251,7 +263,7 @@ export default function AgentModelsPage() {
     setFormApi(PROVIDER_PRESETS["openai"].apiType);
     setFormAuthType(PROVIDER_PRESETS["openai"].authType);
     setFormApiKey("");
-    setFormModels([]);
+    setFormModels(presetModelRows("openai"));
     setModelTests({});
     setDialogOpen(true);
   };
@@ -287,6 +299,11 @@ export default function AgentModelsPage() {
     setDialogOpen(true);
   };
 
+  // Preset switching is treated as "give me a clean slate for this
+  // provider" — same way it overwrites apiBase/apiType, it also
+  // refreshes the models list with the preset's known model IDs. Edit
+  // mode (openEditDialog) loads stored models directly and never goes
+  // through this path, so user-saved configurations are never clobbered.
   const handlePresetChange = (preset: string) => {
     setFormPreset(preset);
     const cfg = PROVIDER_PRESETS[preset];
@@ -296,6 +313,7 @@ export default function AgentModelsPage() {
       setFormAuthType(cfg.authType);
     }
     setFormName(preset === "custom" ? "" : preset);
+    setFormModels(presetModelRows(preset));
     setModelTests({});
   };
 

--- a/web/src/app/agents/[id]/models/page.tsx
+++ b/web/src/app/agents/[id]/models/page.tsx
@@ -65,7 +65,7 @@ const PROVIDER_PRESETS: Record<
 > = {
   openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token", models: ["gpt-5.5"] },
   openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
-  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-sonnet-4.7"] },
+  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-opus-4.7", "claude-sonnet-4.7", "claude-haiku-4.5"] },
   deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token", models: ["deepseek-v4-pro", "deepseek-v4-flash"] },
   ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
   custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token", models: [] },

--- a/web/src/app/agents/[id]/models/page.tsx
+++ b/web/src/app/agents/[id]/models/page.tsx
@@ -62,6 +62,7 @@ const PROVIDER_PRESETS: Record<
   openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token" },
   openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token" },
   anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key" },
+  deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token" },
   ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token" },
   custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token" },
 };
@@ -70,6 +71,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   openai: "OpenAI",
   openrouter: "OpenRouter",
   anthropic: "Anthropic",
+  deepseek: "DeepSeek",
   ollama: "Ollama",
   custom: "Custom",
 };

--- a/web/src/app/models/page.tsx
+++ b/web/src/app/models/page.tsx
@@ -47,16 +47,20 @@ import {
 // Keep these maps in sync with onboard's ProviderStep so the two flows
 // look and behave identically — same preset set, same labels, same
 // SelectValue render-children pattern.
+// `models` are common model IDs pre-filled into the form when the
+// preset is selected. The user can keep, edit, or remove them. Empty
+// list means "no sensible default" (custom / openrouter / ollama all
+// vary too much to ship a baked-in suggestion).
 const PROVIDER_PRESETS: Record<
   string,
-  { apiBase: string; apiType: string; authType: string }
+  { apiBase: string; apiType: string; authType: string; models: string[] }
 > = {
-  openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token" },
-  openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token" },
-  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key" },
-  deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token" },
-  ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token" },
-  custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token" },
+  openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token", models: ["gpt-5.5"] },
+  openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
+  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-sonnet-4.7"] },
+  deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token", models: ["deepseek-v4-pro", "deepseek-v4-flash"] },
+  ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
+  custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token", models: [] },
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -104,6 +108,14 @@ function emptyModel(): ModelEntry {
     contextWindow: 200000,
     maxTokens: 8192,
   };
+}
+
+// presetModelRows produces ready-to-edit ModelEntry rows for the IDs
+// declared on a preset, so the dialog opens with common models already
+// filled in instead of an empty list.
+function presetModelRows(preset: string): ModelEntry[] {
+  const ids = PROVIDER_PRESETS[preset]?.models || [];
+  return ids.map((id) => ({ ...emptyModel(), id, name: id }));
 }
 
 export default function ModelsPage() {
@@ -250,7 +262,7 @@ export default function ModelsPage() {
     setFormApi(PROVIDER_PRESETS["openai"].apiType);
     setFormAuthType(PROVIDER_PRESETS["openai"].authType);
     setFormApiKey("");
-    setFormModels([]);
+    setFormModels(presetModelRows("openai"));
     setModelTests({});
     setDialogOpen(true);
   };
@@ -297,6 +309,11 @@ export default function ModelsPage() {
   // Match onboard's handleProviderChange: pre-fill api base + api type from
   // the preset, keep provider name editable (auto-set to preset key, but
   // user can rename — e.g. "openai" → "production"), reset test status.
+  // Preset switching is treated as "give me a clean slate for this
+  // provider" — same way it overwrites apiBase/apiType, it also
+  // refreshes the models list with the preset's known model IDs. Edit
+  // mode (openEditDialog) loads stored models directly and never goes
+  // through this path, so user-saved configurations are never clobbered.
   const handlePresetChange = (preset: string) => {
     setFormPreset(preset);
     const cfg = PROVIDER_PRESETS[preset];
@@ -306,6 +323,7 @@ export default function ModelsPage() {
       setFormAuthType(cfg.authType);
     }
     setFormName(preset === "custom" ? "" : preset);
+    setFormModels(presetModelRows(preset));
     setModelTests({});
   };
 

--- a/web/src/app/models/page.tsx
+++ b/web/src/app/models/page.tsx
@@ -54,6 +54,7 @@ const PROVIDER_PRESETS: Record<
   openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token" },
   openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token" },
   anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key" },
+  deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token" },
   ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token" },
   custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token" },
 };
@@ -62,6 +63,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   openai: "OpenAI",
   openrouter: "OpenRouter",
   anthropic: "Anthropic",
+  deepseek: "DeepSeek",
   ollama: "Ollama",
   custom: "Custom",
 };

--- a/web/src/app/models/page.tsx
+++ b/web/src/app/models/page.tsx
@@ -57,7 +57,7 @@ const PROVIDER_PRESETS: Record<
 > = {
   openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token", models: ["gpt-5.5"] },
   openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
-  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-sonnet-4.7"] },
+  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-opus-4.7", "claude-sonnet-4.7", "claude-haiku-4.5"] },
   deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token", models: ["deepseek-v4-pro", "deepseek-v4-flash"] },
   ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
   custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token", models: [] },

--- a/web/src/app/onboard/page.tsx
+++ b/web/src/app/onboard/page.tsx
@@ -94,7 +94,7 @@ const PROVIDERS: Record<
     apiBase: "https://api.anthropic.com",
     apiType: "anthropic-messages",
     authType: "api-key",
-    models: ["claude-sonnet-4.7"],
+    models: ["claude-opus-4.7", "claude-sonnet-4.7", "claude-haiku-4.5"],
   },
   deepseek: {
     apiBase: "https://api.deepseek.com",

--- a/web/src/app/onboard/page.tsx
+++ b/web/src/app/onboard/page.tsx
@@ -54,6 +54,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   openai: "OpenAI",
   openrouter: "OpenRouter",
   anthropic: "Anthropic",
+  deepseek: "DeepSeek",
   ollama: "Ollama",
   custom: "Custom",
 };
@@ -71,31 +72,43 @@ const AUTH_TYPE_LABELS: Record<string, string> = {
 // PROVIDERS holds the per-preset defaults the form pre-fills when the
 // user picks a provider from the dropdown. `models[0]` is shown as the
 // placeholder in the Default model input — the user types over it.
+// authType is synced too so switching from Anthropic (api-key) to a
+// Bearer-token provider doesn't leave the form on the wrong auth.
 const PROVIDERS: Record<
   string,
-  { apiBase: string; apiType: string; models: string[] }
+  { apiBase: string; apiType: string; authType: string; models: string[] }
 > = {
   openai: {
     apiBase: "https://api.openai.com/v1",
     apiType: "openai-chat",
+    authType: "bearer-token",
     models: ["gpt-5.5"],
   },
   openrouter: {
     apiBase: "https://openrouter.ai/api/v1",
     apiType: "openai-chat",
+    authType: "bearer-token",
     models: ["google/gemini-3-flash-preview"],
   },
   anthropic: {
     apiBase: "https://api.anthropic.com",
     apiType: "anthropic-messages",
+    authType: "api-key",
     models: ["claude-sonnet-4.7"],
+  },
+  deepseek: {
+    apiBase: "https://api.deepseek.com",
+    apiType: "openai-chat",
+    authType: "bearer-token",
+    models: ["deepseek-v4-pro"],
   },
   ollama: {
     apiBase: "http://localhost:11434/v1",
     apiType: "openai-chat",
+    authType: "bearer-token",
     models: ["qwen3.5:35b-a3b-int4"],
   },
-  custom: { apiBase: "", apiType: "openai-chat", models: [] },
+  custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token", models: [] },
 };
 
 export default function OnboardPage() {
@@ -158,6 +171,7 @@ export default function OnboardPage() {
     if (preset) {
       setApiBase(preset.apiBase);
       setApiType(preset.apiType);
+      setAuthType(preset.authType);
       if (preset.models[0]) setModel(preset.models[0]);
     }
     // Provider name auto-fills with the preset key — user can still
@@ -570,6 +584,7 @@ function ProviderStep(props: {
                 <SelectItem value="openai">OpenAI</SelectItem>
                 <SelectItem value="openrouter">OpenRouter</SelectItem>
                 <SelectItem value="anthropic">Anthropic</SelectItem>
+                <SelectItem value="deepseek">DeepSeek</SelectItem>
                 <SelectItem value="ollama">Ollama</SelectItem>
                 <SelectItem value="custom">Custom</SelectItem>
               </SelectContent>


### PR DESCRIPTION
## Summary

- Adds DeepSeek as a provider preset across the three frontend forms (onboarding wizard, system/user-level Models page, agent-level Models page) using the OpenAI-compatible path recommended by DeepSeek's official docs.
- Aligns the CLI `agentcli` `deepseek` preset base URL to match the official endpoint.
- Drive-by fix in onboarding's `handleProviderChange`: now also syncs `authType` from the preset (previously, switching from Anthropic → a Bearer-token provider would leave the form on `api-key`).

## Preset values (from DeepSeek's official docs)

| Field | Value |
|---|---|
| `apiBase` | `https://api.deepseek.com` |
| `apiType` | `openai-chat` |
| `authType` | `bearer-token` |
| Default model | `deepseek-v4-pro` |

No backend code changes — DeepSeek is OpenAI-compatible and goes through the existing OpenAI provider. `DEEPSEEK_API_KEY` was already wired into `internal/provider/credentials.go` `knownEnvVars`.

Default behavior matches the official guidance: thinking mode defaults to enabled and `reasoning_effort` defaults to `high` server-side, so agent reasoning quality is unaffected by us not explicitly forwarding those params.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/agentcli/...` passes
- [ ] `tsc --noEmit` clean on the three edited pages
- [ ] Onboarding wizard: pick DeepSeek → form auto-fills `https://api.deepseek.com`, `openai-chat`, `bearer-token`, `deepseek-v4-pro`; "Test connection" succeeds with a valid key
- [ ] Onboarding wizard: pick Anthropic → switch to DeepSeek, confirm `authType` flips from `api-key` back to `bearer-token`
- [ ] Models page (system) and agents/[id]/models page: DeepSeek shows in the preset dropdown and pre-fills the same values