### PR TITLE
refactor(agent): replace auto plan-mode with /plan slash command

### DIFF
--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -24,53 +24,6 @@ var bootstrapFiles = []string{
 	"IDENTITY.md",
 }
 
-// autoPlanPrompt teaches the agent to decide on its own whether the
-// user's request warrants a plan-before-execute turn vs an immediate
-// answer/action. Replaces the explicit Plan toggle in the composer —
-// users shouldn't have to know the term "plan mode" or remember to
-// flip a switch on long prompts. The model has all the context to
-// make this call.
-const autoPlanPrompt = `# Decide whether to plan before acting
-
-Before doing any work, look at the request and pick one of two shapes:
-
-**Plan first** (emit a numbered plan, no tool calls, end with "Reply ` + "`go`" + ` to execute, or tell me what to change."):
-
-- Request decomposes into 3+ distinct phases (research → synthesis →
-  delivery; or "find N X across K categories then write Y for each").
-- Long structured deliverable expected (table with many rows, multi-
-  section report, multiple emails).
-- Mentions a number that implies repetition ("find 50 leads", "review
-  these 8 docs", "draft emails for each of the following").
-- Anything that would naturally use ` + "`delegate_task`" + ` for fan-out, or
-  that you can see hitting the iteration cap if you try to one-shot
-  it.
-
-**Skip the plan, act immediately** for:
-
-- Single-shot questions ("what is X?", "calculate Y", "fix this bug").
-- Direct commands that map to one or two tool calls ("read foo.md and
-  summarize", "search for X").
-- Conversational replies, clarifications, status checks.
-- The user already said "go" / "do it" / "yes" — they previously saw
-  a plan and are now authorizing execution. Execute now, don't re-plan.
-  (Confirmations in the user's natural language also count; recognise
-  intent, not exact words.)
-
-**When you plan**: do NOT call any tools during the plan turn — the
-plan IS your reply. Tools are still listed in your catalog but
-deliberately holding off lets the user steer. Reference tool names
-in plan steps so the user sees what you intend to invoke (e.g.
-"Step 3: Use ` + "`delegate_task`" + ` to find 10 X").
-
-**When the user replies after a plan**: their next message is either
-a confirmation or edits. Treat confirmation as authorization to
-execute every step end-to-end — don't ask permission step by step,
-and don't write another plan. Just do it. If they edited the plan,
-apply the edits and execute the revised version.
-
-`
-
 // taskDelegationPrompt teaches the agent when to reach for delegate_task.
 // Without this, even when the tool description is in the tool catalog,
 // flash-tier models keep cramming all the work into their own loop and
