### PR TITLE
feat(tools): add bash_output and kill_shell for backgrounded exec

### DIFF
--- a/internal/agent/tools/bash_session.go
+++ b/internal/agent/tools/bash_session.go
@@ -1,0 +1,295 @@
+package tools
+
+// Background-shell management — Claude-Code-style.
+//
+// One tool call (`exec` with run_in_background=true) launches a long-
+// running command and returns immediately with a `bash_id`. The agent
+// observes progress via `bash_output(bash_id)` (returns new stdout/stderr
+// since the last call) and terminates with `kill_shell(bash_id)`.
+//
+// Scope (deliberately narrow):
+//   - host-mode os/exec only; sandbox-mode background is a v2 follow-up
+//   - tail-only observation; no send-keys / paste / interactive control
+//     (those use cases route through tmux invoked from regular `exec`)
+//   - sessions are agent-private and live until killed or Registry.Close
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// bufferCap caps the output retained per session. When exceeded, the
+// oldest bytes are dropped FIFO. 4 MiB comfortably holds 30 minutes of
+// dev-server logs while bounding total memory at 4 MiB × live sessions.
+const bufferCap = 4 * 1024 * 1024
+
+// outputBuffer is a thread-safe FIFO byte buffer with a hard cap.
+// It tracks the total number of bytes ever written ("absolute offsets")
+// so callers reading "since last check" can survive truncations: when
+// older bytes get dropped, an existing read cursor advances to the
+// current head and the caller learns some output was lost.
+type outputBuffer struct {
+	mu       sync.Mutex
+	data     []byte
+	head     int // absolute offset of data[0]; equals total bytes dropped
+	total    int // absolute offset just past data[end]; equals total bytes ever written
+	maxBytes int
+}
+
+func newOutputBuffer(maxBytes int) *outputBuffer {
+	return &outputBuffer{maxBytes: maxBytes}
+}
+
+// Write appends p to the buffer, dropping the oldest bytes if cap is
+// exceeded. Always succeeds; returns len(p), nil to satisfy io.Writer
+// (so it can plug directly into exec.Cmd.Stdout / Stderr).
+func (b *outputBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.data = append(b.data, p...)
+	b.total += len(p)
+	if len(b.data) > b.maxBytes {
+		drop := len(b.data) - b.maxBytes
+		b.data = b.data[drop:]
+		b.head += drop
+	}
+	return len(p), nil
+}
+
+// readSince returns content from absolute offset `since` onward. If
+// `since` is below the head (older content was dropped), returns
+// everything currently held with `dropped=true` so the caller can warn
+// the model. Returns the new absolute offset for the caller to remember.
+func (b *outputBuffer) readSince(since int) (out []byte, dropped bool, newSince int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if since < b.head {
+		dropped = true
+		since = b.head
+	}
+	// since is now ≥ b.head, so start ≥ 0 by construction. The only
+	// remaining out-of-range case is "caller's cursor is ahead of what
+	// we've ever produced" (since > b.total), which means there's
+	// nothing new yet.
+	start := since - b.head
+	if start > len(b.data) {
+		return nil, dropped, b.total
+	}
+	// Copy out so the caller can release the lock without aliasing.
+	out = append([]byte(nil), b.data[start:]...)
+	return out, dropped, b.total
+}
+
+// bashSession is a single backgrounded shell command and the state
+// needed to observe and terminate it.
+type bashSession struct {
+	id        string
+	command   string
+	startedAt time.Time
+
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+	out    *outputBuffer
+
+	// readCursor is the absolute offset already returned to bash_output.
+	// Guarded by readMu (separate from outputBuffer.mu so writers and
+	// readers don't contend on one lock).
+	readMu     sync.Mutex
+	readCursor int
+
+	// done flips to true exactly once when cmd.Wait returns. exitCode is
+	// written before done; reading exitCode is safe iff done is true
+	// (acquire-release via atomic.Bool).
+	done     atomic.Bool
+	exitCode int
+	exitErr  error
+}
+
+// status reports a session's runtime state.
+type bashStatus int
+
+const (
+	statusRunning bashStatus = iota
+	statusExited
+)
+
+// snapshot returns a consistent view of the session's terminal state.
+// status is observable while running; exitCode is meaningful only when
+// status == statusExited.
+func (s *bashSession) snapshot() (status bashStatus, exitCode int, exitErr error) {
+	if !s.done.Load() {
+		return statusRunning, 0, nil
+	}
+	return statusExited, s.exitCode, s.exitErr
+}
+
+// readNew pulls all output produced since the last readNew call on this
+// session. dropped=true means the buffer rolled past the read cursor
+// and some bytes are permanently gone.
+func (s *bashSession) readNew() (out []byte, dropped bool) {
+	s.readMu.Lock()
+	defer s.readMu.Unlock()
+	out, dropped, next := s.out.readSince(s.readCursor)
+	s.readCursor = next
+	return out, dropped
+}
+
+// kill signals SIGKILL via the cancel function tied to the session's
+// own context. Returns nil if the session was already done. Idempotent.
+func (s *bashSession) kill() error {
+	if s.done.Load() {
+		return nil
+	}
+	s.cancel()
+	return nil
+}
+
+// shellManager owns every backgrounded session for a Registry. Sessions
+// outlive the request context that started them — they die on kill, on
+// natural exit, or on Registry.Close.
+type shellManager struct {
+	mu      sync.Mutex
+	shells  map[string]*bashSession
+	counter int
+	closed  bool // Close was called; Start refuses new sessions
+}
+
+func newShellManager() *shellManager {
+	return &shellManager{shells: make(map[string]*bashSession)}
+}
+
+// Start launches command via `sh -c` and returns its bash_id. The
+// session lives until kill or natural exit; the caller's ctx does NOT
+// propagate to the child — that ctx dies at turn end and would take
+// every backgrounded process with it.
+func (m *shellManager) Start(command string, env []string) (*bashSession, error) {
+	if command == "" {
+		return nil, errors.New("command is required")
+	}
+
+	// Refuse new sessions after Close. Without this, a Start that
+	// races with shutdown could land its session in the post-Close map
+	// and leak the process forever.
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return nil, errors.New("shell manager closed")
+	}
+	m.mu.Unlock()
+
+	// context.Background here is intentional — a backgrounded shell
+	// must outlive the turn that spawned it. The session's own cancel
+	// is the only path that terminates it before natural exit.
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	if env != nil {
+		cmd.Env = env
+	}
+
+	// Spawn into a fresh process group so kill_shell reaches every
+	// descendant (e.g. `sh -c "npm run dev"` forks node — without group
+	// kill, killing sh leaves node running). Override CommandContext's
+	// default Cancel (which only kills cmd.Process directly) to send
+	// SIGKILL to the whole group.
+	setProcessGroup(cmd)
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return killProcessGroup(cmd.Process.Pid)
+	}
+
+	out := newOutputBuffer(bufferCap)
+	cmd.Stdout = out
+	cmd.Stderr = out // outputBuffer's Write is mutex-protected so concurrent stdout+stderr is safe
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start background shell: %w", err)
+	}
+
+	// Re-check closed under the same lock that does the insert. The
+	// pre-Start check above is just an early-out to avoid forking sh
+	// when we know we're shutting down — the race-safe verdict is here.
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		cancel() // group-kill the shell we just spawned
+		return nil, errors.New("shell manager closed")
+	}
+	m.counter++
+	id := fmt.Sprintf("bash_%d", m.counter)
+	s := &bashSession{
+		id:        id,
+		command:   command,
+		startedAt: time.Now(),
+		cmd:       cmd,
+		cancel:    cancel,
+		out:       out,
+	}
+	m.shells[id] = s
+	m.mu.Unlock()
+
+	// Reaper: cmd.Wait returns when the process exits OR when ctx is
+	// cancelled (kill). Capture exit code, then flip done.
+	go func() {
+		err := cmd.Wait()
+		s.exitErr = err
+		var ee *exec.ExitError
+		if err == nil {
+			s.exitCode = 0
+		} else if errors.As(err, &ee) {
+			s.exitCode = ee.ExitCode()
+		} else {
+			// Killed by cancel, or pipe / IO error. Use -1 to signal
+			// "abnormal termination" — the agent can disambiguate from
+			// the exit_err string returned by snapshot.
+			s.exitCode = -1
+		}
+		s.done.Store(true)
+		// Note: we deliberately do NOT remove the session from the map
+		// here. bash_output remains useful after exit so the agent can
+		// fetch the final output and exit status. Registry.Close handles
+		// cleanup, or a future TTL eviction can be layered on top.
+	}()
+
+	return s, nil
+}
+
+// Get fetches a session by bash_id, or nil if not found.
+func (m *shellManager) Get(id string) *bashSession {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.shells[id]
+}
+
+// Close kills every live session, clears the registry, and refuses any
+// future Start. Idempotent. Called from Registry.Close on agent
+// shutdown so backgrounded processes don't outlive their owner.
+func (m *shellManager) Close() {
+	m.mu.Lock()
+	shells := m.shells
+	m.shells = make(map[string]*bashSession)
+	m.closed = true
+	m.mu.Unlock()
+	for _, s := range shells {
+		s.cancel()
+	}
+}
+
+// list returns a snapshot of all current sessions, sorted by id.
+// Currently used only by tests; exposed for future list_shells tool.
+func (m *shellManager) list() []*bashSession {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*bashSession, 0, len(m.shells))
+	for _, s := range m.shells {
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/agent/tools/bash_session_test.go
+++ b/internal/agent/tools/bash_session_test.go
@@ -1,0 +1,468 @@
+//go:build unix
+
+package tools
+
+// Tests rely on `sh`, `sleep`, `echo`, `printf`, and process-group
+// signaling — all Unix-only. Build-tagged so cross-compile to Windows
+// stays clean (the production code paths it exercises are also
+// Unix-only via bash_session_unix.go).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// =====================================================================
+// outputBuffer — pure-function tests
+// =====================================================================
+
+func TestOutputBuffer_AppendAndRead(t *testing.T) {
+	b := newOutputBuffer(1024)
+	_, _ = b.Write([]byte("hello"))
+	_, _ = b.Write([]byte(" world"))
+
+	out, dropped, since := b.readSince(0)
+	if dropped {
+		t.Errorf("unexpected drop")
+	}
+	if string(out) != "hello world" {
+		t.Errorf("got %q want %q", out, "hello world")
+	}
+	if since != 11 {
+		t.Errorf("since: %d want 11", since)
+	}
+
+	// Re-reading from `since` returns nothing new.
+	out, _, since2 := b.readSince(since)
+	if len(out) != 0 || since2 != 11 {
+		t.Errorf("re-read: out=%q since=%d", out, since2)
+	}
+}
+
+func TestOutputBuffer_FIFODrop(t *testing.T) {
+	b := newOutputBuffer(8) // tiny cap
+	_, _ = b.Write([]byte("AAAA"))
+	_, _ = b.Write([]byte("BBBB"))
+	_, _ = b.Write([]byte("CCCC")) // forces drop of "AAAA"
+
+	out, dropped, since := b.readSince(0)
+	if !dropped {
+		t.Errorf("expected dropped=true after cap exceeded")
+	}
+	if string(out) != "BBBBCCCC" {
+		t.Errorf("got %q want %q", out, "BBBBCCCC")
+	}
+	if since != 12 {
+		t.Errorf("since=%d want 12 (total bytes ever written)", since)
+	}
+}
+
+func TestOutputBuffer_ReadSinceFuture(t *testing.T) {
+	b := newOutputBuffer(64)
+	_, _ = b.Write([]byte("hello"))
+	out, _, since := b.readSince(100)
+	if len(out) != 0 {
+		t.Errorf("read past end should be empty, got %q", out)
+	}
+	if since != 5 {
+		t.Errorf("since=%d want 5", since)
+	}
+}
+
+func TestOutputBuffer_ConcurrentWriteRead(t *testing.T) {
+	// Smoke test: many concurrent writers and a reader. Race detector
+	// catches data races; we just want the test to not panic and the
+	// final read to see all bytes.
+	b := newOutputBuffer(1 << 20)
+	var wg sync.WaitGroup
+	const N = 100
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = b.Write([]byte("x"))
+		}()
+	}
+	wg.Wait()
+	out, _, _ := b.readSince(0)
+	if len(out) != N {
+		t.Errorf("got %d bytes, want %d", len(out), N)
+	}
+}
+
+// =====================================================================
+// shellManager / bashSession — integration tests
+// =====================================================================
+//
+// These spawn real `sh -c` processes. They run on every CI environment
+// FastClaw cares about. Tests use short sleeps (≤ 200ms) so the suite
+// stays fast.
+
+func waitDone(t *testing.T, s *bashSession, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !s.done.Load() {
+		if time.Now().After(deadline) {
+			t.Fatalf("session %s did not exit within %v", s.id, timeout)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestShellManager_EchoExitsZero(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+
+	s, err := m.Start("echo hello", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitDone(t, s, 2*time.Second)
+
+	out, dropped := s.readNew()
+	if dropped {
+		t.Errorf("unexpected drop")
+	}
+	if string(out) != "hello\n" {
+		t.Errorf("got %q want \"hello\\n\"", out)
+	}
+
+	status, code, _ := s.snapshot()
+	if status != statusExited {
+		t.Errorf("status=%d want exited", status)
+	}
+	if code != 0 {
+		t.Errorf("code=%d want 0", code)
+	}
+}
+
+func TestShellManager_NonZeroExitCodePreserved(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+	s, err := m.Start("exit 42", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitDone(t, s, 2*time.Second)
+	_, code, _ := s.snapshot()
+	if code != 42 {
+		t.Errorf("code=%d want 42", code)
+	}
+}
+
+func TestShellManager_KillTerminatesRunning(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+	s, err := m.Start("sleep 10", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Give it a moment to actually start.
+	time.Sleep(20 * time.Millisecond)
+	if s.done.Load() {
+		t.Fatalf("session ended too early")
+	}
+	if err := s.kill(); err != nil {
+		t.Errorf("kill: %v", err)
+	}
+	waitDone(t, s, 2*time.Second)
+	status, code, _ := s.snapshot()
+	if status != statusExited {
+		t.Errorf("status not exited")
+	}
+	// Killed via context cancel — code is -1 (abnormal termination).
+	if code != -1 {
+		t.Errorf("code=%d want -1 (killed)", code)
+	}
+}
+
+// TestShellManager_KillReachesGrandchildren guards the process-group
+// kill behaviour: `sh -c` forks a child shell, the child shell forks
+// `sleep`. Without Setpgid + group kill, only the shell would die and
+// `sleep` would orphan and keep running, so the model thinks dev
+// servers / build watchers were stopped when they're still consuming
+// the port. We verify by capturing the grandchild's PID via lsof of
+// /proc — but that's Linux-specific and brittle. Simpler proof: spawn
+// a long-lived grandchild and rely on the test deadline. After
+// kill_shell, no descendant should still be writing to the buffer.
+func TestShellManager_KillReachesGrandchildren(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+	// `sh -c "sleep 30 & wait"` — the shell forks `sleep`, then waits
+	// on it. Without group kill, killing the shell leaves `sleep`
+	// behind. With group kill, both go.
+	s, err := m.Start("sleep 30 & echo started; wait", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Wait for "started" so we know the grandchild PID is in flight.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		out, _ := s.readNew()
+		if bytes.Contains(out, []byte("started")) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := s.kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	// The whole group should die fast — Wait blocks on the shell, but
+	// the shell can't return until its `wait` builtin completes, which
+	// only happens after `sleep` is also gone. If group kill works,
+	// done flips within milliseconds. If it doesn't, the test times
+	// out at 30s sleep.
+	waitDone(t, s, 2*time.Second)
+}
+
+func TestShellManager_KillIsIdempotentOnExited(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+	s, err := m.Start("true", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitDone(t, s, 2*time.Second)
+	if err := s.kill(); err != nil {
+		t.Errorf("kill on exited should be no-op, got %v", err)
+	}
+}
+
+func TestShellManager_IncrementalReadAdvancesCursor(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+	// Two outputs separated by a sleep so we can read between them.
+	s, err := m.Start("echo first; sleep 0.15; echo second", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Wait for the first line to land.
+	deadline := time.Now().Add(1 * time.Second)
+	var first []byte
+	for time.Now().Before(deadline) {
+		out, _ := s.readNew()
+		if len(out) > 0 {
+			first = append(first, out...)
+			if bytes.Contains(first, []byte("first\n")) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !bytes.Contains(first, []byte("first\n")) {
+		t.Fatalf("never saw first line; got %q", first)
+	}
+	if bytes.Contains(first, []byte("second")) {
+		t.Fatalf("saw second line too early; reads aren't incremental: %q", first)
+	}
+
+	waitDone(t, s, 2*time.Second)
+	out, _ := s.readNew()
+	if !bytes.Contains(out, []byte("second\n")) {
+		t.Errorf("second read missing 'second': %q", out)
+	}
+	if bytes.Contains(out, []byte("first")) {
+		t.Errorf("second read leaked 'first' (cursor not advanced): %q", out)
+	}
+}
+
+func TestShellManager_CloseKillsAllSessions(t *testing.T) {
+	m := newShellManager()
+	// Capture session pointers BEFORE Close — Close empties m.shells,
+	// and ranging over the cleared map would silently iterate nothing
+	// and pass the assertion regardless of whether kills actually fired.
+	captured := make([]*bashSession, 0, 3)
+	for i := 0; i < 3; i++ {
+		s, err := m.Start("sleep 30", nil)
+		if err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		captured = append(captured, s)
+	}
+	if got := len(m.list()); got != 3 {
+		t.Fatalf("expected 3 sessions before close, got %d", got)
+	}
+
+	m.Close()
+
+	if got := len(m.list()); got != 0 {
+		t.Errorf("Close did not clear shells map; still has %d", got)
+	}
+
+	// Each captured session should reach done=true after Close cancels
+	// its context and the reaper goroutine processes the SIGKILL.
+	for _, s := range captured {
+		waitDone(t, s, 2*time.Second)
+		_, code, _ := s.snapshot()
+		if code != -1 {
+			t.Errorf("session %s exit code %d, expected -1 (killed)", s.id, code)
+		}
+	}
+}
+
+// TestShellManager_StartAfterCloseRefuses guards the close+start race:
+// once Close returned, any subsequent Start must NOT silently land in
+// the post-Close map and leak the spawned process. Refusing is the
+// safe verdict.
+func TestShellManager_StartAfterCloseRefuses(t *testing.T) {
+	m := newShellManager()
+	m.Close()
+	s, err := m.Start("echo nope", nil)
+	if err == nil {
+		t.Errorf("Start after Close should error, got session %v", s)
+	}
+}
+
+// TestBashOutputTool_DrainsTailOnExit guards the read-then-status
+// race: bytes that land between the first readNew and the snapshot's
+// done=true observation must NOT be lost when bash_output reports
+// "[status] exited". We provoke the race by polling repeatedly while
+// a short command is finishing — without the post-snapshot drain the
+// last lines are eventually skipped.
+func TestBashOutputTool_DrainsTailOnExit(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+	defer r.Close()
+
+	// Print a sentinel just before exit so we can detect the loss case
+	// directly: a successful drain MUST yield the sentinel together
+	// with the "exited" status line.
+	s, err := r.shellMgr.Start("printf 'tail-sentinel\\n'", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitDone(t, s, 2*time.Second)
+
+	args, _ := json.Marshal(map[string]string{"bash_id": s.id})
+	got, err := r.Execute(context.Background(), "bash_output", string(args))
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(got, "tail-sentinel") {
+		t.Errorf("missed tail bytes; got %q", got)
+	}
+	if !strings.Contains(got, "[status] exited (code=0)") {
+		t.Errorf("status missing; got %q", got)
+	}
+}
+
+// =====================================================================
+// bash_output / kill_shell — tool-level tests
+// =====================================================================
+
+func TestBashOutputTool_FilterRegex(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+	defer r.Close()
+
+	s, err := r.shellMgr.Start("printf 'INFO: ok\\nERROR: boom\\nINFO: done\\n'", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitDone(t, s, 2*time.Second)
+
+	args, _ := json.Marshal(map[string]string{"bash_id": s.id, "filter": "^ERROR:"})
+	got, err := r.Execute(context.Background(), "bash_output", string(args))
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(got, "ERROR: boom") {
+		t.Errorf("filter dropped the matching line: %q", got)
+	}
+	if strings.Contains(got, "INFO:") {
+		t.Errorf("filter let through non-matching lines: %q", got)
+	}
+	if !strings.Contains(got, "[status] exited (code=0)") {
+		t.Errorf("status footer missing: %q", got)
+	}
+}
+
+func TestBashOutputTool_UnknownIDErrors(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+	defer r.Close()
+	args, _ := json.Marshal(map[string]string{"bash_id": "bash_999"})
+	_, err := r.Execute(context.Background(), "bash_output", string(args))
+	if err == nil || !strings.Contains(err.Error(), "no such bash_id") {
+		t.Errorf("expected 'no such bash_id' error, got %v", err)
+	}
+}
+
+func TestKillShellTool_AlreadyExited(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+	defer r.Close()
+	s, err := r.shellMgr.Start("true", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitDone(t, s, 2*time.Second)
+
+	args, _ := json.Marshal(map[string]string{"bash_id": s.id})
+	got, err := r.Execute(context.Background(), "kill_shell", string(args))
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(got, "Already exited") {
+		t.Errorf("got %q; expected 'Already exited'", got)
+	}
+}
+
+func TestKillShellTool_TerminatesRunning(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+	defer r.Close()
+	s, err := r.shellMgr.Start("sleep 30", nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	args, _ := json.Marshal(map[string]string{"bash_id": s.id})
+	got, err := r.Execute(context.Background(), "kill_shell", string(args))
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(got, "Sent kill") {
+		t.Errorf("got %q; expected 'Sent kill'", got)
+	}
+	waitDone(t, s, 2*time.Second)
+}
+
+// =====================================================================
+// exec(run_in_background) integration
+// =====================================================================
+
+func TestExecTool_BackgroundReturnsBashID(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+	defer r.Close()
+	args, _ := json.Marshal(map[string]any{
+		"command":           "sleep 0.05; echo done",
+		"run_in_background": true,
+	})
+	got, err := r.Execute(context.Background(), "exec", string(args))
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(got, "bash_") || !strings.Contains(got, "Started background shell") {
+		t.Fatalf("expected bash_id in result, got %q", got)
+	}
+	// Wait for it to actually finish, then read output via the tool.
+	if got1 := r.shellMgr.list(); len(got1) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got1))
+	}
+	s := r.shellMgr.list()[0]
+	waitDone(t, s, 2*time.Second)
+
+	outArgs, _ := json.Marshal(map[string]string{"bash_id": s.id})
+	out, err := r.Execute(context.Background(), "bash_output", string(outArgs))
+	if err != nil {
+		t.Fatalf("bash_output: %v", err)
+	}
+	if !strings.Contains(out, "done") || !strings.Contains(out, "exited (code=0)") {
+		t.Errorf("bash_output got %q", out)
+	}
+}

--- a/internal/agent/tools/bash_session_unix.go
+++ b/internal/agent/tools/bash_session_unix.go
@@ -1,0 +1,40 @@
+//go:build unix
+
+package tools
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup configures the command to spawn into a NEW process
+// group (Setpgid=true with Pgid=0 makes the child the group leader).
+// Must be set before cmd.Start. Together with killProcessGroup this
+// guarantees `kill_shell` reaches every descendant the command spawned
+// — without it, killing `sh -c "npm run dev"` leaves the node process
+// orphaned and still bound to the dev server's port.
+func setProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killProcessGroup sends SIGKILL to the entire process group whose
+// leader's PID is groupLeaderPid. The negative-pid trick (kill(2) with
+// -pid) is the POSIX idiom for group signals. ESRCH ("no such process")
+// is mapped to nil — that just means the group already terminated,
+// which is the same end state we wanted.
+func killProcessGroup(groupLeaderPid int) error {
+	if groupLeaderPid <= 0 {
+		return nil
+	}
+	if err := syscall.Kill(-groupLeaderPid, syscall.SIGKILL); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/agent/tools/bash_session_windows.go
+++ b/internal/agent/tools/bash_session_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package tools
+
+import "os/exec"
+
+// Windows has no Setpgid analogue exposed via syscall.SysProcAttr — job
+// objects exist but require non-trivial wiring. FastClaw's exec path is
+// already Unix-only in practice (uses `sh -c`), so a no-op here keeps
+// cross-compilation green without pretending to support Windows.
+//
+// Practical consequence: on Windows the default cmd.Cancel (Kill on the
+// direct child only) applies, and grandchildren can survive a
+// kill_shell. Acceptable for v1 — the same gap exists in the
+// synchronous exec path.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+func killProcessGroup(groupLeaderPid int) error { return nil }

--- a/internal/agent/tools/bash_tools.go
+++ b/internal/agent/tools/bash_tools.go
@@ -1,0 +1,173 @@
+package tools
+
+// bash_output and kill_shell — companion tools to exec(run_in_background).
+//
+// Tool surface mirrors Claude Code's `BashOutput` / `KillShell` so prompts
+// and skills written for that runtime port over without translation.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type bashOutputArgs struct {
+	BashID string `json:"bash_id"`
+	Filter string `json:"filter,omitempty"` // optional regex applied per output line
+}
+
+type killShellArgs struct {
+	BashID string `json:"bash_id"`
+}
+
+const bashOutputDescription = `Read new stdout/stderr from a backgrounded shell since the last call. Use this to monitor a long-running process started with exec(run_in_background=true).
+
+Returns:
+  - new output produced since the previous bash_output call on this bash_id (each call advances a per-session cursor)
+  - "[status] running" or "[status] exited (code=N)" — only "exited" rows guarantee the process is done; killed processes report code=-1 with the kill reason appended
+  - a "[truncated]" line prepended if the 4 MiB per-session output buffer rolled past the read cursor (oldest bytes dropped FIFO)
+
+Notes:
+  - The session keeps running across calls until kill_shell or natural exit.
+  - After exit, bash_output is still callable to read any final output and confirm the exit code.
+  - The optional 'filter' regex is applied per output line (lines that don't match are dropped before return) — useful for tailing a noisy log when you only care about errors.`
+
+const killShellDescription = `Terminate a backgrounded shell started by exec(run_in_background=true). Sends SIGKILL via process-group cancellation. Idempotent — calling it on an already-exited shell is a no-op and returns success.`
+
+func registerBashOutput(r *Registry) {
+	r.Register("bash_output", bashOutputDescription, map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"bash_id": map[string]interface{}{
+				"type":        "string",
+				"description": "Identifier returned by exec(run_in_background=true), e.g. \"bash_3\".",
+			},
+			"filter": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional regex (RE2). Only output lines matching this pattern are returned.",
+			},
+		},
+		"required": []string{"bash_id"},
+	}, func(ctx context.Context, raw json.RawMessage) (string, error) {
+		var args bashOutputArgs
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", fmt.Errorf("bash_output: parse args: %w", err)
+		}
+		if args.BashID == "" {
+			return "", fmt.Errorf("bash_output: bash_id is required")
+		}
+		if r.shellMgr == nil {
+			return "", fmt.Errorf("bash_output: shell manager not initialised")
+		}
+		s := r.shellMgr.Get(args.BashID)
+		if s == nil {
+			return "", fmt.Errorf("bash_output: no such bash_id %q (call exec(run_in_background=true) first; ids are valid only within the same agent process)", args.BashID)
+		}
+
+		var filter *regexp.Regexp
+		if args.Filter != "" {
+			re, err := regexp.Compile(args.Filter)
+			if err != nil {
+				return "", fmt.Errorf("bash_output: invalid filter regex: %w", err)
+			}
+			filter = re
+		}
+
+		raw2, dropped := s.readNew()
+		status, code, exitErr := s.snapshot()
+		// Race fix: bytes can land in the buffer AFTER our readNew but
+		// BEFORE the reaper flips done=true. Without this drain, an
+		// "exited" report would silently miss the last few bytes (often
+		// the most useful ones — the error message or summary line).
+		// Drain only when exited; running shells can poll again later
+		// for new output.
+		if status == statusExited {
+			more, dropped2 := s.readNew()
+			if len(more) > 0 {
+				raw2 = append(raw2, more...)
+			}
+			dropped = dropped || dropped2
+		}
+		body := string(raw2)
+		if filter != nil && body != "" {
+			body = filterLines(body, filter)
+		}
+
+		var sb strings.Builder
+		if dropped {
+			sb.WriteString("[truncated] earlier output exceeded the 4 MiB session cap and was dropped\n")
+		}
+		if body != "" {
+			sb.WriteString(body)
+			if !strings.HasSuffix(body, "\n") {
+				sb.WriteByte('\n')
+			}
+		}
+		switch status {
+		case statusRunning:
+			sb.WriteString("[status] running")
+		case statusExited:
+			fmt.Fprintf(&sb, "[status] exited (code=%d)", code)
+			if exitErr != nil && code == -1 {
+				// abnormal: killed, IO error, etc.
+				fmt.Fprintf(&sb, " — %s", exitErr.Error())
+			}
+		}
+		return sb.String(), nil
+	})
+}
+
+func registerKillShell(r *Registry) {
+	r.Register("kill_shell", killShellDescription, map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"bash_id": map[string]interface{}{
+				"type":        "string",
+				"description": "Identifier returned by exec(run_in_background=true).",
+			},
+		},
+		"required": []string{"bash_id"},
+	}, func(ctx context.Context, raw json.RawMessage) (string, error) {
+		var args killShellArgs
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", fmt.Errorf("kill_shell: parse args: %w", err)
+		}
+		if args.BashID == "" {
+			return "", fmt.Errorf("kill_shell: bash_id is required")
+		}
+		if r.shellMgr == nil {
+			return "", fmt.Errorf("kill_shell: shell manager not initialised")
+		}
+		s := r.shellMgr.Get(args.BashID)
+		if s == nil {
+			return "", fmt.Errorf("kill_shell: no such bash_id %q", args.BashID)
+		}
+		if s.done.Load() {
+			_, code, _ := s.snapshot()
+			return fmt.Sprintf("Already exited (code=%d).", code), nil
+		}
+		_ = s.kill()
+		return fmt.Sprintf("Sent kill to %s.", s.id), nil
+	})
+}
+
+// filterLines retains only lines matching re. Trailing newline policy
+// follows the input: a body with a trailing newline keeps it, one
+// without doesn't. Lines that don't match are dropped silently.
+func filterLines(body string, re *regexp.Regexp) string {
+	hadTrailingNL := strings.HasSuffix(body, "\n")
+	lines := strings.Split(strings.TrimSuffix(body, "\n"), "\n")
+	kept := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if re.MatchString(l) {
+			kept = append(kept, l)
+		}
+	}
+	out := strings.Join(kept, "\n")
+	if hadTrailingNL && out != "" {
+		out += "\n"
+	}
+	return out
+}

--- a/internal/agent/tools/exec.go
+++ b/internal/agent/tools/exec.go
@@ -15,10 +15,11 @@ import (
 )
 
 type execArgs struct {
-	Command string `json:"command"`
-	Stdin   string `json:"stdin,omitempty"`   // optional: piped to the command's stdin
-	Timeout int    `json:"timeout,omitempty"` // seconds, default 30
-	Sandbox bool   `json:"sandbox,omitempty"` // force sandbox for this call
+	Command         string `json:"command"`
+	Stdin           string `json:"stdin,omitempty"`             // optional: piped to the command's stdin
+	Timeout         int    `json:"timeout,omitempty"`           // seconds, default 30
+	Sandbox         bool   `json:"sandbox,omitempty"`           // force sandbox for this call
+	RunInBackground bool   `json:"run_in_background,omitempty"` // launch detached, return bash_id for bash_output / kill_shell
 }
 
 // MetaSandboxPrefix marks an exec result as having run inside a sandbox.
@@ -87,6 +88,10 @@ func registerExecFull(r *Registry, sbCfg *SandboxConfig, envProvider SkillEnvPro
 				"type":        "boolean",
 				"description": "Force execution in sandbox container",
 			},
+			"run_in_background": map[string]interface{}{
+				"type":        "boolean",
+				"description": "Launch the command in the background and return a bash_id immediately. Use this for long-running processes (dev servers, build watchers, migrations). Read output later via bash_output(bash_id); terminate via kill_shell(bash_id). Background sessions live until killed or the agent shuts down.",
+			},
 		},
 		"required": []string{"command"},
 	}, makeExecToolFull(r, sbCfg, envProvider, skillDirs))
@@ -143,6 +148,34 @@ func makeExecToolFull(r *Registry, sbCfg *SandboxConfig, envProvider SkillEnvPro
 		// sandbox is mandatory after construction (sibling agent wanted
 		// it, or admin flipped settings.sandbox.enabled mid-process).
 		useSandbox := args.Sandbox || (sbCfg != nil && sbCfg.Enabled) || (r != nil && r.sandboxRequired)
+
+		// Background mode is host-only in v1. Sandbox-mode background
+		// would need StartBackground / Poll / Kill on sandbox.Executor
+		// (or per-backend tmux-inside-container plumbing) — both are
+		// follow-ups. Until then, point the model at tmux as a
+		// workaround so it has a path forward inside sandboxes.
+		if args.RunInBackground {
+			if useSandbox {
+				return "", fmt.Errorf("run_in_background is not yet supported in sandbox mode — start the long-running command via tmux inside the sandbox instead, e.g. exec({command: \"tmux new-session -d -s job '<your command>'\"}) then exec({command: \"tmux capture-pane -t job -p\"}) to read output and exec({command: \"tmux kill-session -t job\"}) to stop")
+			}
+			if r == nil || r.shellMgr == nil {
+				return "", fmt.Errorf("run_in_background unavailable: shell manager not initialised")
+			}
+			// Build env exactly like the synchronous path so skills
+			// running in the background see their FAL_KEY etc.
+			var sessEnv []string
+			if envProvider != nil && skillDirs != nil {
+				if skillEnv := resolveSkillEnv(args.Command, envProvider, skillDirs); len(skillEnv) > 0 {
+					sessEnv = mergeEnv(os.Environ(), skillEnv)
+				}
+			}
+			s, err := r.shellMgr.Start(command, sessEnv)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Started background shell %s for command: %s\nUse bash_output(bash_id=%q) to read output, kill_shell(bash_id=%q) to terminate.", s.id, args.Command, s.id, s.id), nil
+		}
+
 		if useSandbox && sbCfg != nil && sbCfg.Pool != nil {
 			sb := sbCfg.Pool.Get(sbCfg.AgentID, sbCfg.Image, sbCfg.Workspace, sbCfg.Policy)
 			out, err := sb.Exec(execCtx, command, "/workspace")
@@ -280,6 +313,10 @@ func registerSandboxedExec(r *Registry, ex sandbox.Executor) {
 				"type":        "integer",
 				"description": "Timeout in seconds (default 30)",
 			},
+			"run_in_background": map[string]interface{}{
+				"type":        "boolean",
+				"description": "Launch in background. NOT YET SUPPORTED in sandbox mode — use `tmux new-session -d -s NAME '<cmd>'` directly instead.",
+			},
 		},
 		"required": []string{"command"},
 	}, func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
@@ -289,6 +326,9 @@ func registerSandboxedExec(r *Registry, ex sandbox.Executor) {
 		}
 		if args.Command == "" {
 			return "", fmt.Errorf("command is required")
+		}
+		if args.RunInBackground {
+			return "", fmt.Errorf("run_in_background is not yet supported in sandbox mode — use tmux inside the sandbox instead: exec({command: \"tmux new-session -d -s job '<your command>'\"}) to start, exec({command: \"tmux capture-pane -t job -p\"}) to read, exec({command: \"tmux kill-session -t job\"}) to stop")
 		}
 		timeout := 30
 		if args.Timeout > 0 {

--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -128,6 +128,11 @@ type Registry struct {
 	// hash so both layers agree on what "the same call" means.
 	turnFailMu sync.Mutex
 	turnFails  map[turnFailKey]string
+	// shellMgr owns every `exec(run_in_background=true)` shell so the
+	// agent can later read their output via bash_output and terminate
+	// them via kill_shell. Sessions outlive individual turns; they die
+	// only on explicit kill or on Registry.Close.
+	shellMgr *shellManager
 }
 
 type turnFailKey struct {
@@ -260,9 +265,21 @@ func NewRegistry(systemRoot, userRoot string) *Registry {
 		tools:      make(map[string]registeredTool),
 		systemRoot: systemRoot,
 		userRoot:   userRoot,
+		shellMgr:   newShellManager(),
 	}
 	r.registerBuiltins()
 	return r
+}
+
+// Close releases per-Registry resources. Currently terminates every
+// running background shell (started via exec with run_in_background)
+// so they don't outlive their owning agent. Safe to call multiple
+// times. Callers that don't have a clean shutdown hook can omit it —
+// the OS reaps zombies when the FastClaw process exits anyway.
+func (r *Registry) Close() {
+	if r.shellMgr != nil {
+		r.shellMgr.Close()
+	}
 }
 
 // Register adds a tool to the registry (as a built-in tool).
@@ -356,6 +373,8 @@ func (r *Registry) registerBuiltins() {
 	registerExec(r)
 	registerFile(r)
 	registerApplyPatch(r)
+	registerBashOutput(r)
+	registerKillShell(r)
 	registerMessage(r)
 }
 


### PR DESCRIPTION
## Why this tool is necessary

The existing `exec` tool is purely synchronous — `cmd.CombinedOutput()` blocks until the command exits. That coupling between command lifetime and tool-call lifetime breaks for the everyday cases that motivate background process control:

1. **Long-running servers** (`npm run dev`, `go run .`, `python manage.py runserver`) — they never exit naturally. Today the agent has to wait for `tools.exec.timeoutSec` to fire SIGKILL, never seeing the "listening on :3000" log line that confirms startup.
2. **Watch processes** (`cargo watch`, `npm test -- --watch`) — same problem.
3. **Long jobs with progress** (data migrations, model training, batch processing) — agent should be able to poll progress and abort early on error, not block until the very end.
4. **Multiple things at once** — running a server and tail-grepping its log file in parallel.

`apply_patch` (PR #37) fixed cross-file editing efficiency. This PR fixes the other half of the daily agent-coding workflow: long-running subprocess observation.

## Why not a richer `process` tool (OpenAI/OpenClaw style)

The earlier-discussed OpenClaw `process` tool also supports `send-keys`, `paste`, `submit` for driving interactive REPLs (vim, psql, gdb). I deliberately scoped this PR narrower — closer to Claude Code's `BashOutput` / `KillShell` — for two reasons:

- **tmux already does interactive REPL control well**, and the model knows tmux fluently from training. `tmux new-session -d -s <name>` + `tmux send-keys` + `tmux capture-pane` covers everything `process` would, via the existing `exec` tool. We don't gain anything by reinventing it as a typed tool.
- **Keeping the tool surface minimal makes the design reviewable and the implementation small.** Tail-only observation is what 90% of "long-running" cases actually need.

The new tools' shape mirrors Claude Code's exactly so prompts and skills written for that runtime port over without translation.

## Tool surface

```
exec({command: "npm run dev", run_in_background: true})
  → "Started background shell bash_3 for command: npm run dev
     Use bash_output(bash_id="bash_3") to read output, kill_shell(bash_id="bash_3") to terminate."

bash_output({bash_id: "bash_3"})
  → "<new stdout/stderr since last call>
     [status] running"

bash_output({bash_id: "bash_3", filter: "^ERROR"})
  → "ERROR: failed to load module
     [status] running"

kill_shell({bash_id: "bash_3"})
  → "Sent kill to bash_3."

bash_output({bash_id: "bash_3"})
  → "<final output>
     [status] exited (code=-1) — signal: killed"
```

## Implementation notes

### Process group safety (the real teeth of `kill_shell`)

`exec.CommandContext`'s default cancel sends `SIGKILL` only to the direct child (`sh -c "..."`). For commands like `npm run dev`, `sh` execs `npm` which forks `node` — killing `sh` leaves `node` orphaned and still bound to the dev server's port. **Without process-group kill, `kill_shell` would silently fail at its central use case.**

Fix: spawn the child into a fresh process group via `Setpgid: true` (in `bash_session_unix.go`), then override `cmd.Cancel` to send `SIGKILL` to `-pid` (the negative-pid trick for groups). Build-tagged Unix-only; Windows gets a no-op shim. Verified by `TestShellManager_KillReachesGrandchildren` which uses `sh -c "sleep 30 & wait"` — without the group kill, the test times out at the 30-second sleep; with it, it finishes in ~20 ms.

### Output buffer with cursor that survives truncation

Per session: 4 MiB FIFO buffer with absolute byte offsets (\"head\" tracks bytes dropped, \"total\" tracks bytes written). Each session has a `readCursor` for "since last check" semantics. When the buffer rolls past the cursor (long-running noisy server), bash_output prepends a `[truncated]` line so the agent knows it lost some bytes.

Stdout and stderr both write to the same outputBuffer; the buffer's mutex is what makes that safe.

### Race fixes

Two genuine concurrency hazards in the first cut, both fixed and regression-tested:

1. **Read-then-status race**: bytes can land in the buffer AFTER bash_output's `readNew()` but BEFORE its `snapshot()` observes `done=true`. Without a drain, the model sees `[status] exited` while the last bytes — often the most useful, like the error message — are silently held back. Fix: when status is `exited`, do a second `readNew` to drain.
2. **Close + concurrent Start race**: a Start that lands between Close's map-swap and its cancel loop would slip into the new (post-Close) map and never be killed. Fix: `closed` flag set under the same lock that does the map swap; Start checks it both early-out (avoid forking when shutting down) AND under the same lock that does the insert (race-safe verdict).

### Sandbox mode is host-only in v1

`sandbox.Executor` only exposes `Exec(ctx, cmd, timeout)` — no concept of "start now, poll later". v1 returns a clear error when `run_in_background=true` is requested under sandbox, pointing the model at tmux inside the container as the workaround:

```
exec({command: "tmux new-session -d -s job '<cmd>'"})  // start
exec({command: "tmux capture-pane -t job -p"})          // read
exec({command: "tmux kill-session -t job"})             // stop
```

A future PR can add real sandbox-mode background by extending `sandbox.Executor` or by wrapping these tmux commands behind the same tool surface.

### Lifecycle

Sessions outlive turns. They die on:
- explicit `kill_shell`
- natural exit (and remain in the map so the agent can read final output and exit code)
- `Registry.Close()` — agent shutdown kills every running session

## Test coverage

**18 tests**, race-detector clean:

- **outputBuffer**: append/read, FIFO drop (real cap-overflow), reading past end, concurrent write/read.
- **shellManager / bashSession**: echo exits zero, non-zero exit code preserved, kill terminates running, kill is idempotent on exited, kill reaches grandchildren (the regression test for the process-group fix), incremental read advances cursor, Close kills all (with pointers captured BEFORE Close so the assertion is real), Start-after-Close refused.
- **Tool-level**: filter regex, unknown id error, kill_shell on already-exited, kill_shell on running, exec(run_in_background) returns bash_id and bash_output reads its result, bash_output drains tail on exit.

Three rounds of self-review caught and fixed: the process-group leak, a vacuous Close test, the read-then-status race, the Close+Start race, and a description/output mismatch.

## Test plan

- [x] `go test -race ./internal/agent/tools/` (18 cases passing under race detector)
- [x] `go vet ./internal/agent/tools/`
- [x] `GOOS=linux/darwin/windows go build ./internal/agent/tools/` (cross-compiles clean — Unix-specific code is build-tagged)
- [ ] Manual test: model starts a real dev server in background and observes output across turns

## Known limitations (deliberate, not bugs)

- **Sandbox-mode background**: not yet supported (returns clear error pointing at tmux). Follow-up PR.
- **Interactive REPL control**: out of scope; use tmux invoked from regular `exec`.
- **Sessions never auto-evicted from the map after exit**: the agent can read final output indefinitely. Long-running agents that start hundreds of distinct background commands will see linear growth of small per-session structs (~struct + 4 MiB cap). Future PR can add LRU eviction once we see this in practice.
- **WaitDelay not set**: if `cmd.Cancel` ever returned an error and the kernel didn't deliver SIGKILL, `cmd.Wait` could block. In practice SIGKILL on processes we own doesn't fail except for ESRCH (which we treat as success). Defensive `cmd.WaitDelay = 5*time.Second` is a one-line follow-up.