### PR TITLE
feat(agents): create-only `init` + `create`/`new`/`add` aliases

### DIFF
--- a/cmd/fastclaw/cmd_agents.go
+++ b/cmd/fastclaw/cmd_agents.go
@@ -116,7 +116,7 @@ func agentsInitCmd() *cobra.Command {
 	var opts agentcli.InitOptions
 	cmd := &cobra.Command{
 		Use:     "init <name>",
-		Aliases: []string{"create", "new"},
+		Aliases: []string{"create", "new", "add"},
 		Short:   "Create or update an agent in the operator's store",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/fastclaw/cmd_agents.go
+++ b/cmd/fastclaw/cmd_agents.go
@@ -115,9 +115,10 @@ func agentsListCmd() *cobra.Command {
 func agentsInitCmd() *cobra.Command {
 	var opts agentcli.InitOptions
 	cmd := &cobra.Command{
-		Use:   "init <name>",
-		Short: "Create or update an agent in the operator's store",
-		Args:  cobra.ExactArgs(1),
+		Use:     "init <name>",
+		Aliases: []string{"create", "new"},
+		Short:   "Create or update an agent in the operator's store",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			st, err := openStoreFromEnv()
 			if err != nil {

--- a/internal/agentcli/agentcli.go
+++ b/internal/agentcli/agentcli.go
@@ -99,10 +99,16 @@ func Init(ctx context.Context, st store.Store, name string, opts InitOptions) (*
 	if err != nil {
 		return nil, err
 	}
+	// Without --id we treat init as create-only: a name collision is a
+	// mistake (likely a forgotten --id), not an implicit update. --id
+	// remains the documented update path for dashboard-created agents.
+	if existing != nil && opts.AgentID == "" {
+		return nil, fmt.Errorf("agent %q already exists (id %s); use a different name, or pass --id %s to update it", displayName, existing.ID, existing.ID)
+	}
 
-	// Re-initing an existing agent without an explicit --username preserves
-	// the current owner instead of trying to look up the default admin
-	// (which may not be the agent's owner).
+	// Updating an existing agent (--id) without --username preserves the
+	// current owner instead of looking up the default admin (which may
+	// not be the agent's owner).
 	var owner *users.Account
 	var ownerCreated bool
 	var generatedPassword string

--- a/internal/agentcli/agentcli_test.go
+++ b/internal/agentcli/agentcli_test.go
@@ -100,22 +100,45 @@ func TestInitProviderPreflightRunsBeforeWrites(t *testing.T) {
 	}
 }
 
-func TestInitReuseByName(t *testing.T) {
+func TestInitRejectsDuplicateName(t *testing.T) {
 	st := freshStore(t)
 
 	res1, err := Init(context.Background(), st, "alpha", InitOptions{Description: "first"})
 	if err != nil {
 		t.Fatalf("init 1: %v", err)
 	}
-	res2, err := Init(context.Background(), st, "alpha", InitOptions{Description: "second"})
+	_, err = Init(context.Background(), st, "alpha", InitOptions{Description: "second"})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected duplicate-name error, got %v", err)
+	}
+	rec, err := st.GetAgent(context.Background(), res1.Agent.ID)
 	if err != nil {
-		t.Fatalf("init 2: %v", err)
+		t.Fatalf("get: %v", err)
+	}
+	if rec.Config["description"] != "first" {
+		t.Fatalf("description was overwritten despite the rejection: %#v", rec.Config)
+	}
+}
+
+func TestInitUpdatesByExplicitID(t *testing.T) {
+	st := freshStore(t)
+
+	res1, err := Init(context.Background(), st, "alpha", InitOptions{Description: "first"})
+	if err != nil {
+		t.Fatalf("init 1: %v", err)
+	}
+	res2, err := Init(context.Background(), st, "alpha", InitOptions{
+		AgentID:     res1.Agent.ID,
+		Description: "second",
+	})
+	if err != nil {
+		t.Fatalf("update by --id: %v", err)
 	}
 	if res2.Created {
-		t.Fatal("expected re-init to update, not create")
+		t.Fatal("expected --id to update, not create")
 	}
-	if res1.Agent.ID != res2.Agent.ID {
-		t.Fatalf("agent id changed across re-init: %s -> %s", res1.Agent.ID, res2.Agent.ID)
+	if res2.Agent.ID != res1.Agent.ID {
+		t.Fatalf("agent id changed: %s -> %s", res1.Agent.ID, res2.Agent.ID)
 	}
 	if res2.Agent.Config["description"] != "second" {
 		t.Fatalf("description not updated: %#v", res2.Agent.Config)
@@ -164,16 +187,19 @@ func TestInitRejectsRebindToOtherUser(t *testing.T) {
 		t.Fatalf("create bob: %v", err)
 	}
 
-	// Re-init with --username bob: must refuse.
-	_, err = Init(context.Background(), st, "alpha", InitOptions{Username: "bob"})
+	// Update via --id with --username bob: must refuse the silent rebind.
+	_, err = Init(context.Background(), st, "alpha", InitOptions{
+		AgentID:  res1.Agent.ID,
+		Username: "bob",
+	})
 	if err == nil || !strings.Contains(err.Error(), "is owned by user") {
 		t.Fatalf("expected rebind refusal, got %v", err)
 	}
 
-	// Re-init without --username: owner preserved.
-	res3, err := Init(context.Background(), st, "alpha", InitOptions{})
+	// Update via --id without --username: owner preserved.
+	res3, err := Init(context.Background(), st, "alpha", InitOptions{AgentID: res1.Agent.ID})
 	if err != nil {
-		t.Fatalf("re-init: %v", err)
+		t.Fatalf("update by --id: %v", err)
 	}
 	if res3.Agent.UserID != res1.Agent.UserID {
 		t.Fatalf("owner silently rebound: %s -> %s", res1.Agent.UserID, res3.Agent.UserID)


### PR DESCRIPTION
## Summary

Two related changes to `fastclaw agents init`:

### 1. `init` is now create-only

Previously `agents init <name>` upserted: re-running with the same name silently updated the existing agent. That was easy to miss — a typo or a forgotten `--id` would mutate the wrong record.

A name collision now returns an error pointing at the existing `agt_` id. Updates still go through `--id`, which has always been the documented way to update an agent created elsewhere (e.g. via the dashboard).

```
$ fastclaw agents init alpha
Agent "alpha" created
$ fastclaw agents init alpha
Error: agent "alpha" already exists (id agt_xxx); use a different name, or pass --id agt_xxx to update it
```

### 2. Aliases: `create`, `new`, `add`

Most users reach for `create`/`new`/`add` to make a thing — `init` is the less common naming. All three are now cobra aliases for the canonical `init` command. With create-only semantics, `add` is an accurate alias too (it would have been misleading under the old upsert behavior).

```
fastclaw agents init my-agent      # canonical
fastclaw agents create my-agent    # alias
fastclaw agents new my-agent       # alias
fastclaw agents add my-agent       # alias
```

## Test plan

- [x] `go test ./internal/agentcli/... ./cmd/fastclaw/...` passes
- [x] New `TestInitRejectsDuplicateName` covers the error path
- [x] New `TestInitUpdatesByExplicitID` confirms `--id` still updates
- [x] `TestInitRejectsRebindToOtherUser` reframed around `--id` (the new update path)