### PR TITLE
feat(tools): add apply_patch for atomic multi-file edits

### DIFF
--- a/internal/agent/tools/apply_patch.go
+++ b/internal/agent/tools/apply_patch.go
@@ -1,0 +1,778 @@
+package tools
+
+// apply_patch — multi-file patch tool aligned with OpenAI Codex's DSL.
+//
+// One tool call adds, updates, deletes, or renames any number of files.
+// Two-phase execution: parse the envelope and compute every file's new
+// content in memory first; only when every hunk anchors successfully do
+// we flush writes/deletes. If any hunk fails, no file on disk changes —
+// the agent gets a clear error and can re-emit the patch.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/fastclaw-ai/fastclaw/internal/sandbox"
+)
+
+// -----------------------------------------------------------------------------
+// AST
+// -----------------------------------------------------------------------------
+
+type patchOpType int
+
+const (
+	opAdd patchOpType = iota
+	opUpdate
+	opDelete
+)
+
+type hunkLineKind int
+
+const (
+	lineContext hunkLineKind = iota
+	lineAdd
+	lineRemove
+)
+
+type hunkLine struct {
+	Kind hunkLineKind
+	Text string // without the leading +/-/space marker
+}
+
+type hunk struct {
+	Lines []hunkLine
+	IsEOF bool // hunk anchors to end of file
+}
+
+type patchOp struct {
+	Type    patchOpType
+	Path    string
+	MoveTo  string // Update only — empty when no rename
+	AddBody string // Add only — literal new file contents
+	Hunks   []hunk // Update only
+}
+
+type patch struct {
+	Ops []patchOp
+}
+
+const (
+	beginPatch   = "*** Begin Patch"
+	endPatch     = "*** End Patch"
+	addPrefix    = "*** Add File: "
+	updatePrefix = "*** Update File: "
+	deletePrefix = "*** Delete File: "
+	moveToPrefix = "*** Move to: "
+	endOfFile    = "*** End of File"
+	hunkSep      = "@@"
+)
+
+// -----------------------------------------------------------------------------
+// Parser
+// -----------------------------------------------------------------------------
+
+// parsePatch turns a patch envelope into a structured AST. Errors include
+// the offending line so the model can self-correct.
+func parsePatch(input string) (*patch, error) {
+	trimmed := strings.TrimSpace(input)
+	if !strings.HasPrefix(trimmed, beginPatch) {
+		return nil, fmt.Errorf("apply_patch: input must start with %q", beginPatch)
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
+	}
+
+	p := &patch{}
+	var (
+		currentOp   *patchOp
+		currentHunk *hunk
+		seenEnd     bool
+	)
+
+	flushOp := func() {
+		if currentOp == nil {
+			return
+		}
+		if currentHunk != nil {
+			currentOp.Hunks = append(currentOp.Hunks, *currentHunk)
+			currentHunk = nil
+		}
+		p.Ops = append(p.Ops, *currentOp)
+		currentOp = nil
+	}
+
+loop:
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
+
+		switch {
+		case strings.TrimSpace(line) == endPatch:
+			flushOp()
+			seenEnd = true
+			break loop
+
+		case strings.HasPrefix(line, addPrefix):
+			flushOp()
+			currentOp = &patchOp{Type: opAdd, Path: strings.TrimSpace(line[len(addPrefix):])}
+
+		case strings.HasPrefix(line, updatePrefix):
+			flushOp()
+			currentOp = &patchOp{Type: opUpdate, Path: strings.TrimSpace(line[len(updatePrefix):])}
+
+		case strings.HasPrefix(line, deletePrefix):
+			flushOp()
+			currentOp = &patchOp{Type: opDelete, Path: strings.TrimSpace(line[len(deletePrefix):])}
+
+		case strings.HasPrefix(line, moveToPrefix):
+			if currentOp == nil || currentOp.Type != opUpdate {
+				return nil, fmt.Errorf("apply_patch: %q outside an Update File block", strings.TrimSpace(line))
+			}
+			if currentOp.MoveTo != "" {
+				return nil, fmt.Errorf("apply_patch: duplicate Move to: for %q", currentOp.Path)
+			}
+			if len(currentOp.Hunks) > 0 || currentHunk != nil {
+				return nil, fmt.Errorf("apply_patch: %q must come before any hunk in Update File: %q",
+					strings.TrimSpace(line), currentOp.Path)
+			}
+			currentOp.MoveTo = strings.TrimSpace(line[len(moveToPrefix):])
+
+		case strings.TrimSpace(line) == endOfFile:
+			if currentOp == nil || currentOp.Type != opUpdate || currentHunk == nil {
+				return nil, fmt.Errorf("apply_patch: %q not inside an Update hunk", endOfFile)
+			}
+			currentHunk.IsEOF = true
+			currentOp.Hunks = append(currentOp.Hunks, *currentHunk)
+			currentHunk = nil
+
+		case strings.HasPrefix(line, hunkSep):
+			if currentOp == nil || currentOp.Type != opUpdate {
+				return nil, fmt.Errorf("apply_patch: %q outside an Update File block", hunkSep)
+			}
+			if currentHunk != nil {
+				currentOp.Hunks = append(currentOp.Hunks, *currentHunk)
+			}
+			currentHunk = &hunk{}
+
+		default:
+			if currentOp == nil {
+				if strings.TrimSpace(line) == "" {
+					continue
+				}
+				return nil, fmt.Errorf("apply_patch: unexpected line outside any file block: %q", line)
+			}
+			switch currentOp.Type {
+			case opAdd:
+				if !strings.HasPrefix(line, "+") {
+					return nil, fmt.Errorf("apply_patch: Add File body line must start with %q (got %q)", "+", line)
+				}
+				// Each + line contributes one line of file content. Append a
+				// trailing newline so the file ends in \n (POSIX convention,
+				// matches what most tools emit).
+				currentOp.AddBody += line[1:] + "\n"
+			case opDelete:
+				if strings.TrimSpace(line) != "" {
+					return nil, fmt.Errorf("apply_patch: Delete File expects no body (got %q)", line)
+				}
+			case opUpdate:
+				if currentHunk == nil {
+					currentHunk = &hunk{}
+				}
+				if line == "" {
+					// A bare blank line inside a hunk is treated as a blank
+					// context line. Strict Codex requires " " (space) but
+					// LLMs often drop the prefix; tolerating is harmless.
+					currentHunk.Lines = append(currentHunk.Lines, hunkLine{Kind: lineContext, Text: ""})
+					continue
+				}
+				switch line[0] {
+				case ' ':
+					currentHunk.Lines = append(currentHunk.Lines, hunkLine{Kind: lineContext, Text: line[1:]})
+				case '+':
+					currentHunk.Lines = append(currentHunk.Lines, hunkLine{Kind: lineAdd, Text: line[1:]})
+				case '-':
+					currentHunk.Lines = append(currentHunk.Lines, hunkLine{Kind: lineRemove, Text: line[1:]})
+				default:
+					return nil, fmt.Errorf("apply_patch: hunk line must start with ' ', '+', or '-' (got %q)", line)
+				}
+			}
+		}
+	}
+
+	if !seenEnd {
+		return nil, fmt.Errorf("apply_patch: missing %q sentinel", endPatch)
+	}
+	if len(p.Ops) == 0 {
+		return nil, errors.New("apply_patch: empty patch (no file operations)")
+	}
+	return p, nil
+}
+
+// -----------------------------------------------------------------------------
+// Applier (pure functions)
+// -----------------------------------------------------------------------------
+
+// applyHunks applies all hunks of an Update to oldContent and returns the
+// new content. Trailing-newline state is preserved. The first hunk that
+// fails to anchor produces an error mentioning its expected lines.
+func applyHunks(path, oldContent string, hunks []hunk) (string, error) {
+	hadTrailingNL := strings.HasSuffix(oldContent, "\n")
+	var lines []string
+	if oldContent != "" {
+		lines = strings.Split(strings.TrimSuffix(oldContent, "\n"), "\n")
+	}
+
+	// searchFrom advances past each applied hunk so successive hunks can't
+	// re-match into already-rewritten regions.
+	searchFrom := 0
+	for hi, h := range hunks {
+		pattern := patternLines(h)
+		// A pure-add hunk (only '+' lines, no context, no remove) has an
+		// empty pattern. Per the Codex spec these are anchored to the end
+		// of the current file — and crucially, they do NOT advance the
+		// search cursor, so a later anchored hunk can still match earlier
+		// in the file.
+		anchorEOF := h.IsEOF || len(pattern) == 0
+
+		idx := findHunkAnchor(lines, pattern, anchorEOF, searchFrom)
+		if idx < 0 {
+			return "", fmt.Errorf(
+				"apply_patch: hunk #%d in %s did not match — re-read the file and emit a fresh patch.\nExpected lines:\n%s",
+				hi+1, path, strings.Join(pattern, "\n"))
+		}
+
+		// Build the replacement using the file's *actual* text for context
+		// lines (so a successful fuzzy / Unicode-normalised match
+		// preserves the file's whitespace and original glyphs instead of
+		// overwriting with the patch's ASCII version). Equivalent to
+		// replacementLines(h) when the match was exact.
+		replacement := buildReplacement(h, lines, idx)
+
+		next := make([]string, 0, len(lines)-len(pattern)+len(replacement))
+		next = append(next, lines[:idx]...)
+		next = append(next, replacement...)
+		next = append(next, lines[idx+len(pattern):]...)
+		lines = next
+		// Only advance the cursor for anchored hunks. EOF-anchored and
+		// pure-add hunks tack onto the end of the file and must not
+		// constrain where subsequent anchored hunks search from.
+		if !anchorEOF {
+			searchFrom = idx + len(replacement)
+		}
+	}
+
+	out := strings.Join(lines, "\n")
+	if hadTrailingNL && out != "" {
+		out += "\n"
+	}
+	return out, nil
+}
+
+// patternLines extracts the pattern that must be matched in the file:
+// context + remove lines, in order.
+func patternLines(h hunk) []string {
+	out := make([]string, 0, len(h.Lines))
+	for _, l := range h.Lines {
+		if l.Kind == lineContext || l.Kind == lineRemove {
+			out = append(out, l.Text)
+		}
+	}
+	return out
+}
+
+// buildReplacement assembles the lines that should replace the matched
+// region. Context lines are sourced from the file (preserves the file's
+// own whitespace when fuzzy matching squashed differences); add lines come
+// from the hunk; remove lines are dropped. fileLines[startIdx:] must
+// already align with the hunk's pattern.
+func buildReplacement(h hunk, fileLines []string, startIdx int) []string {
+	out := make([]string, 0, len(h.Lines))
+	off := 0 // cursor into the matched region in fileLines
+	for _, l := range h.Lines {
+		switch l.Kind {
+		case lineContext:
+			out = append(out, fileLines[startIdx+off])
+			off++
+		case lineRemove:
+			off++
+		case lineAdd:
+			out = append(out, l.Text)
+		}
+	}
+	return out
+}
+
+// seekSequence returns the smallest index ≥ start where pattern aligns
+// with haystack, or -1. An empty pattern is allowed and anchors at start
+// (used by pure-add hunks at the top of a file or with EOF anchor).
+func seekSequence(haystack, pattern []string, start int) int {
+	if len(pattern) == 0 {
+		if start <= len(haystack) {
+			return start
+		}
+		return -1
+	}
+	for i := start; i+len(pattern) <= len(haystack); i++ {
+		if linesEqual(haystack, i, pattern) {
+			return i
+		}
+	}
+	return -1
+}
+
+func linesEqual(haystack []string, start int, pattern []string) bool {
+	if start < 0 || start+len(pattern) > len(haystack) {
+		return false
+	}
+	for j, p := range pattern {
+		if haystack[start+j] != p {
+			return false
+		}
+	}
+	return true
+}
+
+// findHunkAnchor locates a hunk's pattern in `lines`, trying progressively
+// more lenient transforms: identity → rstrip → full trim → Unicode
+// normalisation. EOF-anchored hunks prefer end-of-file alignment but fall
+// back to a forward scan from searchFrom (matches Codex's seek_sequence).
+// Returns -1 when no transform finds a match.
+//
+// Transforms are line-by-line and don't change the line count, so the
+// returned index is valid against the original `lines` array. Callers
+// pass that index to buildReplacement so context lines are sourced from
+// the file's actual (un-normalised) text — fuzzy matching tolerates
+// glyph differences without rewriting them.
+func findHunkAnchor(lines, pattern []string, anchorEOF bool, searchFrom int) int {
+	transforms := []func(string) string{
+		nil,               // identity
+		rstripWS,          // trailing whitespace tolerance
+		strings.TrimSpace, // full whitespace tolerance
+		normalizeForFuzzy, // Unicode dashes/quotes/spaces → ASCII
+	}
+	for _, t := range transforms {
+		var tl, tp []string
+		if t == nil {
+			tl, tp = lines, pattern
+		} else {
+			tl = mapLines(lines, t)
+			tp = mapLines(pattern, t)
+		}
+		if anchorEOF {
+			start := len(tl) - len(tp)
+			if start >= 0 && linesEqual(tl, start, tp) {
+				return start
+			}
+			// EOF position miss → forward scan, matching Codex behavior.
+		}
+		if idx := seekSequence(tl, tp, searchFrom); idx >= 0 {
+			return idx
+		}
+	}
+	return -1
+}
+
+func mapLines(in []string, f func(string) string) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = f(s)
+	}
+	return out
+}
+
+func rstripWS(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+// normalizeForFuzzy maps typographic glyphs that LLMs (or auto-correct
+// editors) frequently substitute for their ASCII counterparts. After
+// mapping, the line is also fully trimmed so this level subsumes the
+// trim level when the difference happens to be both whitespace and
+// glyphs. Mirrors the Unicode mapping in Codex's seek_sequence.
+func normalizeForFuzzy(s string) string {
+	if isASCII(s) {
+		return strings.TrimSpace(s)
+	}
+	var sb strings.Builder
+	sb.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		// Dashes & hyphens (en/em/figure/non-breaking/minus/small/fullwidth).
+		case '‐', '‑', '‒', '–', '—', '―',
+			'−', '﹘', '﹣', '－':
+			sb.WriteByte('-')
+		// Single quotes / apostrophes (left, right, low, high-reversed).
+		case '‘', '’', '‚', '‛':
+			sb.WriteByte('\'')
+		// Double quotes (left, right, low, high-reversed).
+		case '“', '”', '„', '‟':
+			sb.WriteByte('"')
+		// Various spaces (NBSP, figure, punctuation, thin, hair, narrow
+		// no-break, medium math, ideographic).
+		case ' ', ' ', ' ', ' ', ' ',
+			' ', ' ', '　':
+			sb.WriteByte(' ')
+		default:
+			sb.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+// -----------------------------------------------------------------------------
+// Tool description / schema
+// -----------------------------------------------------------------------------
+
+const applyPatchDescription = `Apply a multi-file patch in OpenAI Codex DSL format. Use this instead of chained edit_file/write_file calls when a change touches ≥2 files or ≥2 hunks — one tool call performs every edit atomically (parse + hunk matching happens for every file before any write; if any hunk fails to anchor, NO file is modified).
+
+Format:
+
+  *** Begin Patch
+  *** Add File: path/new.go
+  +line one
+  +line two
+  *** Update File: path/old.go
+  *** Move to: path/renamed.go    (optional rename, before any hunk)
+  @@
+   keep_this_line
+  -drop_this
+  +add_this
+   keep_this_too
+  @@
+   second_anchor
+  -bye
+  +hi
+  *** End of File                  (optional; pin the previous hunk to file end)
+  *** Delete File: path/legacy.go
+  *** End Patch
+
+Rules:
+- Hunks anchor on context lines (' ' prefix) plus '-' lines that must literally match the file. Provide enough context to make the location unambiguous; matching is in-order, first match wins.
+- Pure-add hunks (only '+' lines) only work with *** End of File or at the very top of a file.
+- Identity files (SOUL.md, IDENTITY.md, MEMORY.md, AGENTS.md, BOOTSTRAP.md, TOOLS.md, HEARTBEAT.md, USER.md, agent.json) accept Add and Update but NOT Delete or Move.
+- Path resolution matches read_file/write_file: workspace-relative paths go to the workspace store, identity-file basenames go to the system store, absolute paths go to disk.`
+
+var applyPatchSchema = map[string]interface{}{
+	"type": "object",
+	"properties": map[string]interface{}{
+		"input": map[string]interface{}{
+			"type":        "string",
+			"description": "The complete patch envelope from `*** Begin Patch` to `*** End Patch`.",
+		},
+	},
+	"required": []string{"input"},
+}
+
+type applyPatchArgs struct {
+	Input string `json:"input"`
+}
+
+// -----------------------------------------------------------------------------
+// Backend helpers — host filesystem mode (mirrors registerFile's routing)
+// -----------------------------------------------------------------------------
+
+func (r *Registry) readForPatch(ctx context.Context, path string) (string, error) {
+	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
+		rc, err := r.workspaceStore.Get(ctx, r.agentID, r.sessionID, path)
+		if err != nil {
+			return "", fmt.Errorf("workspace get: %w", err)
+		}
+		defer rc.Close()
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			return "", fmt.Errorf("workspace read: %w", err)
+		}
+		return string(data), nil
+	}
+	if r.systemFileStore != nil && r.agentID != "" && basenameIsSystemFile(path) {
+		name := filepath.Base(filepath.Clean(path))
+		if data, err := r.systemFileStore.GetWorkspaceFile(ctx, r.agentID, r.systemFileUserID(name), name); err == nil {
+			return string(data), nil
+		}
+		if r.systemRoot != "" {
+			if data, err := os.ReadFile(filepath.Join(r.systemRoot, name)); err == nil {
+				return string(data), nil
+			}
+		}
+		return "", nil
+	}
+	root := r.rootForPath(path)
+	full, err := resolvePathSandboxed(root, r.effectiveSandboxRoot(root), path)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(full)
+	if err != nil {
+		if os.IsNotExist(err) && isSingleSegmentSystemFile(path) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	return string(data), nil
+}
+
+func (r *Registry) writeForPatch(ctx context.Context, path, content string) error {
+	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
+		return r.workspaceStore.Put(ctx, r.agentID, r.sessionID, path,
+			strings.NewReader(content), int64(len(content)), "")
+	}
+	if r.systemFileStore != nil && r.agentID != "" && isSingleSegmentSystemFile(path) {
+		name := filepath.Clean(path)
+		if err := r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(name), name, []byte(content)); err != nil {
+			return err
+		}
+		// Mirror to disk so this pod's in-process readers (context builder,
+		// skills loader) see the new content immediately. Same invariant as
+		// makeWriteFile.
+		if r.systemRoot != "" {
+			disk := filepath.Join(r.systemRoot, name)
+			_ = os.MkdirAll(filepath.Dir(disk), 0o755)
+			_ = os.WriteFile(disk, []byte(content), 0o644)
+		}
+		return nil
+	}
+	root := r.rootForPath(path)
+	full, err := resolvePathSandboxed(root, r.effectiveSandboxRoot(root), path)
+	if err != nil {
+		return err
+	}
+	if isGlobalSkillsPath(full) {
+		return errGlobalSkillsDirWrite
+	}
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		return fmt.Errorf("mkdir for %s: %w", path, err)
+	}
+	return os.WriteFile(full, []byte(content), 0o644)
+}
+
+func (r *Registry) deleteForPatch(ctx context.Context, path string) error {
+	// Identity files refuse Delete: systemFileStore has no Delete API and
+	// these files have a fixed slot — clearing them via Delete would
+	// corrupt the agent. Use Update File with empty target content
+	// instead.
+	if isSingleSegmentSystemFile(path) {
+		return fmt.Errorf("apply_patch: refusing to delete identity file %q (use Update File with empty content instead)", path)
+	}
+	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
+		return r.workspaceStore.Delete(ctx, r.agentID, r.sessionID, path)
+	}
+	root := r.rootForPath(path)
+	full, err := resolvePathSandboxed(root, r.effectiveSandboxRoot(root), path)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(full); err != nil {
+		return fmt.Errorf("delete %s: %w", path, err)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Backend helpers — sandbox mode (mirrors registerSandboxedFile's routing)
+// -----------------------------------------------------------------------------
+
+func (r *Registry) readForPatchSandbox(ctx context.Context, ex sandbox.Executor, path string) (string, error) {
+	if r.systemFileStore != nil && r.agentID != "" && basenameIsSystemFile(path) {
+		name := filepath.Base(filepath.Clean(path))
+		if data, err := r.systemFileStore.GetWorkspaceFile(ctx, r.agentID, r.systemFileUserID(name), name); err == nil {
+			return string(data), nil
+		}
+		return "", nil
+	}
+	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
+		rc, err := r.workspaceStore.Get(ctx, r.agentID, r.sessionID, path)
+		if err == nil {
+			defer rc.Close()
+			data, readErr := io.ReadAll(rc)
+			if readErr == nil {
+				return string(data), nil
+			}
+		}
+		// Fall through to executor on store miss / read error.
+	}
+	return ex.ReadFile(ctx, path)
+}
+
+func (r *Registry) writeForPatchSandbox(ctx context.Context, ex sandbox.Executor, path, content string) error {
+	if r.systemFileStore != nil && r.agentID != "" && isSingleSegmentSystemFile(path) {
+		name := filepath.Clean(path)
+		return r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(name), name, []byte(content))
+	}
+	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
+		return r.workspaceStore.Put(ctx, r.agentID, r.sessionID, path,
+			strings.NewReader(content), int64(len(content)), "")
+	}
+	_, err := ex.WriteFile(ctx, path, content)
+	return err
+}
+
+func (r *Registry) deleteForPatchSandbox(ctx context.Context, ex sandbox.Executor, path string) error {
+	if isSingleSegmentSystemFile(path) {
+		return fmt.Errorf("apply_patch: refusing to delete identity file %q (use Update File with empty content instead)", path)
+	}
+	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
+		return r.workspaceStore.Delete(ctx, r.agentID, r.sessionID, path)
+	}
+	// Sandbox executor exposes no Delete API; fall back to `rm`. Single-quote
+	// the path and escape embedded single quotes so a pathological filename
+	// can't inject shell.
+	q := "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+	_, err := ex.Exec(ctx, "rm -f -- "+q, 0)
+	return err
+}
+
+// -----------------------------------------------------------------------------
+// Tool registration
+// -----------------------------------------------------------------------------
+
+func registerApplyPatch(r *Registry) {
+	r.Register("apply_patch", applyPatchDescription, applyPatchSchema, func(ctx context.Context, raw json.RawMessage) (string, error) {
+		var args applyPatchArgs
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", fmt.Errorf("apply_patch: parse args: %w", err)
+		}
+		return runApplyPatch(ctx, args.Input,
+			func(ctx context.Context, p string) (string, error) { return r.readForPatch(ctx, p) },
+			func(ctx context.Context, p, c string) error { return r.writeForPatch(ctx, p, c) },
+			func(ctx context.Context, p string) error { return r.deleteForPatch(ctx, p) },
+		)
+	})
+}
+
+func registerSandboxedApplyPatch(r *Registry, ex sandbox.Executor) {
+	r.Register("apply_patch", applyPatchDescription, applyPatchSchema, func(ctx context.Context, raw json.RawMessage) (string, error) {
+		var args applyPatchArgs
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", fmt.Errorf("apply_patch: parse args: %w", err)
+		}
+		out, err := runApplyPatch(ctx, args.Input,
+			func(ctx context.Context, p string) (string, error) { return r.readForPatchSandbox(ctx, ex, p) },
+			func(ctx context.Context, p, c string) error { return r.writeForPatchSandbox(ctx, ex, p, c) },
+			func(ctx context.Context, p string) error { return r.deleteForPatchSandbox(ctx, ex, p) },
+		)
+		if err != nil {
+			return "", err
+		}
+		return MetaSandboxPrefix + out, nil
+	})
+}
+
+// runApplyPatch is the storage-agnostic engine. Phase 1: parse and compute
+// every file's new content / planned deletes in memory. Phase 2: only after
+// all hunks anchor successfully, flush writes (then deletes — Move source
+// goes last so the destination is in place before its old slot is freed).
+//
+// Phase-2 errors leak partial state (one file written, the next failed);
+// the agent can re-emit the patch after fixing the underlying cause
+// (permissions, disk full, ...). Cross-backend transactional rollback is
+// not attempted — it would require snapshotting every touched store.
+func runApplyPatch(
+	ctx context.Context,
+	input string,
+	read func(context.Context, string) (string, error),
+	write func(context.Context, string, string) error,
+	del func(context.Context, string) error,
+) (string, error) {
+	p, err := parsePatch(input)
+	if err != nil {
+		return "", err
+	}
+
+	type plannedWrite struct{ path, content string }
+	var (
+		writes  []plannedWrite
+		deletes []string
+	)
+
+	for _, op := range p.Ops {
+		switch op.Type {
+		case opAdd:
+			if op.Path == "" {
+				return "", errors.New("apply_patch: Add File requires a non-empty path")
+			}
+			writes = append(writes, plannedWrite{op.Path, op.AddBody})
+
+		case opDelete:
+			if op.Path == "" {
+				return "", errors.New("apply_patch: Delete File requires a non-empty path")
+			}
+			// Identity files have a fixed slot in the systemFileStore and
+			// no Delete API; allowing Delete here would corrupt the agent.
+			// Refuse at the engine level so backend del() doesn't have to
+			// repeat the rule (defense-in-depth still does in
+			// deleteForPatch / deleteForPatchSandbox).
+			if isSingleSegmentSystemFile(op.Path) {
+				return "", fmt.Errorf("apply_patch: refusing to delete identity file %q (use Update File with empty content instead)", op.Path)
+			}
+			deletes = append(deletes, op.Path)
+
+		case opUpdate:
+			if op.Path == "" {
+				return "", errors.New("apply_patch: Update File requires a non-empty path")
+			}
+			if op.MoveTo != "" && (isSingleSegmentSystemFile(op.Path) || isSingleSegmentSystemFile(op.MoveTo)) {
+				return "", fmt.Errorf("apply_patch: refusing to Move identity file %q → %q", op.Path, op.MoveTo)
+			}
+			old, err := read(ctx, op.Path)
+			if err != nil {
+				return "", fmt.Errorf("apply_patch: read %s: %w", op.Path, err)
+			}
+			updated, err := applyHunks(op.Path, old, op.Hunks)
+			if err != nil {
+				return "", err
+			}
+			target := op.Path
+			if op.MoveTo != "" && op.MoveTo != op.Path {
+				target = op.MoveTo
+				deletes = append(deletes, op.Path)
+			}
+			writes = append(writes, plannedWrite{target, updated})
+		}
+	}
+
+	for _, w := range writes {
+		if err := write(ctx, w.path, w.content); err != nil {
+			return "", fmt.Errorf("apply_patch: write %s: %w", w.path, err)
+		}
+	}
+	for _, d := range deletes {
+		if err := del(ctx, d); err != nil {
+			return "", fmt.Errorf("apply_patch: delete %s: %w", d, err)
+		}
+	}
+
+	var sb strings.Builder
+	for _, op := range p.Ops {
+		switch op.Type {
+		case opAdd:
+			fmt.Fprintf(&sb, "A %s\n", op.Path)
+		case opDelete:
+			fmt.Fprintf(&sb, "D %s\n", op.Path)
+		case opUpdate:
+			if op.MoveTo != "" && op.MoveTo != op.Path {
+				fmt.Fprintf(&sb, "M %s -> %s (%d hunk(s))\n", op.Path, op.MoveTo, len(op.Hunks))
+			} else {
+				fmt.Fprintf(&sb, "U %s (%d hunk(s))\n", op.Path, len(op.Hunks))
+			}
+		}
+	}
+	return sb.String(), nil
+}

