### PR TITLE
feat(agent): mid-run steering — command the agent while it works

### DIFF
--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -8,7 +8,7 @@ import (
 
 // ChatEvent represents a real-time event emitted during the agent ReAct loop.
 type ChatEvent struct {
-	Type string         `json:"type"` // "content", "tool_call", "tool_result", "error", "done"
+	Type string         `json:"type"` // "content", "content_delta", "tool_call", "tool_result", "steer", "error", "done", "turn_pending", "subagent_progress"
 	Data map[string]any `json:"data,omitempty"`
 }
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -403,6 +403,46 @@ func (a *Agent) HandleWebChatStream(ctx context.Context, sessionId, projectIDHin
 	return a.HandleMessage(ctx, msg)
 }
 
+// SteerWeb buffers a steering message for an in-flight web turn on the
+// given session. Returns true if a turn was active and the message was
+// buffered (the running loop will fold it in between tool rounds and
+// emit a "steer" event on the existing SSE), false if no turn is
+// running — in which case the caller should fall back to a normal send.
+// Session resolution mirrors HandleWebChatStream exactly so we land on
+// the same *session.Session pointer the running turn holds.
+func (a *Agent) SteerWeb(sessionId, projectIDHint, text string) bool {
+	if sessionId == "" {
+		sessionId = "web-ui"
+	}
+	channel, accountID, chatID, projectID := a.recoverWebTriple(sessionId)
+	if projectID == "" {
+		projectID = projectIDHint
+	}
+	sess := a.sessions.Get(channel, accountID, chatID, projectID)
+	return sess.PushSteerIfActive(provider.Message{
+		Role:      "user",
+		Content:   text,
+		Timestamp: time.Now().UnixMilli(),
+	})
+}
+
+// SteerInbound buffers a steering message for an in-flight turn keyed by
+// the inbound message's (channel, accountID, chatID, projectID) — the
+// SAME fields HandleMessage resolves the session with (NOT the
+// taskqueue's per-agent accountID), so the pointer matches the running
+// turn. `text` is the already-formatted body the Submit path would have
+// delivered (e.g. the group `\[name\]:` prefix). Returns false when no
+// turn is active so the caller falls back to taskQueue.Submit.
+func (a *Agent) SteerInbound(msg bus.InboundMessage, text string) bool {
+	sess := a.sessions.Get(msg.Channel, msg.AccountID, msg.ChatID, msg.ProjectID)
+	return sess.PushSteerIfActive(provider.Message{
+		Role:      "user",
+		Content:   text,
+		Metadata:  senderMetadata(msg),
+		Timestamp: time.Now().UnixMilli(),
+	})
+}
+
 // recoverWebTriple maps a URL `?session=` token (which can be a
 // session_key for any channel, OR a legacy web chat_id) to the full
 // (channel, accountID, chatID, projectID) tuple downstream callers
@@ -1316,6 +1356,12 @@ func (a *Agent) handlePlanMode(ctx context.Context, msg bus.InboundMessage) stri
 	chatterUID := a.chatterUserID(msg)
 	ctx = sandbox.WithUserID(ctx, chatterUID)
 	sess := a.sessions.Get(msg.Channel, msg.AccountID, msg.ChatID, msg.ProjectID)
+	// Steering during plan drafting: plan mode has no ReAct loop to drain
+	// into, so a mid-draft steer is parked in history and answered on
+	// the user's next turn — which matches the plan-mode contract
+	// (review the plan, then reply to execute).
+	sess.BeginTurn()
+	defer a.flushLeftoverSteer(sess)
 	defer padOrphanToolResults(sess)
 
 	// Mirror the regular path's user-message construction so multimodal
@@ -1376,6 +1422,39 @@ func (a *Agent) handlePlanMode(ctx context.Context, msg bus.InboundMessage) stri
 	}})
 	emitEvent(ctx, ChatEvent{Type: "done"})
 	return resp.Content