@@ -199,7 +152,6 @@ type ContextBuilder struct {
 	thinking       string // off, low, medium, high, adaptive
 	sandboxEnabled bool
 	sandboxBackend string
-	goalActive     bool // when true, omit autoPlanPrompt — see SetGoalActive
 	store   MemoryStore
 	userID  string
 	agentID string
@@ -234,29 +186,6 @@ func (cb *ContextBuilder) SetWorkspace(p string) { cb.workspace = p }
 // store at turn start end up visible to the model without rebuilding the
 // whole context builder.
 func (cb *ContextBuilder) SetSkillsSummary(s string) { cb.skillsSummary = s }
-
-// SetGoalActive flags the current turn as belonging to an active goal
-// session. When true, BuildSystemPrompt omits autoPlanPrompt:
-//
-//   - Plan's contract ("emit a numbered plan, no tool calls, end with
-//     'Reply `go` to execute'") demands a human checkpoint; goal's
-//     contract ("iterate autonomously until done") forbids one. With
-//     both injected, the model emits a plan-only turn that the goal
-//     continuation hook then auto-resumes — a "pseudo-plan" turn that
-//     wastes a round and misleads the UI (the "Reply `go`" approve
-//     buttons render even though no one will wait for the user's `go`).
-//
-//   - Removing the prompt is preferred over adding a counter-instruction.
-//     A negative "don't write a plan-first turn" risks the model
-//     over-generalizing to "don't structure your thinking at all";
-//     simply not teaching the plan-first shape leaves general reflective
-//     capability intact (audit checklist in goal continuation + todo.md
-//     in taskDelegationPrompt already cover structured progress).
-//
-// Caller (loop.go) sets this per turn from sessionHasActiveGoal — the
-// ContextBuilder is shared across turns on an Agent, so the flag must be
-// set explicitly on every turn or stale state leaks.
-func (cb *ContextBuilder) SetGoalActive(active bool) { cb.goalActive = active }
 
 // BuildSystemPrompt assembles the system prompt from identity, bootstrap files, memory, and skills.
 // Reads everything under the agent owner's bucket — equivalent to the
@@ -483,21 +412,8 @@ Then in your final reply, write: ![](/workspace/output.png)`
 		parts = append(parts, sandboxPrompt)
 	}
 
-	// Auto-plan + task delegation guidance — both shape how the model
-	// approaches multi-step work, so they live ahead of bootstrap files
-	// (which can carry agent-specific persona overrides). Order matters:
-	// auto-plan covers the "do I plan or act?" branch first, delegation
-	// then teaches the planning model what tool to write into the steps.
-	//
-	// autoPlanPrompt is suppressed when this turn belongs to an active
-	// goal session. See SetGoalActive for the rationale. taskDelegationPrompt
-	// stays in — its "Plan first when delegating" subsection is conditioned
-	// on plan mode actually being on, so in a goal session it naturally
-	// becomes a no-op, and the surrounding delegate_task / todo.md guidance
-	// is still useful.
-	if !cb.goalActive {
-		parts = append(parts, autoPlanPrompt)
-	}
+	// Task delegation guidance lives ahead of bootstrap files so per-
+	// agent persona overrides can still reshape downstream behavior.
 	parts = append(parts, taskDelegationPrompt)
 
 	// 3. Bootstrap files. USER.md is the only per-chatter entry — it

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1228,94 +1226,6 @@ func isPlanMode(params map[string]any) bool {
 	return false
 }
 
-// looksLikeComplexFirstTurn is the server-side heuristic that decides
-// whether a fresh-session user message is "Wayne-class" — long, multi-
-// section, asks for a structured deliverable — and should be force-
-// routed through plan mode even though the user didn't toggle it.
-//
-// Trusting the LLM to self-detect via the system prompt's autoPlanPrompt
-// proved unreliable (especially with flash-tier models that just dive
-// into web_fetch). This is a backstop: tight enough to not trigger on
-// "hi, what can you do" but loose enough to catch the lead-research /
-// research-then-synthesize / find-N-of-X shape.
-//
-// Returns true iff ALL of:
-//   - message length >= 400 chars (rules out short Qs that happen to
-//     contain numbers in passing)
-//   - signal count >= 2 among:
-//     · 3+ numbered section markers (一、二、三、… or 1./2./3.)
-//     · explicit count >= 10 ("50 leads" / "找 50 个" / "list 20")
-//     · multi-line bullet list (4+ "- " / "* " lines)
-//     · keywords typical of structured-deliverable prompts
-//     (ICP / 表格 / table / list of / draft N / 报告 / report)
-//
-// Two-signal threshold keeps the false-positive rate low: a long but
-// open-ended discussion ("explain how X works in detail") trips at
-// most one signal and stays in normal mode.
-func looksLikeComplexFirstTurn(text string) bool {
-	if len(text) < 400 {
-		return false
-	}
-	signals := 0
-
-	// Section markers: Chinese 一、 through 十、 plus Western "1." "2." "3."
-	// at line starts. Want at least three to count.
-	cnSections := regexp.MustCompile(`[一二三四五六七八九十][、。．]`)
-	if len(cnSections.FindAllString(text, -1)) >= 3 {
-		signals++
-	} else {
-		// Look for ordered-list openers at the start of distinct lines.
-		// Three "1. … 2. … 3. …" pattern is enough.
-		ordered := regexp.MustCompile(`(?m)^\s*[1-9][.\)、]\s+`)
-		if len(ordered.FindAllString(text, -1)) >= 3 {
-			signals++
-		}
-	}
-
-	// Explicit numeric count >= 10 + repetition word.
-	countRe := regexp.MustCompile(`(?i)(\d{2,})\s*(个|名|位|leads?|items?|rows?|emails?|prospects?|clients?|companies)`)
-	if m := countRe.FindStringSubmatch(text); len(m) >= 2 {
-		if n, err := strconv.Atoi(m[1]); err == nil && n >= 10 {
-			signals++
-		}
-	} else {
-		// Variant: "find / list / draft / 找 / 写 / 挖掘" + number
-		findRe := regexp.MustCompile(`(?i)(find|list|draft|search|挖掘|找|写|生成|寻找)[^\n]{0,20}\d{2,}`)
-		if findRe.MatchString(text) {
-			signals++
-		}
-	}
-
-	// Bullet list of 4+ distinct items — strong "structured asks" signal.
-	bullets := regexp.MustCompile(`(?m)^\s*[-*]\s+\S`)
-	if len(bullets.FindAllString(text, -1)) >= 4 {
-		signals++
-	}
-
-	// Structured-deliverable keywords. ICP / table / report / 表格 / 报告 /
-	// 模板 / template / each of. Cheap one-shot scan.
-	kwRe := regexp.MustCompile(`(?i)(ICP|表格|table\b|报告|report\b|deliverable|each of|每一个|每个).{0,40}(table|表|list|report|报告|each|delivery|交付|outputs?|输出)?`)
-	if kwRe.MatchString(text) {
-		// Cap a single-keyword to one signal so a message that just
-		// mentions "ICP" doesn't ride three matches into auto-plan.
-		signals++
-	}
-
-	return signals >= 2
-}
-
-// sessionAlreadyEngaged reports whether the session already has an
-// assistant reply. We only auto-plan on the FIRST user message of a
-// session — re-planning every long follow-up would be obnoxious.
-func sessionAlreadyEngaged(sess *session.Session) bool {
-	for _, m := range sess.GetMessages() {
-		if m.Role == "assistant" && (m.Content != "" || len(m.ToolCalls) > 0) {
-			return true
-		}
-	}
-	return false
-}
-
 // planModeNudge is the system message we prepend on plan-mode turns.
 // Spells out the contract: tools are server-side disabled THIS turn so
 // don't attempt them; they WILL be available on the next turn when the
@@ -1421,11 +1331,6 @@ func (a *Agent) handlePlanMode(ctx context.Context, msg bus.InboundMessage) stri
 		return noProviderMsg
 	}
 
-	// handlePlanMode is only reached when sessionHasActiveGoal is false
-	// (see HandleMessage gate at the planMode check), but the
-	// ContextBuilder is shared across turns so we set the flag
-	// explicitly to avoid stale state from a prior goal-active turn.
-	a.ctxBuilder.SetGoalActive(false)
 	systemPrompt := a.ctxBuilder.BuildSystemPromptAs(chatterUID, a.memory.WithUserID(chatterUID))
 	// Tool catalog injection: plan mode passes tools=nil to the LLM so
 	// it can't accidentally call anything, but that also hides the
@@ -1498,48 +1403,6 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 		return result.reply
 	}
 
-	// Auto-trigger plan mode when the FIRST user message of a session
-	// looks like a Wayne-class structured-deliverable request (long,
-	// numbered sections, asks for 10+ rows/leads, etc.). Trusting the
-	// LLM's autoPlanPrompt to self-detect was unreliable on flash-tier
-	// models — they kept diving straight into web_fetch. The heuristic
-	// only fires on the first turn of a session so a user mid-execution
-	// asking a long follow-up doesn't get re-planned.
-	//
-	// Two opt-outs that take precedence over the heuristic:
-	//
-	//   1. Runtime-originated turns (cron / heartbeat / sub-agent /
-	//      goal_context). The /goal continuation template has a
-	//      1./2./3./4. audit checklist + the word "deliverables" —
-	//      exactly what the heuristic was designed to catch on real
-	//      users. And the `/goal foo` slash that precedes the first
-	//      continuation doesn't `sess.Append`, so sessionAlreadyEngaged
-	//      is still false when the continuation lands. Without this
-	//      gate, every first continuation gets force-routed into
-	//      plan-mode.
-	//
-	//   2. Session has an active goal. plan-mode and goal are
-	//      semantically opposed — plan says "wait for me to approve",
-	//      goal says "iterate autonomously until done". If a goal is
-	//      running, even a user's regular turn shouldn't be forced
-	//      into plan-mode behind their back: that would interrupt the
-	//      autonomous loop. Goal takes precedence, by design.
-	autoPlanEligible := (msg.Source == "" || msg.Source == bus.SourceUser) &&
-		!a.sessionHasActiveGoal(ctx, msg)
-	if autoPlanEligible && !isPlanMode(msg.Params) && msg.Text != "" {
-		sess := a.sessions.Get(msg.Channel, msg.AccountID, msg.ChatID, msg.ProjectID)
-		if !sessionAlreadyEngaged(sess) && looksLikeComplexFirstTurn(msg.Text) {
-			slog.Info("auto-routing to plan mode",
-				"agent", a.name,
-				"chat_id", msg.ChatID,
-				"len", len(msg.Text))
-			if msg.Params == nil {
-				msg.Params = map[string]any{}
-			}
-			msg.Params["planMode"] = true
-		}
-	}
-
 	// Plan mode short-circuits the ReAct loop: tools off, the model
 	// emits a numbered plan, the user reviews it and replies normally
 	// (no planMode flag) on the next turn to execute. Lets users catch
@@ -1603,10 +1466,6 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 	// Hook: BeforeSystemPrompt
 	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: BeforeSystemPrompt, UserID: a.ownerUserID})
 
-	// Suppress autoPlanPrompt when a goal owns this session — plan's
-	// "wait for `go`" semantics fight goal's autonomous-loop contract.
-	// See ContextBuilder.SetGoalActive.
-	a.ctxBuilder.SetGoalActive(a.sessionHasActiveGoal(ctx, msg))
 	chatterMem := a.memory.WithUserID(chatterUID)
 	systemPrompt := a.ctxBuilder.BuildSystemPromptAs(chatterUID, chatterMem)
 
@@ -2180,8 +2039,6 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 	defer padOrphanToolResults(sess)
 
 	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: BeforeSystemPrompt, UserID: a.ownerUserID})
-	// See HandleMessage twin for rationale on SetGoalActive.
-	a.ctxBuilder.SetGoalActive(a.sessionHasActiveGoal(ctx, msg))
 	chatterMem := a.memory.WithUserID(chatterUID)
 	systemPrompt := a.ctxBuilder.BuildSystemPromptAs(chatterUID, chatterMem)
 	a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: AfterSystemPrompt, UserID: a.ownerUserID})

--- a/internal/agent/slash.go
+++ b/internal/agent/slash.go
@@ -118,6 +118,9 @@ func (a *Agent) handleSlashCommand(msg bus.InboundMessage) slashResult {
 	case "/goal":
 		return a.slashGoal(msg, args)
 
+	case "/plan":
+		return a.slashPlan(msg, args)
+
 	case "/help":
 		return slashResult{handled: true, reply: a.slashHelp()}
 
@@ -479,6 +482,9 @@ Goal (persistent multi-turn objective)
   /goal resume      — Resume a paused goal
   /goal clear       — Delete the goal
 
+Plan
+  /plan <task>      — Run <task> in plan mode: emit a numbered plan, no tool calls
+
 Info
   /help           — Show this help
   /version        — Show version
@@ -487,6 +493,38 @@ Info
 🔒 Write commands (/new /reset /undo /retry /compact /model /personality)
    in IM channels are restricted to the agent owner + admins listed in
    agent.json's "admins" field. Use /whoami to find your ID.`