--- a/internal/agent/tools/apply_patch_test.go
+++ b/internal/agent/tools/apply_patch_test.go
@@ -1,0 +1,763 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Pure-function tests: parser + applier. Backend integration (workspace
+// store / system file store / sandbox executor) is exercised through the
+// running agent — same scope split as file_test.go's TestApplyEdit.
+
+func TestParsePatch_Basics(t *testing.T) {
+	in := `*** Begin Patch
+*** Add File: foo.txt
++hello
++world
+*** Update File: bar.txt
+@@
+ ctx
+-old
++new
+*** Delete File: legacy.txt
+*** End Patch`
+
+	p, err := parsePatch(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got, want := len(p.Ops), 3; got != want {
+		t.Fatalf("ops count: got %d want %d", got, want)
+	}
+
+	add := p.Ops[0]
+	if add.Type != opAdd || add.Path != "foo.txt" || add.AddBody != "hello\nworld\n" {
+		t.Errorf("add: %+v", add)
+	}
+
+	upd := p.Ops[1]
+	if upd.Type != opUpdate || upd.Path != "bar.txt" || len(upd.Hunks) != 1 {
+		t.Errorf("update: %+v", upd)
+	}
+	want := []hunkLine{
+		{Kind: lineContext, Text: "ctx"},
+		{Kind: lineRemove, Text: "old"},
+		{Kind: lineAdd, Text: "new"},
+	}
+	if got := upd.Hunks[0].Lines; !linesEq(got, want) {
+		t.Errorf("hunk lines: got %+v want %+v", got, want)
+	}
+
+	del := p.Ops[2]
+	if del.Type != opDelete || del.Path != "legacy.txt" {
+		t.Errorf("delete: %+v", del)
+	}
+}
+
+func TestParsePatch_MoveAndEOF(t *testing.T) {
+	in := `*** Begin Patch
+*** Update File: a.go
+*** Move to: b.go
+@@
+ keep
+-bye
++hi
+*** End of File
+*** End Patch`
+	p, err := parsePatch(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	op := p.Ops[0]
+	if op.MoveTo != "b.go" {
+		t.Errorf("move target: %q", op.MoveTo)
+	}
+	if !op.Hunks[0].IsEOF {
+		t.Errorf("hunk should be EOF-anchored")
+	}
+}
+
+func TestParsePatch_MultipleHunks(t *testing.T) {
+	in := `*** Begin Patch
+*** Update File: x.txt
+@@
+ a
+-b
++B
+@@
+ c
+-d
++D
+*** End Patch`
+	p, err := parsePatch(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := len(p.Ops[0].Hunks); got != 2 {
+		t.Errorf("hunks: %d", got)
+	}
+}
+
+func TestParsePatch_ToleratesBlanks(t *testing.T) {
+	// Leading whitespace, blank lines between Begin Patch and first op,
+	// trailing newline. All common LLM behaviors.
+	in := "  \n\n*** Begin Patch\n\n*** Add File: f\n+x\n*** End Patch\n"
+	p, err := parsePatch(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if p.Ops[0].AddBody != "x\n" {
+		t.Errorf("body: %q", p.Ops[0].AddBody)
+	}
+}
+
+func TestParsePatch_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantSub string
+	}{
+		{
+			name:    "missing begin",
+			input:   "*** Add File: f\n+x\n*** End Patch",
+			wantSub: "Begin Patch",
+		},
+		{
+			name:    "missing end",
+			input:   "*** Begin Patch\n*** Add File: f\n+x\n",
+			wantSub: "End Patch",
+		},
+		{
+			name:    "move outside update",
+			input:   "*** Begin Patch\n*** Move to: y\n*** End Patch",
+			wantSub: "outside an Update File",
+		},
+		{
+			name:    "hunk outside update",
+			input:   "*** Begin Patch\n@@\n+x\n*** End Patch",
+			wantSub: "outside an Update File",
+		},
+		{
+			name:    "EOF outside hunk",
+			input:   "*** Begin Patch\n*** Update File: f\n*** End of File\n*** End Patch",
+			wantSub: "not inside an Update hunk",
+		},
+		{
+			name:    "Add body without plus",
+			input:   "*** Begin Patch\n*** Add File: f\nno plus\n*** End Patch",
+			wantSub: "must start with",
+		},
+		{
+			name:    "bad hunk prefix",
+			input:   "*** Begin Patch\n*** Update File: f\n@@\n!bad\n*** End Patch",
+			wantSub: "must start with",
+		},
+		{
+			name:    "empty patch",
+			input:   "*** Begin Patch\n*** End Patch",
+			wantSub: "empty patch",
+		},
+		{
+			name:    "move after hunk",
+			input:   "*** Begin Patch\n*** Update File: f\n@@\n a\n*** Move to: g\n*** End Patch",
+			wantSub: "must come before any hunk",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parsePatch(tc.input)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestApplyHunks_SingleHunk(t *testing.T) {
+	old := "alpha\nbeta\ngamma\n"
+	hunks := []hunk{{
+		Lines: []hunkLine{
+			{Kind: lineContext, Text: "alpha"},
+			{Kind: lineRemove, Text: "beta"},
+			{Kind: lineAdd, Text: "BETA"},
+			{Kind: lineContext, Text: "gamma"},
+		},
+	}}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if want := "alpha\nBETA\ngamma\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestApplyHunks_MultipleHunksAdvanceAnchor(t *testing.T) {
+	// Two hunks anchored on the same context line; the applier must advance
+	// past the first match so the second hunk lands on the second occurrence.
+	old := "x\nctx\na\nctx\nb\n"
+	hunks := []hunk{
+		{Lines: []hunkLine{
+			{Kind: lineContext, Text: "ctx"},
+			{Kind: lineRemove, Text: "a"},
+			{Kind: lineAdd, Text: "A"},
+		}},
+		{Lines: []hunkLine{
+			{Kind: lineContext, Text: "ctx"},
+			{Kind: lineRemove, Text: "b"},
+			{Kind: lineAdd, Text: "B"},
+		}},
+	}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if want := "x\nctx\nA\nctx\nB\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestApplyHunks_EOFAppend(t *testing.T) {
+	old := "a\nb\nc\n"
+	hunks := []hunk{{
+		IsEOF: true,
+		Lines: []hunkLine{
+			{Kind: lineContext, Text: "c"},
+			{Kind: lineAdd, Text: "d"},
+		},
+	}}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if want := "a\nb\nc\nd\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestApplyHunks_FuzzyTrailingWS(t *testing.T) {
+	// File has trailing spaces the patch context did not.
+	old := "alpha   \nbeta\n"
+	hunks := []hunk{{
+		Lines: []hunkLine{
+			{Kind: lineContext, Text: "alpha"},
+			{Kind: lineRemove, Text: "beta"},
+			{Kind: lineAdd, Text: "BETA"},
+		},
+	}}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// Replacement uses the trimmed-pattern position, so the original
+	// trailing-space line is preserved verbatim.
+	if want := "alpha   \nBETA\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestApplyHunks_NoMatch(t *testing.T) {
+	old := "alpha\nbeta\n"
+	hunks := []hunk{{
+		Lines: []hunkLine{
+			{Kind: lineContext, Text: "missing"},
+			{Kind: lineAdd, Text: "x"},
+		},
+	}}
+	_, err := applyHunks("foo.go", old, hunks)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "did not match") || !strings.Contains(err.Error(), "foo.go") {
+		t.Errorf("unhelpful error: %v", err)
+	}
+}
+
+func TestApplyHunks_PreservesNoTrailingNewline(t *testing.T) {
+	old := "a\nb" // no trailing \n
+	hunks := []hunk{{
+		Lines: []hunkLine{
+			{Kind: lineContext, Text: "a"},
+			{Kind: lineRemove, Text: "b"},
+			{Kind: lineAdd, Text: "B"},
+		},
+	}}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if want := "a\nB"; got != want {
+		t.Errorf("got %q want %q (trailing-newline state must be preserved)", got, want)
+	}
+}
+
+// Borrowed from openai/codex codex-rs/apply-patch:
+// test_pure_addition_chunk_followed_by_removal. A pure-add hunk (no
+// context, no remove) is implicitly EOF-anchored and must not consume
+// the search cursor — otherwise the following anchored hunk can no
+// longer find its match at the head of the file.
+func TestApplyHunks_PureAddBeforeAnchoredHunk(t *testing.T) {
+	old := "line1\nline2\nline3\n"
+	hunks := []hunk{
+		{Lines: []hunkLine{
+			{Kind: lineAdd, Text: "after-context"},
+			{Kind: lineAdd, Text: "second-line"},
+		}},
+		{Lines: []hunkLine{
+			{Kind: lineContext, Text: "line1"},
+			{Kind: lineRemove, Text: "line2"},
+			{Kind: lineRemove, Text: "line3"},
+			{Kind: lineAdd, Text: "line2-replacement"},
+		}},
+	}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if want := "line1\nline2-replacement\nafter-context\nsecond-line\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// Borrowed from openai/codex test_update_file_hunk_interleaved_changes:
+// three hunks on disjoint regions, the last one EOF-anchored. Stresses
+// search-cursor advancement and EOF interplay.
+func TestApplyHunks_Interleaved(t *testing.T) {
+	old := "a\nb\nc\nd\ne\nf\n"
+	hunks := []hunk{
+		{Lines: []hunkLine{
+			{Kind: lineContext, Text: "a"},
+			{Kind: lineRemove, Text: "b"},
+			{Kind: lineAdd, Text: "B"},
+		}},
+		{Lines: []hunkLine{
+			{Kind: lineContext, Text: "c"},
+			{Kind: lineContext, Text: "d"},
+			{Kind: lineRemove, Text: "e"},
+			{Kind: lineAdd, Text: "E"},
+		}},
+		{IsEOF: true, Lines: []hunkLine{
+			{Kind: lineContext, Text: "f"},
+			{Kind: lineAdd, Text: "g"},
+		}},
+	}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if want := "a\nB\nc\nd\nE\nf\ng\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// Borrowed from openai/codex test_update_line_with_unicode_dash:
+// the file's line uses U+2013 (en-dash) and U+2011 (non-breaking
+// hyphen) where the patch wrote ASCII '-'. Codex's third-level fuzzy
+// matcher normalises typographic glyphs before comparing, so the patch
+// still anchors. We follow the same rule.
+func TestApplyHunks_UnicodeDash(t *testing.T) {
+	old := "import asyncio  # local import – avoids top‑level dep\n"
+	hunks := []hunk{{Lines: []hunkLine{
+		{Kind: lineRemove, Text: "import asyncio  # local import - avoids top-level dep"},
+		{Kind: lineAdd, Text: "import asyncio  # HELLO"},
+	}}}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if want := "import asyncio  # HELLO\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// Full trim() fuzzy level: file has leading indentation that the patch
+// context dropped (or vice versa). rstrip alone wouldn't catch this.
+func TestApplyHunks_LeadingWhitespaceFuzzy(t *testing.T) {
+	old := "    func foo() {\n    return 1\n    }\n"
+	// Patch context is un-indented (model normalized whitespace away).
+	hunks := []hunk{{Lines: []hunkLine{
+		{Kind: lineContext, Text: "func foo() {"},
+		{Kind: lineRemove, Text: "return 1"},
+		{Kind: lineAdd, Text: "return 2"},
+		{Kind: lineContext, Text: "}"},
+	}}}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// Context lines come from the file (preserved indentation); only
+	// the add line uses the patch's text. Result: file is reindented
+	// where the patch contributed a new line, but context is intact.
+	if want := "    func foo() {\nreturn 2\n    }\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// EOF hunk's end-of-file position fails to match — Codex falls back to
+// a full-file forward scan. We follow.
+func TestApplyHunks_EOFFallbackToForwardScan(t *testing.T) {
+	// File: anchor is at the start, but hunk is mistakenly tagged EOF.
+	// Codex (and us) recover by scanning from searchFrom.
+	old := "anchor\nbody\ntail\n"
+	hunks := []hunk{{
+		IsEOF: true,
+		Lines: []hunkLine{
+			{Kind: lineContext, Text: "anchor"},
+			{Kind: lineAdd, Text: "inserted"},
+		},
+	}}
+	got, err := applyHunks("test", old, hunks)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if want := "anchor\ninserted\nbody\ntail\n"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// Borrowed from openai/codex test_update_file_hunk_can_move_file:
+// Update + Move to: in one op. Source must be deleted, destination has
+// the patched content. Verified at the runApplyPatch level (Move is
+// implemented as write-target + delete-source).
+func TestRunApplyPatch_Move(t *testing.T) {
+	files := map[string]string{"src.txt": "line\n"}
+	read := func(_ context.Context, p string) (string, error) { return files[p], nil }
+	write := func(_ context.Context, p, c string) error { files[p] = c; return nil }
+	del := func(_ context.Context, p string) error { delete(files, p); return nil }
+
+	patch := `*** Begin Patch
+*** Update File: src.txt
+*** Move to: dst.txt
+@@
+-line
++line2
+*** End Patch`
+	if _, err := runApplyPatch(context.Background(), patch, read, write, del); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, ok := files["src.txt"]; ok {
+		t.Errorf("src.txt should be removed after move")
+	}
+	if files["dst.txt"] != "line2\n" {
+		t.Errorf("dst.txt: %q", files["dst.txt"])
+	}
+}
+
+func TestRunApplyPatch_HappyPath(t *testing.T) {
+	// In-memory backend simulating fs.
+	files := map[string]string{
+		"old.txt":    "alpha\nbeta\ngamma\n",
+		"existing.x": "keep\n",
+	}
+	read := func(_ context.Context, p string) (string, error) {
+		s, ok := files[p]
+		if !ok {
+			return "", nil
+		}
+		return s, nil
+	}
+	write := func(_ context.Context, p, c string) error {
+		files[p] = c
+		return nil
+	}
+	del := func(_ context.Context, p string) error {
+		delete(files, p)
+		return nil
+	}
+
+	patch := `*** Begin Patch
+*** Add File: new.txt
++hello
+*** Update File: old.txt
+@@
+ alpha
+-beta
++BETA
+ gamma
+*** Delete File: existing.x
+*** End Patch`
+
+	out, err := runApplyPatch(context.Background(), patch, read, write, del)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !strings.Contains(out, "A new.txt") || !strings.Contains(out, "U old.txt") || !strings.Contains(out, "D existing.x") {
+		t.Errorf("summary missing entries: %q", out)
+	}
+	if files["new.txt"] != "hello\n" {
+		t.Errorf("new.txt: %q", files["new.txt"])
+	}
+	if files["old.txt"] != "alpha\nBETA\ngamma\n" {
+		t.Errorf("old.txt: %q", files["old.txt"])
+	}
+	if _, ok := files["existing.x"]; ok {
+		t.Errorf("existing.x not deleted")
+	}
+}
+
+func TestRunApplyPatch_AtomicOnHunkFail(t *testing.T) {
+	// The first op succeeds in memory but the second op's hunk does not
+	// match. NO write should be flushed: the in-memory plan is built
+	// completely before any write fires.
+	files := map[string]string{
+		"a.txt": "keep\n",
+		"b.txt": "alpha\nbeta\n",
+	}
+	read := func(_ context.Context, p string) (string, error) {
+		s := files[p]
+		return s, nil
+	}
+	writes := 0
+	write := func(_ context.Context, p, c string) error {
+		writes++
+		files[p] = c
+		return nil
+	}
+	del := func(_ context.Context, p string) error {
+		delete(files, p)
+		return nil
+	}
+
+	patch := `*** Begin Patch
+*** Add File: created.txt
++x
+*** Update File: b.txt
+@@
+ NOT_THERE
+-beta
++BETA
+*** End Patch`
+
+	if _, err := runApplyPatch(context.Background(), patch, read, write, del); err == nil {
+		t.Fatal("expected error")
+	}
+	if writes != 0 {
+		t.Errorf("expected 0 writes on hunk failure, got %d", writes)
+	}
+	if _, ok := files["created.txt"]; ok {
+		t.Errorf("created.txt should not exist (atomicity broken)")
+	}
+}
+
+// =====================================================================
+// Direct unit tests for matching primitives.
+//
+// These cover seekSequence and normalizeForFuzzy at the granularity
+// Codex tests them in seek_sequence.rs / parser.rs. applyHunks-level
+// tests already exercise the integrated path; these guard the helper
+// contracts so a regression in normalisation or anchor scanning shows
+// up here directly.
+// =====================================================================
+
+func TestSeekSequence(t *testing.T) {
+	cases := []struct {
+		name     string
+		haystack []string
+		pattern  []string
+		start    int
+		want     int
+	}{
+		{
+			name:     "exact match",
+			haystack: []string{"a", "b", "c", "d"},
+			pattern:  []string{"b", "c"},
+			want:     1,
+		},
+		{
+			name:     "first match wins among duplicates",
+			haystack: []string{"x", "ctx", "y", "ctx", "z"},
+			pattern:  []string{"ctx"},
+			want:     1,
+		},
+		{
+			name:     "start offset skips earlier occurrences",
+			haystack: []string{"x", "ctx", "y", "ctx", "z"},
+			pattern:  []string{"ctx"},
+			start:    2,
+			want:     3,
+		},
+		{
+			name:     "not found returns -1",
+			haystack: []string{"a", "b"},
+			pattern:  []string{"missing"},
+			want:     -1,
+		},
+		{
+			name:     "pattern longer than haystack returns -1",
+			haystack: []string{"a"},
+			pattern:  []string{"a", "b"},
+			want:     -1,
+		},
+		{
+			name:     "empty pattern returns start",
+			haystack: []string{"a", "b"},
+			pattern:  nil,
+			start:    1,
+			want:     1,
+		},
+		{
+			name:     "empty pattern at end returns end",
+			haystack: []string{"a"},
+			pattern:  nil,
+			start:    1,
+			want:     1,
+		},
+		{
+			name:     "start past end returns -1",
+			haystack: []string{"a"},
+			pattern:  []string{"a"},
+			start:    5,
+			want:     -1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := seekSequence(tc.haystack, tc.pattern, tc.start); got != tc.want {
+				t.Errorf("got %d want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeForFuzzy(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// \u-escaped where the glyph matters so an auto-formatter can't
+		// silently rewrite the input back to ASCII and hide what's being
+		// tested.
+		{"ASCII fast path unchanged", "hello world", "hello world"},
+		{"ASCII trim", "  hello  ", "hello"},
+		{"en-dash U+2013", "foo–bar", "foo-bar"},
+		{"em-dash U+2014", "foo—bar", "foo-bar"},
+		{"non-breaking hyphen U+2011", "top‑level", "top-level"},
+		{"figure dash U+2012", "a‒b", "a-b"},
+		{"horizontal bar U+2015", "a―b", "a-b"},
+		{"minus sign U+2212", "a−b", "a-b"},
+		{"hyphen U+2010", "a‐b", "a-b"},
+		{"left single quote U+2018", "it‘s", "it's"},
+		{"right single quote U+2019", "it’s", "it's"},
+		{"low-9 single quote U+201A", "‚oops", "'oops"},
+		{"high-reversed-9 quote U+201B", "‛oops", "'oops"},
+		{"left double quote U+201C", "say “hi”", `say "hi"`},
+		{"low-9 double quote U+201E", "„hi“", `"hi"`},
+		{"high-reversed double quote U+201F", "‟hi", `"hi`},
+		{"non-breaking space U+00A0", "a b", "a b"},
+		{"figure space U+2007", "a b", "a b"},
+		{"thin space U+2009", "a b", "a b"},
+		{"narrow no-break space U+202F", "a b", "a b"},
+		{"ideographic space U+3000", "a　b", "a b"},
+		{"mixed glyphs", "—it’s “ok” now", `-it's "ok" now`},
+		{"non-mapped non-ASCII passes through", "日本語", "日本語"},
+		{"non-mapped non-ASCII trimmed", "  日本語  ", "日本語"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeForFuzzy(tc.in); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Parser case: the first hunk in an Update File block can omit the @@
+// header — Codex's parser.rs allows this in lenient mode.
+func TestParsePatch_FirstHunkNoAtAt(t *testing.T) {
+	in := `*** Begin Patch
+*** Update File: f.go
+ ctx
+-old
++new
+*** End Patch`
+	p, err := parsePatch(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := len(p.Ops[0].Hunks); got != 1 {
+		t.Fatalf("hunks: %d", got)
+	}
+	want := []hunkLine{
+		{Kind: lineContext, Text: "ctx"},
+		{Kind: lineRemove, Text: "old"},
+		{Kind: lineAdd, Text: "new"},
+	}
+	if got := p.Ops[0].Hunks[0].Lines; !linesEq(got, want) {
+		t.Errorf("got %+v want %+v", got, want)
+	}
+}
+
+// Engine-level identity-file refusals — both Delete and Move should
+// reject the operation BEFORE any backend call fires. Tested via
+// runApplyPatch with a noop backend that would otherwise let the op
+// through.
+func TestRunApplyPatch_IdentityRefusals(t *testing.T) {
+	noopRead := func(_ context.Context, _ string) (string, error) { return "", nil }
+	noopWrite := func(_ context.Context, _, _ string) error { return nil }
+	noopDel := func(_ context.Context, _ string) error { return nil }
+
+	cases := []struct {
+		name    string
+		patch   string
+		wantSub string
+	}{
+		{
+			name: "delete SOUL.md refused",
+			patch: `*** Begin Patch
+*** Delete File: SOUL.md
+*** End Patch`,
+			wantSub: "refusing to delete identity file",
+		},
+		{
+			name: "move FROM identity refused",
+			patch: `*** Begin Patch
+*** Update File: SOUL.md
+*** Move to: x.md
+@@
+-a
++b
+*** End Patch`,
+			wantSub: "refusing to Move identity file",
+		},
+		{
+			name: "move TO identity refused",
+			patch: `*** Begin Patch
+*** Update File: x.md
+*** Move to: SOUL.md
+@@
+-a
++b
+*** End Patch`,
+			wantSub: "refusing to Move identity file",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runApplyPatch(context.Background(), tc.patch, noopRead, noopWrite, noopDel)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// linesEq compares two hunkLine slices.
+func linesEq(a, b []hunkLine) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -42,7 +42,7 @@ const (
 // Registry holds all registered tools.
 type Registry struct {
 	tools       map[string]registeredTool
-	sandboxRoot string // if non-empty, file tools reject paths outside this dir
+	sandboxRoot string           // if non-empty, file tools reject paths outside this dir
 	executor    sandbox.Executor // if non-nil, all file+exec tools route through this
 	// File tool roots. systemRoot is the agent metadata dir (SOUL.md etc.);
 	// userRoot is where user-facing artifacts go. A relative path whose base
@@ -320,11 +320,13 @@ func (r *Registry) SetExecutor(ex sandbox.Executor) {
 	r.executor = ex
 	// Re-register built-in tools to use the executor.
 	registerSandboxedFile(r, ex)
+	registerSandboxedApplyPatch(r, ex)
 	registerSandboxedExec(r, ex)
 }
 
 func (r *Registry) registerBuiltins() {
 	registerExec(r)
 	registerFile(r)
+	registerApplyPatch(r)
 	registerMessage(r)
 }


### PR DESCRIPTION
## Why this tool is necessary

FastClaw's existing `edit_file` solves single-point replacement (`old_string` → `new_string`) and works fine for small tweaks. But the following everyday agent-coding scenarios are very high-frequency, and chained `edit_file` calls fall apart on them:

1. **Cross-file refactors**: renaming a function imported by 30 files → 30 round-trips of `read_file` + `edit_file`, token cost balloons quadratically, and any single `old_string is not unique` makes the model take a detour.
2. **Rename + content change**: `edit_file` can't do this. You're forced to combine `exec("mv")` + `edit_file`, and any partial failure leaves orphan state.
3. **Bulk scaffolding**: serial `write_file` calls, one round-trip per file.
4. **Reasoning continuity**: an `edit_file` chain forces the model to wait for a tool result between every file. **Attention gets fragmented across N segments**. A single patch lets the model "think through and emit all changes at once", which measurably improves edit quality.

`apply_patch` wraps a git-style unified diff into one tool call that creates / updates / deletes / renames files in any combination across the workspace. OpenAI Codex CLI and Claude Code both treat this as their primary editing tool, **because git diffs are heavily represented in model training data — it's the most natural output format**. OpenClaw lists `apply_patch` as a first-class member of `group:fs`. FastClaw was the only comparable agent runtime missing it.

## DSL (aligned with OpenAI Codex)

```
*** Begin Patch
*** Add File: pkg/foo/bar.go
+package foo
+
+func Bar() string { return "bar" }
*** Update File: cmd/main.go
*** Move to: cmd/app/main.go        (optional rename, must precede any hunk)
@@
 import (
+    "myapp/pkg/foo"
     "fmt"
 )
@@
 func main() {
-    fmt.Println("hello")
+    fmt.Println(foo.Bar())
 }
*** End of File                       (optional, anchors the hunk to file end)
*** Delete File: legacy/old.go
*** End Patch
```

## Implementation notes

- **Two-phase execution (atomic in spirit)**: parse the entire envelope, then compute every file's new content in memory; **if any hunk fails to anchor, no file is written** (covered by `TestRunApplyPatch_AtomicOnHunkFail`). Phase-2 I/O failures can leave partial state — this is a known tradeoff. Cross-backend transactional rollback would require snapshotting every touched store, which isn't worth the complexity.

- **Four-level progressive fuzzy match** (mirrors Codex's `seek_sequence`):
  1. Exact byte equality
  2. `rstrip` — ignore trailing whitespace
  3. `TrimSpace` — ignore leading and trailing whitespace
  4. **Unicode normalization** — typographic dashes (`– — ‑ ‒ ― −` etc.) → ASCII `-`, smart quotes (`' ' " " „ ‟` etc.) → ASCII, various spaces (NBSP / figure / thin / ideographic) → regular space.

  Key invariant: when a fuzzy level matches, context lines are pulled from **the file's actual text** (`buildReplacement`), so the file's original glyphs / whitespace are preserved instead of being silently rewritten by the patch's normalized version.

- **EOF anchoring semantics**: a pure-add hunk (only `+` lines) is implicitly EOF-anchored AND **does not advance the search cursor**. This is what lets a patch with pure-add first and an anchored hunk second still match at the file head. Borrowing Codex's `test_pure_addition_chunk_followed_by_removal` test caught a real bug in my first cut of the cursor logic — the test stays in place to guard the invariant.

- **Identity-file protection**: `SOUL.md` / `IDENTITY.md` / `MEMORY.md` / `AGENTS.md` / `BOOTSTRAP.md` / `TOOLS.md` / `HEARTBEAT.md` / `USER.md` / `agent.json` accept Add and Update but **refuse Delete and Move**. Reason: `SystemFileStore` has no Delete API, and these files have fixed slots in the schema — deleting them would corrupt the agent. Refusal happens at both the engine layer (`runApplyPatch`) and the backend layer (`deleteForPatch`) for defense in depth.

- **Backend routing reuses existing rules**: `isWorkspacePath` → workspaceStore; `isSingleSegmentSystemFile` → systemFileStore + on-disk mirror; otherwise `rootForPath` + `resolvePathSandboxed`. Two separate registrations (host filesystem and sandbox), behaviorally consistent with `read_file` / `write_file` / `edit_file`.

- **Sandbox delete**: `sandbox.Executor` has no Delete method, so we fall back to `Exec("rm -f -- '<path>'")`. The path is wrapped in single quotes with embedded quotes escaped to prevent shell injection.

## Test coverage

**50+ test cases** in total:

- **Parser** (5 tests): Add / Update / Delete / Move + EOF / multi-hunk / whitespace tolerance, plus 9 error branches (missing markers, misplaced `Move to:`, etc.)
- **Pure-function helpers** (2 groups): `seekSequence` direct — 8 cases; `normalizeForFuzzy` direct — 25 cases covering 7 dash variants, 5 quote variants, 5 space variants, ASCII fast path, and CJK passthrough
- **Applier** (11 tests): single hunk, multi-hunk cursor advancement, EOF append, fuzzy WS, no-match errors, no-trailing-newline preservation, pure-add anchoring, interleaved hunks, Unicode dash, leading-whitespace fuzzy, EOF fallback to forward scan
- **Engine** (4 tests): happy path, atomic-on-hunk-fail, Move, identity-file Delete & Move refusal

Three test cases are borrowed directly from `codex-rs`: `test_pure_addition_chunk_followed_by_removal`, `test_update_file_hunk_interleaved_changes`, `test_update_line_with_unicode_dash`, `test_update_file_hunk_can_move_file`. The first one **caught a cursor bug in the first implementation pass**.

## Alignment with Codex reference implementation

Roughly **95%**. Deliberately omitted:
- `AppliedPatchDelta` metadata (exact / overwritten tracking) — upper layers don't need it
- Strict / Lenient mode toggle — single lenient mode is sufficient
- Heredoc unwrap parsing — edge case
- Pure-add anchored "before final blank line" — minor semantic divergence

## Test plan

- [x] `go test ./internal/agent/tools/` (50+ cases passing)
- [x] `go vet ./internal/agent/tools/`
- [x] `go build ./...`
- [ ] Manual test: model issues a real cross-file patch in a chat session