+}
+
+// appendSteer folds drained steer messages into the running turn: each
+// is persisted to the session, added to the live LLM message slice, and
+// echoed as a "steer" event so the web UI renders it as a user bubble
+// (persisted → late-join backfill + seq-dedup work for free).
+func (a *Agent) appendSteer(ctx context.Context, sess *session.Session, messages []provider.Message, steer []provider.Message) []provider.Message {
+	for _, sm := range steer {
+		sess.Append(sm)
+		messages = append(messages, sm)
+		emitEvent(ctx, ChatEvent{Type: "steer", Data: map[string]any{"content": sm.Content}})
+		slog.Info("steer message folded into running turn", "agent", a.name)
+	}
+	return messages
+}
+
+// flushLeftoverSteer handles the end-of-turn race: a steer accepted by
+// PushSteerIfActive after the loop's last drain but before the turn was
+// declared done (realistically only the max-iteration synthesis call,
+// an errored turn, or a sub-millisecond window — the between-rounds and
+// pre-done drains cover every normal path). It's persisted to history
+// so it isn't lost and rides the next turn's context; we deliberately
+// do NOT re-run a hidden turn for it (kept simple + avoids the
+// IM-has-no-reply asymmetry of a recursive redispatch).
+func (a *Agent) flushLeftoverSteer(sess *session.Session) {
+	leftover := sess.EndTurn()
+	for _, m := range leftover {
+		sess.Append(m)
+	}
+	if len(leftover) > 0 {
+		slog.Warn("steer arrived at end of turn; parked in history for the next turn",
+			"agent", a.name, "count", len(leftover))
+	}
 }
 
 // HandleMessage processes an inbound message through the ReAct loop.
@@ -1445,6 +1524,15 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 	// identifier); goal tools need the durable session.Session.SessionKey
 	// to address rows in agent_goals.
 	a.registry.SetGoalSessionKey(sess.SessionKey())
+
+	// Steering: mark a turn in-flight so messages arriving mid-run are
+	// buffered onto the session (drained between tool iterations below)
+	// instead of starting a separate turn. flushLeftoverSteer parks any
+	// steer that lost the end-of-turn race into history. Registered
+	// before padOrphanToolResults so it runs LAST (defers are LIFO) —
+	// orphan padding settles history first.
+	sess.BeginTurn()
+	defer a.flushLeftoverSteer(sess)
 
 	// Safety net for client-aborted turns: if the loop exits with a
 	// tool_use that never got its matching tool_result appended (the
@@ -1585,8 +1673,25 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 		a.meterTokens(ctx, sess.Key(), resp.Usage)
 
 		if !resp.HasToolCalls() {
-			sess.Append(provider.Message{Role: "assistant", Content: resp.Content, Thinking: resp.Thinking, Timestamp: time.Now().UnixMilli(), RawAssistant: resp.RawAssistant})
+			asst := provider.Message{Role: "assistant", Content: resp.Content, Thinking: resp.Thinking, Timestamp: time.Now().UnixMilli(), RawAssistant: resp.RawAssistant}
+			sess.Append(asst)
 			emitEvent(ctx, ChatEvent{Type: "content", Data: map[string]any{"content": resp.Content}})
+			// End-of-turn steer race: a message buffered after the last
+			// between-rounds drain but before we declare the turn done.
+			// Fold it in and keep going instead of returning, so the
+			// user's mid-flight instruction isn't deferred to a new turn.
+			if steer := sess.DrainSteer(); len(steer) > 0 {
+				// Carry the just-produced answer into the next LLM call
+				// only when it has text. A no-text, no-tool-call
+				// assistant message is an invalid turn for Anthropic
+				// (an assistant turn needs a non-empty content block),
+				// and this is the only path that would re-send one.
+				if resp.Content != "" {
+					messages = append(messages, asst)
+				}
+				messages = a.appendSteer(ctx, sess, messages, steer)
+				continue
+			}
 			emitEvent(ctx, ChatEvent{Type: "done"})
 			a.runPostTurn(ctx, msg, messages, totalToolCalls, chatterMem)
 			return resp.Content
@@ -1812,6 +1917,13 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 			allFailedRounds++
 		} else {
 			allFailedRounds = 0
+		}
+
+		// Steering: messages that arrived while this tool round ran are
+		// folded in here, between rounds, so the next LLM call sees them
+		// and can change course.
+		if steer := sess.DrainSteer(); len(steer) > 0 {
+			messages = a.appendSteer(ctx, sess, messages, steer)
 		}
 	}
 