+}
+
+// slashPlan handles `/plan <task>`: republish the rest of the message
+// onto bus.Inbound with planMode=true so the regular HandleMessage path
+// routes it into handlePlanMode. Manual replacement for the auto-plan
+// heuristic — users opt in explicitly per turn rather than the server
+// guessing from message shape.
+func (a *Agent) slashPlan(msg bus.InboundMessage, args []string) slashResult {
+	task := strings.TrimSpace(strings.Join(args, " "))
+	if task == "" {
+		return slashResult{handled: true, reply: "Usage: `/plan <task>`"}
+	}
+
+	// Clone the inbound msg so routing fields (channel, account, chat,
+	// project, user, sender, owner) carry over verbatim. Rewrite only
+	// Text and Params — the plan-mode flag is what handlePlanMode keys
+	// on (see isPlanMode in loop.go).
+	out := msg
+	out.Text = task
+	params := map[string]any{}
+	for k, v := range msg.Params {
+		params[k] = v
+	}
+	params["planMode"] = true
+	out.Params = params
+
+	select {
+	case a.messageBus.Inbound <- out:
+		return slashResult{handled: true, reply: "", continuationQueued: true}
+	default:
+		return slashResult{handled: true, reply: "Bus full, try again."}
+	}
 }
 
 func truncateSlash(s string, n int) string {


### PR DESCRIPTION
## Summary

Removes the implicit auto plan-mode routing and replaces it with an explicit `/plan <task>` slash command.

Previously two mechanisms could silently force a user's turn into plan-mode:
- `autoPlanPrompt` in the system prompt (LLM self-elected based on shape).
- `looksLikeComplexFirstTurn` server-side heuristic (regex match on length / section markers / count keywords).

Both rewrote the user's intent without consent. The judgment criteria are opaque, so users couldn't predict when planning would kick in and ended up phrasing around the heuristic instead of benefiting from it. The new behavior: nothing auto-triggers — users who want a plan pass through `/plan <task>` (slash) or toggle the existing composer button. Both routes land in the same `handlePlanMode` path.

## Changes

- **New**: `/plan <task>` slash command in `slash.go`. Republishes the task text onto `messageBus.Inbound` with `Params["planMode"] = true`, then returns `continuationQueued: true` so the SSE stream stays open.
- **Removed**:
  - `autoPlanPrompt` const + the conditional append in `BuildSystemPromptAs`.
  - `goalActive` field + `SetGoalActive` method (only existed to suppress `autoPlanPrompt` inside goal sessions; obsolete).
  - `looksLikeComplexFirstTurn` + `sessionAlreadyEngaged` + the auto-routing block in `HandleMessage`.
  - 3 `SetGoalActive` call sites.
  - Unused `regexp` / `strconv` imports.
- **Preserved**: `isPlanMode`, `handlePlanMode`, `planModeNudge`, `buildToolCatalogForPlan`, and the frontend composer plan-mode toggle (its `params.planMode=true` flag goes straight to `handlePlanMode`).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `/plan find me X` produces a plan-only turn
- [ ] Manual: composer plan-mode toggle still works
- [ ] Manual: a previously-auto-routed long structured message now executes normally
- [ ] Manual: `/plan` with no args returns the usage hint