### PR TITLE
fix(models): use dash-separated Anthropic model IDs

### DIFF
--- a/internal/scope/fallback_test.go
+++ b/internal/scope/fallback_test.go
@@ -50,15 +50,15 @@ func TestSettingPrecedence_AgentBeatsUserBeatsSystem(t *testing.T) {
 
 	// agent-scope override on top
 	if err := SaveSetting(ctx, db, "", agentID, "agents.defaults",
-		map[string]interface{}{"model": "anthropic/claude-opus-4.7"}); err != nil {
+		map[string]interface{}{"model": "anthropic/claude-opus-4-7"}); err != nil {
 		t.Fatalf("save agent: %v", err)
 	}
 	got = config.AgentDefaults{}
 	if err := SettingInto(ctx, db, "agents.defaults", userID, agentID, &got); err != nil {
 		t.Fatalf("setting into: %v", err)
 	}
-	if got.Model != "anthropic/claude-opus-4.7" {
-		t.Fatalf("agent should beat user: want anthropic/claude-opus-4.7, got %q", got.Model)
+	if got.Model != "anthropic/claude-opus-4-7" {
+		t.Fatalf("agent should beat user: want anthropic/claude-opus-4-7, got %q", got.Model)
 	}
 
 	// Verify the raw agent-scope row reads what we wrote, independent of
@@ -72,8 +72,8 @@ func TestSettingPrecedence_AgentBeatsUserBeatsSystem(t *testing.T) {
 	if rec == nil {
 		t.Fatal("agent-scope row missing after save")
 	}
-	if v, _ := rec.Data["model"].(string); v != "anthropic/claude-opus-4.7" {
-		t.Fatalf("agent-scope row model: want anthropic/claude-opus-4.7, got %q", v)
+	if v, _ := rec.Data["model"].(string); v != "anthropic/claude-opus-4-7" {
+		t.Fatalf("agent-scope row model: want anthropic/claude-opus-4-7, got %q", v)
 	}
 
 	// Delete agent-scope (empty data) → falls back to user-scope.

--- a/web/src/app/agents/[id]/models/page.tsx
+++ b/web/src/app/agents/[id]/models/page.tsx
@@ -65,7 +65,7 @@ const PROVIDER_PRESETS: Record<
 > = {
   openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token", models: ["gpt-5.5"] },
   openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
-  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-opus-4.7", "claude-sonnet-4.7", "claude-haiku-4.5"] },
+  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-opus-4-7", "claude-sonnet-4-7", "claude-haiku-4-5"] },
   deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token", models: ["deepseek-v4-pro", "deepseek-v4-flash"] },
   ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
   custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token", models: [] },

--- a/web/src/app/models/page.tsx
+++ b/web/src/app/models/page.tsx
@@ -57,7 +57,7 @@ const PROVIDER_PRESETS: Record<
 > = {
   openai: { apiBase: "https://api.openai.com/v1", apiType: "openai-chat", authType: "bearer-token", models: ["gpt-5.5"] },
   openrouter: { apiBase: "https://openrouter.ai/api/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
-  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-opus-4.7", "claude-sonnet-4.7", "claude-haiku-4.5"] },
+  anthropic: { apiBase: "https://api.anthropic.com", apiType: "anthropic-messages", authType: "api-key", models: ["claude-opus-4-7", "claude-sonnet-4-7", "claude-haiku-4-5"] },
   deepseek: { apiBase: "https://api.deepseek.com", apiType: "openai-chat", authType: "bearer-token", models: ["deepseek-v4-pro", "deepseek-v4-flash"] },
   ollama: { apiBase: "http://localhost:11434/v1", apiType: "openai-chat", authType: "bearer-token", models: [] },
   custom: { apiBase: "", apiType: "openai-chat", authType: "bearer-token", models: [] },

--- a/web/src/app/onboard/page.tsx
+++ b/web/src/app/onboard/page.tsx
@@ -94,7 +94,7 @@ const PROVIDERS: Record<
     apiBase: "https://api.anthropic.com",
     apiType: "anthropic-messages",
     authType: "api-key",
-    models: ["claude-opus-4.7", "claude-sonnet-4.7", "claude-haiku-4.5"],
+    models: ["claude-opus-4-7", "claude-sonnet-4-7", "claude-haiku-4-5"],
   },
   deepseek: {
     apiBase: "https://api.deepseek.com",


### PR DESCRIPTION
## Summary

Anthropic uses dashes (not dots) in its model version IDs — `claude-opus-4-7`, `claude-sonnet-4-7`, `claude-haiku-4-5`. The provider presets shipped the dotted form (`claude-opus-4.7`, etc.), which the Anthropic API rejects.

## Changes

- `web/src/app/onboard/page.tsx`
- `web/src/app/models/page.tsx`
- `web/src/app/agents/[id]/models/page.tsx`
- `internal/scope/fallback_test.go` — test fixture using `anthropic/claude-opus-4.7`

## Test plan

- [ ] On the onboarding / models / agent-models pages, the Anthropic preset now offers `claude-opus-4-7`, `claude-sonnet-4-7`, `claude-haiku-4-5`
- [ ] `go test ./internal/scope/...` passes