--- a/internal/gateway/routing.go
+++ b/internal/gateway/routing.go
@@ -103,6 +103,30 @@ func (g *Gateway) resolveChannelOwner(ctx context.Context, msg bus.InboundMessag
 	return ""
 }
 
+// trySteer diverts msg into target's currently in-flight turn instead of
+// queuing a separate one. `text` is the body the Submit path would have
+// delivered. Returns true when the message was folded into a running
+// turn — the caller must then NOT also Submit. False means no turn is
+// active; fall back to taskQueue.Submit.
+func (g *Gateway) trySteer(target *agent.Agent, msg bus.InboundMessage, text string) bool {
+	if target == nil || !target.SteerInbound(msg, text) {
+		return false
+	}
+	slog.Info("message steered into in-flight turn",
+		"agent", target.Name(), "channel", msg.Channel, "chat_id", msg.ChatID)
+	return true
+}
+
+// groupSteerText mirrors the `\[name\]: body` sender labeling
+// buildUserMessage applies to queued group turns, so a steered message
+// gives the model the same speaker context a normal group turn would.
+func groupSteerText(msg bus.InboundMessage) string {
+	if msg.SenderName == "" {
+		return msg.Text
+	}
+	return fmt.Sprintf("\\[%s\\]: %s", msg.SenderName, msg.Text)
+}
+
 func (g *Gateway) routeDM(ctx context.Context, msg bus.InboundMessage) {
 	space, err := g.users.getOrLoad(ctx, msg.OwnerUserID)
 	if err != nil {
@@ -119,6 +143,9 @@ func (g *Gateway) routeDM(ctx context.Context, msg bus.InboundMessage) {
 	slog.Info("routing DM",
 		"user", msg.OwnerUserID, "channel", msg.Channel,
 		"chat_id", msg.ChatID, "agent", ag.Name())
+	if g.trySteer(ag, msg, msg.Text) {
+		return
+	}
 	g.taskQueue.Submit(ag.Name(), chatKey(msg.Channel, msg.AccountID, msg.ChatID), msg, msg.AccountID)
 }
 
@@ -143,7 +170,9 @@ func (g *Gateway) routeGroup(ctx context.Context, msg bus.InboundMessage) {
 				triggerMsg := msg
 				triggerMsg.Text = fmt.Sprintf("\\[%s\\]: %s", msg.SenderName, msg.Text)
 				triggerMsg.IsBotMessage = false
-				g.taskQueue.Submit(target.Name(), chatKey(triggerMsg.Channel, triggerMsg.AccountID, triggerMsg.ChatID), triggerMsg, g.accountIDForAgent(space, target.Name(), triggerMsg.Channel))
+				if !g.trySteer(target, triggerMsg, triggerMsg.Text) {
+					g.taskQueue.Submit(target.Name(), chatKey(triggerMsg.Channel, triggerMsg.AccountID, triggerMsg.ChatID), triggerMsg, g.accountIDForAgent(space, target.Name(), triggerMsg.Channel))
+				}
 			}
 		}
 		return
@@ -158,7 +187,9 @@ func (g *Gateway) routeGroup(ctx context.Context, msg bus.InboundMessage) {
 			slog.Info("routing group mention",
 				"user", msg.OwnerUserID, "channel", msg.Channel,
 				"chat_id", msg.ChatID, "agent", target.Name())
-			g.taskQueue.Submit(target.Name(), chatKey(msg.Channel, msg.AccountID, msg.ChatID), msg, g.accountIDForAgent(space, target.Name(), msg.Channel))
+			if !g.trySteer(target, msg, groupSteerText(msg)) {
+				g.taskQueue.Submit(target.Name(), chatKey(msg.Channel, msg.AccountID, msg.ChatID), msg, g.accountIDForAgent(space, target.Name(), msg.Channel))
+			}
 			return
 		}
 	}
@@ -174,7 +205,9 @@ func (g *Gateway) routeGroup(ctx context.Context, msg bus.InboundMessage) {
 				ag.InjectGroupMessage(ctx, msg)
 			}
 		}
-		g.taskQueue.Submit(target.Name(), chatKey(msg.Channel, msg.AccountID, msg.ChatID), msg, g.accountIDForAgent(space, target.Name(), msg.Channel))
+		if !g.trySteer(target, msg, groupSteerText(msg)) {
+			g.taskQueue.Submit(target.Name(), chatKey(msg.Channel, msg.AccountID, msg.ChatID), msg, g.accountIDForAgent(space, target.Name(), msg.Channel))
+		}
 	default:
 		for _, ag := range boundAgents {
 			ag.InjectGroupMessage(ctx, msg)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -38,6 +38,16 @@ type Session struct {
 	// rows it's read back via Manager.Get and late-bound here so the
 	// next save preserves it.
 	projectID string
+
+	// Steering: turnDepth counts in-flight HandleMessage turns for this
+	// session (a counter, not a bool, so re-entrant/overlapping turns
+	// don't strand the active flag). steerBuf holds user messages that
+	// arrived mid-turn; the running ReAct loop drains them between tool
+	// iterations. Both are guarded by mu. getByKey never touches these,
+	// so a Manager.Get reload (which overwrites Messages) can't clobber a
+	// pending steer.
+	turnDepth int
+	steerBuf  []provider.Message
 }
 
 // SessionKey returns the opaque session_key this Session is bound to.
@@ -441,6 +451,61 @@ func (s *Session) GetMessages() []provider.Message {
 	msgs := make([]provider.Message, len(s.Messages))
 	copy(msgs, s.Messages)
 	return msgs
+}
+
+// BeginTurn marks a HandleMessage turn as in-flight for this session.
+// Paired with EndTurn. Steering messages are only accepted while at
+// least one turn is active.
+func (s *Session) BeginTurn() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.turnDepth++
+}
+
+// EndTurn marks a turn as finished. When the last in-flight turn ends it
+// returns any steer messages still buffered (the end-of-turn race: a
+// message pushed after the loop's final drain). Callers redispatch the
+// leftovers as a fresh turn.
+func (s *Session) EndTurn() []provider.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.turnDepth > 0 {
+		s.turnDepth--
+	}
+	if s.turnDepth > 0 || len(s.steerBuf) == 0 {
+		return nil
+	}
+	leftover := s.steerBuf
+	s.steerBuf = nil
+	return leftover
+}
+
+// PushSteerIfActive buffers a steering message iff a turn is currently
+// in-flight. Returns false when no turn is active, so the caller can
+// fall back to dispatching the message as a normal new turn. The return
+// value is the single source of truth — there is deliberately no
+// separate "is running" probe to race against.
+func (s *Session) PushSteerIfActive(msg provider.Message) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.turnDepth == 0 {
+		return false
+	}
+	s.steerBuf = append(s.steerBuf, msg)
+	return true
+}
+
+// DrainSteer atomically returns and clears the buffered steer messages.
+// The running loop calls this between tool iterations.
+func (s *Session) DrainSteer() []provider.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.steerBuf) == 0 {
+		return nil
+	}
+	drained := s.steerBuf
+	s.steerBuf = nil
+	return drained
 }
 
 // UnconsolidatedCount returns the number of messages since last consolidation.

--- a/internal/session/steer_test.go
+++ b/internal/session/steer_test.go
@@ -1,0 +1,116 @@
+package session
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+)
+
+func um(s string) provider.Message {
+	return provider.Message{Role: "user", Content: s}
+}
+
+func TestPushSteerRequiresActiveTurn(t *testing.T) {
+	s := &Session{}
+
+	if s.PushSteerIfActive(um("a")) {
+		t.Fatal("push before BeginTurn should return false")
+	}
+	if got := s.DrainSteer(); got != nil {
+		t.Fatalf("expected empty drain, got %v", got)
+	}
+
+	s.BeginTurn()
+	if !s.PushSteerIfActive(um("b")) {
+		t.Fatal("push during active turn should return true")
+	}
+	drained := s.DrainSteer()
+	if len(drained) != 1 || drained[0].Content != "b" {
+		t.Fatalf("unexpected drain: %v", drained)
+	}
+	if got := s.DrainSteer(); got != nil {
+		t.Fatalf("second drain should be empty, got %v", got)
+	}
+}
+
+func TestEndTurnReturnsLeftoverAndClosesWindow(t *testing.T) {
+	s := &Session{}
+	s.BeginTurn()
+	s.PushSteerIfActive(um("x")) // never drained — end-of-turn race
+
+	leftover := s.EndTurn()
+	if len(leftover) != 1 || leftover[0].Content != "x" {
+		t.Fatalf("EndTurn should return the undrained message, got %v", leftover)
+	}
+	if s.PushSteerIfActive(um("y")) {
+		t.Fatal("push after the last EndTurn should return false")
+	}
+	if got := s.EndTurn(); got != nil {
+		t.Fatalf("EndTurn with no active turn should return nil, got %v", got)
+	}
+}
+
+func TestNestedTurnsDoNotStrandActiveFlag(t *testing.T) {
+	s := &Session{}
+	s.BeginTurn()
+	s.BeginTurn() // re-entrant (redispatch / sub-flow)
+
+	if l := s.EndTurn(); l != nil {
+		t.Fatalf("inner EndTurn must not flush while outer turn active, got %v", l)
+	}
+	if !s.PushSteerIfActive(um("z")) {
+		t.Fatal("turn still active after inner EndTurn — push should succeed")
+	}
+	if l := s.EndTurn(); len(l) != 1 || l[0].Content != "z" {
+		t.Fatalf("outer EndTurn should flush leftover, got %v", l)
+	}
+}
+
+// Concurrent producers vs. a drain loop: every accepted message is
+// delivered exactly once (no loss, no duplication) under -race.
+func TestConcurrentPushDrainNoLossNoDup(t *testing.T) {
+	s := &Session{}
+	s.BeginTurn()
+
+	const producers = 8
+	const perProducer = 200
+
+	var got int64
+	var wg sync.WaitGroup
+	for p := 0; p < producers; p++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perProducer; i++ {
+				s.PushSteerIfActive(provider.Message{Role: "user", Content: "m"})
+			}
+		}()
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			atomic.AddInt64(&got, int64(len(s.DrainSteer())))
+			select {
+			case <-stop:
+				// Final sweep after producers are guaranteed done.
+				atomic.AddInt64(&got, int64(len(s.DrainSteer())))
+				return
+			default:
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	<-done
+	got += int64(len(s.EndTurn())) // sweep the post-last-drain window
+
+	if got != producers*perProducer {
+		t.Fatalf("message count mismatch: got %d want %d", got, producers*perProducer)
+	}
+}

--- a/internal/setup/handlers.go
+++ b/internal/setup/handlers.go
@@ -908,6 +908,39 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusOK, map[string]any{"reply": reply})
 }
 
+// handleChatSteer buffers a message into an in-flight turn for the
+// session. It does NOT open a stream or emit an event — the running
+// turn (started by the earlier /api/chat/stream POST) folds the message
+// in between tool rounds and emits the "steer" event on its existing
+// SSE. 200 {"buffered":true} when a turn was active; 409
+// {"buffered":false} when none is running, so the client falls back to
+// a normal /api/chat/stream send.
+func (s *Server) handleChatSteer(w http.ResponseWriter, r *http.Request) {
+	var req chatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	ag := s.resolveAgent(r, req.AgentID)
+	if ag == nil {
+		jsonResponse(w, http.StatusNotFound, map[string]any{"error": "agent not found"})
+		return
+	}
+	if s.effectiveUserID(r) == "" {
+		jsonResponse(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+		return
+	}
+	if strings.TrimSpace(req.Message) == "" {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "empty message"})
+		return
+	}
+	if ag.SteerWeb(req.SessionID, req.ProjectID, req.Message) {
+		jsonResponse(w, http.StatusOK, map[string]any{"buffered": true})
+		return
+	}
+	jsonResponse(w, http.StatusConflict, map[string]any{"buffered": false})
+}
+
 // agentTurnTimeout is the upper bound on how long an agent goroutine
 // is allowed to run after the client connection drops. Bumped to 45m
 // after fan-out delegate_task work (6 parallel subagents × ~10m each

--- a/internal/setup/server.go
+++ b/internal/setup/server.go
@@ -28,6 +28,10 @@ type AgentHandle interface {
 	Name() string
 	HandleWebChat(ctx context.Context, sessionId, projectIdHint, userID, text string, imageURLs []string, params map[string]any) string
 	HandleWebChatStream(ctx context.Context, sessionId, projectIdHint, userID, text string, imageURLs []string, params map[string]any, events chan<- agent.ChatEvent) string
+	// SteerWeb buffers a message into an in-flight turn for the session;
+	// returns false when no turn is running (caller falls back to a
+	// normal send).
+	SteerWeb(sessionId, projectIDHint, text string) bool
 	WebChatHistory(sessionId string) []map[string]any
 	WebChatSessions() []session.WebSession
 	DeleteWebChatSession(sessionId string) error
@@ -225,6 +229,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// Chat
 	mux.HandleFunc("POST /api/chat", auth(s.handleChat))
 	mux.HandleFunc("POST /api/chat/stream", auth(s.handleChatStream))
+	mux.HandleFunc("POST /api/chat/steer", auth(s.handleChatSteer))
 	mux.HandleFunc("GET /api/chat/history", auth(s.handleChatHistory))
 	mux.HandleFunc("GET /api/chat/todo", auth(s.handleChatTodo))
 	mux.HandleFunc("GET /api/chat/sessions", auth(s.handleChatSessions))

--- a/web/src/components/chat-screen.tsx
+++ b/web/src/components/chat-screen.tsx
@@ -5,7 +5,7 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useAgentIdFromURL } from "@/hooks/use-agent-id";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { getAgent, getChatHistoryWithCursor, getChatSessions, getChatTodo, getMe, listAgentFiles, listProjects, renameChatSession, revealAgentWorkspace, sendChatStream, uploadAgentFiles, getSkills, type ChatHistoryMessage, type ChatStreamEvent, type SkillInfo, type TodoItem, type ToolResultMetadata, type WorkspaceFile } from "@/lib/api";
+import { getAgent, getChatHistoryWithCursor, getChatSessions, getChatTodo, getMe, listAgentFiles, listProjects, renameChatSession, revealAgentWorkspace, sendChatStream, steerChat, uploadAgentFiles, getSkills, type ChatHistoryMessage, type ChatStreamEvent, type SkillInfo, type TodoItem, type ToolResultMetadata, type WorkspaceFile } from "@/lib/api";
 import { Bot, Send, Copy, Check, Pencil, Wrench, ChevronDown, ChevronRight, Download, X, File, FileText, FolderSearch, Image as ImageIcon, FileCode, Film, Music, Puzzle, SlidersHorizontal, ShieldCheck, Paperclip, Square, FolderOpen, RefreshCw, Eye, Code2, RotateCcw, ListChecks, Terminal } from "lucide-react";
 import Link from "next/link";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
@@ -172,6 +172,10 @@ interface ChatMessage {
   toolCalls?: { id: string; name: string; arguments: string; result?: string; metadata?: ToolResultMetadata }[];
   files?: ProducedFile[];
   attachments?: UserAttachment[];
+  // Optimistically-rendered steer bubble awaiting the server's persisted
+  // "steer" echo. Used only to dedup against that echo (cleared on
+  // match) — not rendered differently.
+  pendingSteer?: boolean;
   // Assistant-side metadata (e.g. iteration-cap badge). Stamped from
   // either the live content event's `metadata` payload or the
   // ChatHistoryMessage.metadata on a refresh.
@@ -893,6 +897,11 @@ export function ChatScreen() {
             }
             break;
           }
+          case "steer": {
+            claim();
+            applySteerEvent(data.data?.content || "");
+            break;
+          }
           case "done": {
             claim();
             // Defensive clear — content events should already have
@@ -1178,15 +1187,38 @@ export function ChatScreen() {
     }
   }, [input]);
 
-  const handleSend = useCallback(async (overrideText?: string) => {
+  // applySteerEvent renders a server "steer" echo as a user bubble,
+  // reconciling against the optimistic pendingSteer bubble (if any) so
+  // the message isn't duplicated. seq-dedup is already applied upstream
+  // by both event consumers.
+  const applySteerEvent = useCallback((content: string) => {
+    if (!content) return;
+    setMessages((prev) => {
+      const idx = prev.findIndex(
+        (m) => m.role === "user" && m.pendingSteer && m.content === content,
+      );
+      if (idx >= 0) {
+        const updated = [...prev];
+        updated[idx] = { ...updated[idx], pendingSteer: undefined };
+        return updated;
+      }
+      return [
+        ...prev,
+        { id: `s-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`, role: "user", content, timestamp: Date.now() },
+      ];
+    });
+  }, []);
+
+  const handleSend = useCallback(async (overrideText?: string, force?: boolean) => {
     // overrideText lets caller post a message that didn't come from
     // the composer (e.g. the plan-approval button clicking "go"). When
     // present it bypasses the input field entirely — composer state
-    // stays as the user left it.
+    // stays as the user left it. force bypasses the in-flight guard;
+    // used by the steer 409 fallback (server confirmed no active turn).
     const composerText = (overrideText ?? input).trim();
     const text = composerText;
     // Allow sending with attachments only (no text), but require at least one.
-    if ((!text && attachments.length === 0) || !selectedAgent || sending) return;
+    if ((!text && attachments.length === 0) || !selectedAgent || (sending && !force)) return;
 
     // `/project/<pid>` is the lazy-create marker the sidebar dropped
     // us at. Captured here so it can ride the first chat request body;
@@ -1542,6 +1574,13 @@ export function ChatScreen() {
             }
             break;
           }
+          case "steer": {
+            // A message the user injected mid-turn was folded into the
+            // running turn server-side. Render it as a user bubble
+            // (reconciled against the optimistic pendingSteer bubble).
+            applySteerEvent(evt.data?.content || "");
+            break;
+          }
           case "error": {
             // Surface backend errors as a chat bubble. Without this the
             // turn just hangs — the model failed (provider 4xx/5xx,
@@ -1692,6 +1731,39 @@ export function ChatScreen() {
     abortRef.current?.abort();
   }, []);
 
+  // handleSteer fires while a turn is streaming: it buffers the message
+  // into the running turn (the agent folds it in between tool rounds and
+  // streams a "steer" echo on the existing SSE). On 409 (no active turn
+  // — the turn just ended) it falls back to a normal send so nothing is
+  // lost.
+  const handleSteer = useCallback(async () => {
+    const text = input.trim();
+    // Only ever called from handleKeyDown's `if (sending)` branch;
+    // within one render React state is snapshot-consistent, so `sending`
+    // is necessarily true here.
+    if (!text || !selectedAgent || !sending) return;
+    setInput("");
+    const optimisticId = `s-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    setMessages((prev) => [
+      ...prev,
+      { id: optimisticId, role: "user", content: text, timestamp: Date.now(), pendingSteer: true },
+    ]);
+    let ok = false;
+    try {
+      ok = await steerChat(selectedAgent, sessionId, text, urlProjectId);
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev.filter((m) => m.id !== optimisticId),
+        { id: `e-${Date.now()}`, role: "agent", content: `Steer failed: ${err instanceof Error ? err.message : "unknown error"}`, timestamp: Date.now() },
+      ]);
+      return;
+    }
+    if (!ok) {
+      setMessages((prev) => prev.filter((m) => m.id !== optimisticId));
+      await handleSend(text, true);
+    }
+  }, [input, selectedAgent, sending, sessionId, urlProjectId, handleSend]);
+
   const handleFilePick = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const picked = e.target.files;
     if (!picked || picked.length === 0) return;
@@ -1744,7 +1816,13 @@ export function ChatScreen() {
 
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      handleSend();
+      // While a turn is streaming, Enter steers the running turn instead
+      // of being blocked; otherwise it's a normal send.
+      if (sending) {
+        handleSteer();
+      } else {
+        handleSend();
+      }
     }
   };
 
@@ -2318,7 +2396,7 @@ export function ChatScreen() {
                             ? `Message ${agentName || selectedAgent}... ("/" to pick a skill)`
                             : "Select an agent first"
                     }
-                    disabled={!selectedAgent || sending || isReadOnlyView}
+                    disabled={!selectedAgent || isReadOnlyView}
                     rows={3}
                     className="block w-full resize-none bg-transparent text-[15px] placeholder:text-muted-foreground/50 outline-none disabled:opacity-50"
                     style={{ maxHeight: 240, minHeight: 72 }}
@@ -2412,7 +2490,7 @@ export function ChatScreen() {
                             ? `Message ${agentName || selectedAgent}... ("/" to pick a skill)`
                             : "Select an agent first"
                     }
-                    disabled={!selectedAgent || sending || isReadOnlyView}
+                    disabled={!selectedAgent || isReadOnlyView}
                     rows={1}
                     className="flex-1 resize-none bg-transparent text-[15px] leading-8 placeholder:text-muted-foreground/50 outline-none disabled:opacity-50"
                     style={{ maxHeight: 200, minHeight: 32 }}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -935,6 +935,32 @@ export async function sendChat(agentId: string, sessionId: string, message: stri
   return res.json();
 }
 
+// steerChat buffers a message into an in-flight turn for the session.
+// Resolves true when the server folded it into a running turn (200),
+// false when no turn is active (409) — caller should then fall back to
+// a normal sendChatStream. Throws only on unexpected/transport errors.
+export async function steerChat(
+  agentId: string,
+  sessionId: string,
+  message: string,
+  projectId?: string,
+): Promise<boolean> {
+  const res = await apiFetch("/api/chat/steer", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      agentId,
+      sessionId,
+      projectId: projectId || undefined,
+      message,
+    }),
+  });
+  if (res.status === 409) return false;
+  if (!res.ok) throw new Error(`steer failed: ${res.status}`);
+  const data = await res.json().catch(() => ({}));
+  return data?.buffered === true;
+}
+
 export interface ToolResultMetadata {
   sandbox?: boolean;
   // Stamped on the forced-final-delivery assistant message that the
@@ -955,6 +981,7 @@ export interface ChatStreamEvent {
     | "content_delta"
     | "tool_call"
     | "tool_result"
+    | "steer"
     | "error"
     | "done"
     | "subagent_progress";


### PR DESCRIPTION
## Summary

Lets a user steer an agent while it's mid-task. A message sent during a running turn is folded into the live ReAct loop **between tool rounds** instead of waiting as a separate later turn. Works for both the web dashboard and IM channels.

One unifying mechanism: a per-`Session` steer mailbox the running loop drains; producers (web endpoint, IM router) only buffer, they never start a turn.

- **session**: per-`Session` steer mailbox + turn counter (`BeginTurn`/`EndTurn`/`PushSteerIfActive`/`DrainSteer`), guarded by the existing mutex. Kept in fields `getByKey` never reloads, so a concurrent `Get` (which overwrites `Messages`) can't clobber a pending steer.
- **loop**: drain between tool rounds and again pre-`done`; a steer that loses the end-of-turn race is parked in history for the next turn (no recursive redispatch — keeps web/IM behavior symmetric and simple).
- **gateway**: `trySteer` diverts into the in-flight turn, resolving the session via `msg.AccountID` (the field `HandleMessage` actually uses, not the task-queue per-agent accountID) so the pointer matches the running turn; falls back to `taskQueue.Submit` when no turn is active.
- **web**: `POST /api/chat/steer` (200 buffered / 409 fall back to a normal send); composer stays editable while streaming, Enter steers; `steer` events render as user bubbles with the existing seq-dedup.
- **plan mode / max-iteration / errored turns**: steer is parked in history (answered next turn) — documented in code.

## Test plan

- [x] `go build ./...`, `go vet`
- [x] `go test ./internal/agent/ ./internal/session/ -race` (session mailbox invariants incl. concurrent push/drain)
- [x] web `tsc --noEmit`
- [ ] Manual web: long tool task → steer mid-run → agent adjusts at next round, no second turn; reload mid-turn → subscribe backfill, no dupes; steer at turn end → 409 fallback
- [ ] Manual IM (Telegram/Slack): DM + group @mention long task, steer mid-run reflected at next tool boundary; rapid steers stay ordered