### PR TITLE
feat(agent): typed attachments with filenames; fix non-image vision leak

### DIFF
--- a/internal/agent/attachments.go
+++ b/internal/agent/attachments.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // maxAttachmentBytes caps a single attachment regardless of whether it
@@ -331,7 +332,10 @@ func sanitizeAttachmentName(raw string) string {
 	out := strings.TrimSpace(b.String())
 	out = strings.TrimLeft(out, ".") // hidden-dotfile prefix is rarely intended
 	if len(out) > maxAttachmentNameLen {
-		// Truncate from the stem so we preserve the extension.
+		// Truncate from the stem so we preserve the extension. Byte-
+		// slicing on UTF-8 would chop multi-byte runes (CJK filenames
+		// are 3 bytes/char) and yield invalid UTF-8 on disk, so back
+		// off to the nearest rune boundary at or below the byte budget.
 		ext := path.Ext(out)
 		stem := strings.TrimSuffix(out, ext)
 		keep := maxAttachmentNameLen - len(ext)
@@ -339,6 +343,9 @@ func sanitizeAttachmentName(raw string) string {
 			keep = 1
 		}
 		if len(stem) > keep {
+			for keep > 0 && !utf8.RuneStart(stem[keep]) {
+				keep--
+			}
 			stem = stem[:keep]
 		}
 		out = stem + ext

--- a/internal/agent/attachments.go
+++ b/internal/agent/attachments.go
@@ -9,21 +9,53 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 )
 
-// WriteSessionAttachments materializes user-attached image bytes into the
-// agent's session workspace so skills (image-tool, etc.) can read them as
-// /workspace/<filename>. Each url is one of:
-//   - data URL:  "data:image/png;base64,iVBORw..."
-//   - HTTPS URL: "https://example.com/photo.jpg"
+// maxAttachmentBytes caps a single attachment regardless of whether it
+// arrived as a data URL (in-memory base64) or an HTTPS URL (streamed
+// fetch). 25 MB matches Anthropic's per-image envelope and prevents a
+// pathological data URL from sinking the gateway.
+const maxAttachmentBytes = 25 * 1024 * 1024
+
+// maxAttachmentNameLen caps caller-supplied filenames after sanitization.
+// 96 is roughly the longest a filename can be before terminals start
+// wrapping in chat bubbles, and well clear of any path-length limits.
+const maxAttachmentNameLen = 96
+
+// Attachment is one item the caller wants materialized into /workspace
+// for the current turn. URL is required (data URL or http(s) URL); Name
+// is optional and, when given, is sanitized and used as the on-disk
+// filename so the LLM sees something readable like `quarterly.pdf`
+// instead of `image_3jk7l_0.pdf`.
 //
-// Per-image errors are logged and skipped — a single bad URL must not sink
-// the whole turn. Returns the relative filenames (e.g. "in_<ts>_0.png") in
-// input order, omitting any that failed.
+// Same-Name semantics:
+//   - Within one turn: a second attachment with the same Name is
+//     disambiguated as `<stem>-<idx><ext>` (token-spliced if that also
+//     collides). No silent loss.
+//   - Across turns: re-uploading the same Name overwrites the prior
+//     file in /workspace. This matches the "drag the same name onto a
+//     folder" mental model and avoids unbounded `notes-1.md`,
+//     `notes-2.md`, … buildup. Callers that need to preserve old
+//     versions must vary the Name themselves.
+type Attachment struct {
+	URL  string
+	Name string
+}
+
+// WriteSessionAttachments materializes user-attached bytes into the
+// agent's session workspace so skills (image-tool, file readers, etc.)
+// can reach them via /workspace/<filename>. Each URL is one of:
+//   - data URL:  "data:image/png;base64,iVBORw..."
+//   - HTTPS URL: "https://example.com/report.pdf"
+//
+// Per-item errors are logged and skipped — a single bad URL must not
+// sink the whole turn. Returns the relative filenames in input order,
+// omitting any that failed.
 //
 // Why three writes:
 //
@@ -39,8 +71,8 @@ import (
 // Docker doesn't need the third write (bind mount makes host writes show
 // up instantly), but calling it is harmless. The host write is also
 // harmless for E2B (gateway-local bytes nobody reads).
-func (a *Agent) WriteSessionAttachments(ctx context.Context, sessionID, projectID string, urls []string) []string {
-	if len(urls) == 0 {
+func (a *Agent) WriteSessionAttachments(ctx context.Context, sessionID, projectID string, atts []Attachment) []string {
+	if len(atts) == 0 {
 		return nil
 	}
 	var paths []string
@@ -56,13 +88,19 @@ func (a *Agent) WriteSessionAttachments(ctx context.Context, sessionID, projectI
 	if len(token) > 5 {
 		token = token[len(token)-5:]
 	}
-	for i, u := range urls {
-		data, ext, err := decodeAttachment(ctx, u)
+	// Track names assigned in this batch so two attachments with the
+	// same caller-provided Name don't clobber each other. Cross-turn
+	// collisions are intentionally left to overwrite — re-uploading
+	// `notes.md` should replace, not accumulate `notes-1.md` forever.
+	used := make(map[string]struct{}, len(atts))
+	for i, att := range atts {
+		data, ext, err := decodeAttachment(ctx, att.URL)
 		if err != nil {
 			slog.Warn("attachment decode failed", "agent", a.name, "session", sessionID, "index", i, "error", err)
 			continue
 		}
-		name := fmt.Sprintf("image_%s_%d%s", token, i, ext)
+		name := buildAttachmentName(att.Name, token, i, ext, used)
+		used[name] = struct{}{}
 
 		// 1. Host workspace dir (covers no-sandbox + docker via bind mount)
 		if a.workspacePath != "" {
@@ -125,13 +163,12 @@ func decodeAttachment(ctx context.Context, u string) ([]byte, string, error) {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, "", fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
-	const maxBytes = 25 * 1024 * 1024 // 25 MB ceiling — same envelope as Anthropic's per-image limit
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAttachmentBytes+1))
 	if err != nil {
 		return nil, "", err
 	}
-	if len(body) > maxBytes {
-		return nil, "", fmt.Errorf("attachment exceeds %d bytes", maxBytes)
+	if len(body) > maxAttachmentBytes {
+		return nil, "", fmt.Errorf("attachment exceeds %d bytes", maxAttachmentBytes)
 	}
 	ext := extFromMIME(resp.Header.Get("Content-Type"))
 	if ext == "" {
@@ -177,6 +214,9 @@ func decodeDataURL(u string) ([]byte, string, error) {
 		}
 		data = []byte(decoded)
 	}
+	if len(data) > maxAttachmentBytes {
+		return nil, "", fmt.Errorf("attachment exceeds %d bytes", maxAttachmentBytes)
+	}
 	ext := extFromMIME(mime)
 	if ext == "" {
 		ext = ".bin"
@@ -190,6 +230,7 @@ func extFromMIME(ct string) string {
 		ct = ct[:i]
 	}
 	switch strings.TrimSpace(strings.ToLower(ct)) {
+	// Images
 	case "image/png":
 		return ".png"
 	case "image/jpeg", "image/jpg":
@@ -202,8 +243,107 @@ func extFromMIME(ct string) string {
 		return ".heic"
 	case "image/svg+xml":
 		return ".svg"
+	// Documents — landing as the real extension matters even for models
+	// that can't natively read the bytes, because the LLM picks its
+	// tool based on the extension. `.bin` makes it reach for
+	// file/identify; `.pdf` makes it reach for the right reader.
+	case "application/pdf":
+		return ".pdf"
+	case "text/plain":
+		return ".txt"
+	case "text/markdown", "text/x-markdown":
+		return ".md"
+	case "text/csv":
+		return ".csv"
+	case "text/html":
+		return ".html"
+	case "application/json":
+		return ".json"
+	case "application/xml", "text/xml":
+		return ".xml"
+	case "application/zip":
+		return ".zip"
 	}
 	return ""
+}
+
+// buildAttachmentName turns the caller's optional Name into a safe
+// on-disk filename. If Name is empty (or sanitizes to empty), we fall
+// back to the historical `image_<token>_<i><ext>` shape so existing
+// callers see no behavior change. If Name is present, we keep it
+// (sanitized), append the MIME-derived ext when the user omitted one,
+// and disambiguate within-batch duplicates by suffixing `-<i>`.
+func buildAttachmentName(raw, token string, idx int, ext string, used map[string]struct{}) string {
+	clean := sanitizeAttachmentName(raw)
+	if clean == "" {
+		return fmt.Sprintf("image_%s_%d%s", token, idx, ext)
+	}
+	if path.Ext(clean) == "" && ext != "" {
+		clean += ext
+	}
+	if _, dup := used[clean]; !dup {
+		return clean
+	}
+	stem := strings.TrimSuffix(clean, path.Ext(clean))
+	tail := path.Ext(clean)
+	// First disambiguation: `<stem>-<idx><ext>`. Usually unique, but
+	// can collide if the user explicitly named an earlier attachment
+	// `report-2.pdf` and a later one with the same Name happens to
+	// land at idx=2.
+	candidate := fmt.Sprintf("%s-%d%s", stem, idx, tail)
+	if _, dup := used[candidate]; !dup {
+		return candidate
+	}
+	// Final fallback: splice in the per-turn token. token is unique
+	// per WriteSessionAttachments call, so `<stem>-<token>-<idx><ext>`
+	// is collision-free within the batch.
+	return fmt.Sprintf("%s-%s-%d%s", stem, token, idx, tail)
+}
+
+// sanitizeAttachmentName strips path separators, parent-dir tokens,
+// control characters, and leading dots from a caller-supplied filename.
+// Returns "" if nothing usable remains so the caller can fall back.
+// Uses path.Base (not filepath.Base) so Windows-style paths from the
+// browser are handled identically on a Linux gateway.
+func sanitizeAttachmentName(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	// Normalize Windows separators to / so path.Base reliably extracts
+	// the last component regardless of which side of the wire we run on.
+	raw = strings.ReplaceAll(raw, `\`, "/")
+	raw = path.Base(raw)
+	// `path.Base("..") == ".."`; reject explicitly.
+	if raw == "." || raw == ".." {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range raw {
+		switch {
+		case r < 0x20, r == 0x7f:
+			// control char — drop
+		case r == '/', r == '\\', r == ':', r == 0:
+			// path separator / drive prefix / NUL — drop
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	out = strings.TrimLeft(out, ".") // hidden-dotfile prefix is rarely intended
+	if len(out) > maxAttachmentNameLen {
+		// Truncate from the stem so we preserve the extension.
+		ext := path.Ext(out)
+		stem := strings.TrimSuffix(out, ext)
+		keep := maxAttachmentNameLen - len(ext)
+		if keep < 1 {
+			keep = 1
+		}
+		if len(stem) > keep {
+			stem = stem[:keep]
+		}
+		out = stem + ext
+	}
+	return out
 }
 
 func contentTypeFromExt(ext string) string {
@@ -220,6 +360,22 @@ func contentTypeFromExt(ext string) string {
 		return "image/heic"
 	case ".svg":
 		return "image/svg+xml"
+	case ".pdf":
+		return "application/pdf"
+	case ".txt":
+		return "text/plain"
+	case ".md":
+		return "text/markdown"
+	case ".csv":
+		return "text/csv"
+	case ".html":
+		return "text/html"
+	case ".json":
+		return "application/json"
+	case ".xml":
+		return "application/xml"
+	case ".zip":
+		return "application/zip"
 	}
 	return ""
 }

--- a/internal/agent/attachments_test.go
+++ b/internal/agent/attachments_test.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeAttachmentName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"report.pdf", "report.pdf"},
+		{"../etc/passwd", "passwd"},
+		{"../../foo.txt", "foo.txt"},
+		{"a/b/c.csv", "c.csv"},
+		{`C:\windows\notes.md`, "notes.md"},
+		{"..", ""},
+		{".", ""},
+		{".hiddenrc", "hiddenrc"},
+		{"weird\x00name.txt", "weirdname.txt"},
+		{"control\x07char.csv", "controlchar.csv"},
+		{"  spaced.txt  ", "spaced.txt"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := sanitizeAttachmentName(c.in); got != c.want {
+			t.Errorf("sanitize(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSanitizeAttachmentNameTruncates(t *testing.T) {
+	long := strings.Repeat("a", 200) + ".pdf"
+	got := sanitizeAttachmentName(long)
+	if len(got) > maxAttachmentNameLen {
+		t.Fatalf("len = %d, want <= %d", len(got), maxAttachmentNameLen)
+	}
+	if !strings.HasSuffix(got, ".pdf") {
+		t.Errorf("extension lost: %q", got)
+	}
+}
+
+func TestBuildAttachmentName(t *testing.T) {
+	used := map[string]struct{}{}
+
+	// Empty name → historical shape
+	if got := buildAttachmentName("", "abc12", 0, ".png", used); got != "image_abc12_0.png" {
+		t.Errorf("empty-name fallback = %q", got)
+	}
+
+	// Provided name, with extension → preserved
+	if got := buildAttachmentName("report.pdf", "abc12", 0, ".pdf", used); got != "report.pdf" {
+		t.Errorf("named = %q, want report.pdf", got)
+	}
+	used["report.pdf"] = struct{}{}
+
+	// Duplicate name → disambiguated with index
+	if got := buildAttachmentName("report.pdf", "abc12", 1, ".pdf", used); got != "report-1.pdf" {
+		t.Errorf("dup = %q, want report-1.pdf", got)
+	}
+
+	// Name without extension picks up the MIME-derived ext
+	used2 := map[string]struct{}{}
+	if got := buildAttachmentName("notes", "abc12", 0, ".md", used2); got != "notes.md" {
+		t.Errorf("ext append = %q, want notes.md", got)
+	}
+
+	// Path-escape attempts fall through to sanitize → fallback
+	used3 := map[string]struct{}{}
+	got := buildAttachmentName("..", "abc12", 0, ".bin", used3)
+	if got != "image_abc12_0.bin" {
+		t.Errorf("dotdot fallback = %q", got)
+	}
+}
+
+// Regression: a later attachment hits the disambiguation slot of an
+// earlier one. Walk:
+//   - i=0  Name="report-1-2.pdf"  → "report-1-2.pdf"
+//   - i=1  Name="report-1.pdf"    → "report-1.pdf"
+//   - i=2  Name="report-1.pdf"    → dup; candidate "report-1-2.pdf"
+//     ALSO dup → token-fallback rescues it as "report-1-tok99-2.pdf"
+func TestBuildAttachmentNameSecondaryCollision(t *testing.T) {
+	used := map[string]struct{}{}
+
+	n0 := buildAttachmentName("report-1-2.pdf", "tok99", 0, ".pdf", used)
+	used[n0] = struct{}{}
+	n1 := buildAttachmentName("report-1.pdf", "tok99", 1, ".pdf", used)
+	used[n1] = struct{}{}
+	n2 := buildAttachmentName("report-1.pdf", "tok99", 2, ".pdf", used)
+	used[n2] = struct{}{}
+
+	if n0 != "report-1-2.pdf" || n1 != "report-1.pdf" {
+		t.Fatalf("baseline wrong: n0=%q n1=%q", n0, n1)
+	}
+	if n2 == n0 || n2 == n1 {
+		t.Fatalf("collision: n2=%q hit n0=%q or n1=%q", n2, n0, n1)
+	}
+	if n2 != "report-1-tok99-2.pdf" {
+		t.Errorf("n2 = %q, want report-1-tok99-2.pdf", n2)
+	}
+}
+
+func TestExtFromMIMECoversCommonDocs(t *testing.T) {
+	cases := map[string]string{
+		"application/pdf":             ".pdf",
+		"application/pdf; charset=x":  ".pdf",
+		"text/plain":                  ".txt",
+		"text/markdown":               ".md",
+		"text/csv":                    ".csv",
+		"application/json":            ".json",
+		"application/zip":             ".zip",
+		"image/png":                   ".png",
+		"image/jpg":                   ".jpg",
+		"application/x-unknown-type":  "",
+	}
+	for ct, want := range cases {
+		if got := extFromMIME(ct); got != want {
+			t.Errorf("extFromMIME(%q) = %q, want %q", ct, got, want)
+		}
+	}
+}
+
+func TestDecodeDataURLEnforcesSizeCap(t *testing.T) {
+	// Build a base64-encoded payload that exceeds maxAttachmentBytes.
+	huge := make([]byte, maxAttachmentBytes+1)
+	url := "data:application/octet-stream;base64," + base64.StdEncoding.EncodeToString(huge)
+	if _, _, err := decodeDataURL(url); err == nil {
+		t.Fatal("expected size-cap error, got nil")
+	}
+}
+
+func TestDecodeDataURLPDF(t *testing.T) {
+	payload := []byte("%PDF-1.4 hello")
+	url := "data:application/pdf;base64," + base64.StdEncoding.EncodeToString(payload)
+	data, ext, err := decodeDataURL(url)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(data) != string(payload) {
+		t.Errorf("body mismatch")
+	}
+	if ext != ".pdf" {
+		t.Errorf("ext = %q, want .pdf", ext)
+	}
+}
+
+// Compile-time sanity: decodeAttachment honors data URLs without a ctx.
+var _ = context.Background

--- a/internal/agent/attachments_test.go
+++ b/internal/agent/attachments_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestSanitizeAttachmentName(t *testing.T) {
@@ -39,6 +40,23 @@ func TestSanitizeAttachmentNameTruncates(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, ".pdf") {
 		t.Errorf("extension lost: %q", got)
+	}
+}
+
+// Regression: byte-slicing a multi-byte UTF-8 stem (e.g. CJK filenames
+// at 3 bytes/char) used to chop the last rune in half and leave invalid
+// UTF-8 on disk. Truncation must back off to a rune boundary.
+func TestSanitizeAttachmentNameUTF8Safe(t *testing.T) {
+	stem := strings.Repeat("中", 40) // 120 bytes, well over the 96 cap
+	got := sanitizeAttachmentName(stem + ".pdf")
+	if !utf8.ValidString(got) {
+		t.Errorf("invalid UTF-8 after truncate: %q", got)
+	}
+	if !strings.HasSuffix(got, ".pdf") {
+		t.Errorf("ext lost: %q", got)
+	}
+	if len(got) > maxAttachmentNameLen {
+		t.Errorf("over cap: len=%d", len(got))
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -52,6 +52,65 @@ type chatCompletionRequest struct {
 	// (Anthropic ~5MB/image, OpenAI ~20MB) — fastclaw does not enforce
 	// its own ceiling, the upstream provider returns the rejection.
 	Images []string `json:"images,omitempty"`
+	// ImageURLs is an accepted alias for Images. The web-facing chat
+	// endpoint historically calls this field `imageUrls`; allowing it
+	// here means a caller writing one client against both endpoints
+	// doesn't get silently dropped attachments when they pick the
+	// wrong name.
+	ImageURLs []string `json:"imageUrls,omitempty"`
+	// Attachments is the typed, general-purpose attachment field. Each
+	// entry can carry an optional Name which is sanitized and used as
+	// the on-disk filename so the LLM sees `report.pdf` instead of
+	// `image_3jk7l_0.pdf`. Unlike Images / ImageURLs, entries here are
+	// NOT inlined as vision content parts — they only land in
+	// /workspace and reach the LLM via the `[Attached: /workspace/X]`
+	// breadcrumb. Use Images / ImageURLs (not Attachments) when you
+	// want the bytes shown directly to a vision model.
+	Attachments []attachmentRequest `json:"attachments,omitempty"`
+}
+
+// attachmentRequest is the wire form of a single attachment.
+type attachmentRequest struct {
+	URL  string `json:"url"`
+	Name string `json:"name,omitempty"`
+}
+
+// allAttachments flattens the three input shapes (Images, ImageURLs,
+// Attachments) into one ordered slice for materialization into
+// /workspace. Clients normally pick one; mixing is allowed.
+func (r chatCompletionRequest) allAttachments() []agent.Attachment {
+	n := len(r.Images) + len(r.ImageURLs) + len(r.Attachments)
+	if n == 0 {
+		return nil
+	}
+	out := make([]agent.Attachment, 0, n)
+	for _, u := range r.Images {
+		out = append(out, agent.Attachment{URL: u})
+	}
+	for _, u := range r.ImageURLs {
+		out = append(out, agent.Attachment{URL: u})
+	}
+	for _, a := range r.Attachments {
+		out = append(out, agent.Attachment{URL: a.URL, Name: a.Name})
+	}
+	return out
+}
+
+// inlineImageURLs returns just the URLs eligible for vision inline
+// (PhotoURLs → image_url content blocks). Only Images and ImageURLs
+// qualify — by contract they're caller-asserted images. The general
+// Attachments field is excluded: feeding a PDF / zip URL through the
+// vision channel returns HTTP 400 from upstream providers and sinks
+// the whole turn. Attachments reach the LLM via the
+// `[Attached: /workspace/<file>]` breadcrumb instead.
+func (r chatCompletionRequest) inlineImageURLs() []string {
+	if len(r.Images) == 0 && len(r.ImageURLs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(r.Images)+len(r.ImageURLs))
+	out = append(out, r.Images...)
+	out = append(out, r.ImageURLs...)
+	return out
 }
 
 type chatMessage struct {
@@ -205,7 +264,8 @@ func (s *Server) HandleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// know session_key — so attachments always land in the loose-chat
 	// scope. When/if we expose project addressing here, look up the
 	// session row and pass its project_id instead of "".
-	attachmentPaths := ag.WriteSessionAttachments(r.Context(), sessionKey, "", req.Images)
+	atts := req.allAttachments()
+	attachmentPaths := ag.WriteSessionAttachments(r.Context(), sessionKey, "", atts)
 	if len(attachmentPaths) > 0 {
 		var b strings.Builder
 		for _, p := range attachmentPaths {
@@ -232,7 +292,7 @@ func (s *Server) HandleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		Text:      userText,
 		PeerKind:  "dm",
 		Params:    req.Params,
-		PhotoURLs: req.Images,
+		PhotoURLs: req.inlineImageURLs(),
 	}
 
 	slog.Info("chat completion request",

--- a/internal/api/openai_attachments_test.go
+++ b/internal/api/openai_attachments_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Wire round-trip for the OpenAI-compat endpoint: a client posts a body
+// using all three attachment shapes and the helpers split them into the
+// right buckets.
+func TestChatCompletionRequestAttachmentsRoundTrip(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"messages": [{"role": "user", "content": "hi"}],
+		"images":    ["data:image/png;base64,AAA"],
+		"imageUrls": ["https://x/photo.jpg"],
+		"attachments": [
+			{"url": "data:application/pdf;base64,BBB", "name": "Q4-report.pdf"},
+			{"url": "https://x/archive.zip"}
+		]
+	}`)
+	var req chatCompletionRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(req.Attachments) != 2 || req.Attachments[0].Name != "Q4-report.pdf" {
+		t.Errorf("Attachments = %+v", req.Attachments)
+	}
+
+	inline := req.inlineImageURLs()
+	if len(inline) != 2 {
+		t.Fatalf("inline len = %d, want 2 (Images + ImageURLs only)", len(inline))
+	}
+	if inline[0] != "data:image/png;base64,AAA" || inline[1] != "https://x/photo.jpg" {
+		t.Errorf("inline order/values wrong: %v", inline)
+	}
+	// Critical: a PDF / zip data URL must not leak into the inline-vision
+	// slice — that would be wrapped as an image_url content block and
+	// upstream providers reject the whole turn.
+	for _, u := range inline {
+		if u == "data:application/pdf;base64,BBB" || u == "https://x/archive.zip" {
+			t.Errorf("non-image URL leaked into inline: %q", u)
+		}
+	}
+
+	all := req.allAttachments()
+	if len(all) != 4 {
+		t.Errorf("allAttachments len = %d, want 4 (Images+ImageURLs+Attachments)", len(all))
+	}
+}
+
+// imageUrls alone (without the Images alias) must still flow through —
+// this was the original bug C: the OpenAI endpoint silently dropped it.
+func TestChatCompletionImageUrlsAliasAlone(t *testing.T) {
+	body := []byte(`{
+		"model": "x",
+		"messages": [],
+		"imageUrls": ["https://x/a.png"]
+	}`)
+	var req chatCompletionRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := req.inlineImageURLs(); len(got) != 1 || got[0] != "https://x/a.png" {
+		t.Errorf("inlineImageURLs = %v", got)
+	}
+	if got := req.allAttachments(); len(got) != 1 || got[0].URL != "https://x/a.png" {
+		t.Errorf("allAttachments = %+v", got)
+	}
+}

--- a/internal/setup/handlers.go
+++ b/internal/setup/handlers.go
@@ -888,7 +888,6 @@ func (r chatRequest) inlineImageURLs() []string {
 	return out
 }
 
-
 // preMaterialized reports whether the caller already uploaded the
 // attachments + prefixed `[Attached: /workspace/...]` breadcrumb into
 // the message. The web client does this end-to-end (uploadAgentFiles +

--- a/internal/setup/handlers.go
+++ b/internal/setup/handlers.go
@@ -826,26 +826,68 @@ type chatRequest struct {
 	// web's image_url content parts never reach the agent (empty slice
 	// → no ContentParts persisted → history reload shows no image, and
 	// vision LLMs see only the text breadcrumb).
-	Images    []string       `json:"images,omitempty"`
-	ImageURLs []string       `json:"imageUrls,omitempty"`
-	Params    map[string]any `json:"params,omitempty"`
+	Images    []string `json:"images,omitempty"`
+	ImageURLs []string `json:"imageUrls,omitempty"`
+	// Attachments is the typed, general-purpose attachment field. Each
+	// entry can carry an optional Name which is sanitized and used as
+	// the on-disk filename so the LLM sees `report.pdf` instead of
+	// `image_3jk7l_0.pdf`. Unlike Images / ImageURLs, entries here are
+	// NOT inlined as vision content parts — they only land in
+	// /workspace and reach the LLM via the `[Attached: /workspace/X]`
+	// breadcrumb. Use Images / ImageURLs (not Attachments) when you
+	// want the bytes shown directly to a vision model.
+	Attachments []attachmentRequest `json:"attachments,omitempty"`
+	Params      map[string]any      `json:"params,omitempty"`
 }
 
-// allImages flattens both legacy field names into a single ordered
-// slice (Images first, then ImageURLs). De-dup is intentionally skipped
-// — clients send one or the other, never both.
-func (r chatRequest) allImages() []string {
-	if len(r.ImageURLs) == 0 {
-		return r.Images
+// attachmentRequest is the wire form of a single attachment. URL is the
+// data: or http(s) URL; Name is the optional caller-supplied filename.
+type attachmentRequest struct {
+	URL  string `json:"url"`
+	Name string `json:"name,omitempty"`
+}
+
+// allAttachments flattens the three input shapes (Images, ImageURLs,
+// Attachments) into one ordered slice for materialization into
+// /workspace. Order: Images → ImageURLs → Attachments. Clients
+// normally pick one; mixing is allowed and not de-dup'd.
+func (r chatRequest) allAttachments() []agent.Attachment {
+	n := len(r.Images) + len(r.ImageURLs) + len(r.Attachments)
+	if n == 0 {
+		return nil
 	}
-	if len(r.Images) == 0 {
-		return r.ImageURLs
+	out := make([]agent.Attachment, 0, n)
+	for _, u := range r.Images {
+		out = append(out, agent.Attachment{URL: u})
+	}
+	for _, u := range r.ImageURLs {
+		out = append(out, agent.Attachment{URL: u})
+	}
+	for _, a := range r.Attachments {
+		out = append(out, agent.Attachment{URL: a.URL, Name: a.Name})
+	}
+	return out
+}
+
+// inlineImageURLs returns just the URLs that should be inlined as
+// vision content parts (PhotoURLs → image_url content blocks). Only
+// the legacy image-only fields qualify: Images and ImageURLs are by
+// contract caller-asserted images, so wrapping them as image_url is
+// safe. The newer Attachments field is general-purpose (pdf / zip /
+// txt are all legal), and feeding a non-image URL to provider vision
+// channels fails the whole turn upstream (Anthropic returns 400 for
+// `{type:image, source:{type:url, url:<pdf>}}`). Attachments reach
+// the LLM via the `[Attached: /workspace/<file>]` breadcrumb instead.
+func (r chatRequest) inlineImageURLs() []string {
+	if len(r.Images) == 0 && len(r.ImageURLs) == 0 {
+		return nil
 	}
 	out := make([]string, 0, len(r.Images)+len(r.ImageURLs))
 	out = append(out, r.Images...)
 	out = append(out, r.ImageURLs...)
 	return out
 }
+
 
 // preMaterialized reports whether the caller already uploaded the
 // attachments + prefixed `[Attached: /workspace/...]` breadcrumb into
@@ -899,7 +941,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		jsonResponse(w, http.StatusNotFound, map[string]any{"error": "agent not found"})
 		return
 	}
-	images := req.allImages()
+	atts := req.allAttachments()
 	msgText := req.Message
 	if !req.preMaterialized() {
 		// Resolve the chat's project so attachments land in
@@ -907,10 +949,10 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		// failure → empty pid → loose-chat scope (the historical
 		// behavior).
 		projectID := s.resolveSessionProject(r.Context(), r, ag.Name(), req.SessionID)
-		paths := ag.WriteSessionAttachments(r.Context(), req.SessionID, projectID, images)
+		paths := ag.WriteSessionAttachments(r.Context(), req.SessionID, projectID, atts)
 		msgText = annotateMessageWithAttachments(req.Message, paths)
 	}
-	reply := ag.HandleWebChat(r.Context(), req.SessionID, req.ProjectID, s.effectiveUserID(r), msgText, images, req.Params)
+	reply := ag.HandleWebChat(r.Context(), req.SessionID, req.ProjectID, s.effectiveUserID(r), msgText, req.inlineImageURLs(), req.Params)
 	jsonResponse(w, http.StatusOK, map[string]any{"reply": reply})
 }
 
@@ -986,11 +1028,12 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	// the wire immediately, not held until the response closes.
 	w.Header().Set("X-Accel-Buffering", "no")
 	flusher.Flush()
-	images := req.allImages()
+	atts := req.allAttachments()
+	imageURLs := req.inlineImageURLs()
 	msgText := req.Message
 	if !req.preMaterialized() {
 		projectID := s.resolveSessionProject(r.Context(), r, ag.Name(), req.SessionID)
-		paths := ag.WriteSessionAttachments(r.Context(), req.SessionID, projectID, images)
+		paths := ag.WriteSessionAttachments(r.Context(), req.SessionID, projectID, atts)
 		msgText = annotateMessageWithAttachments(req.Message, paths)
 	}
 
@@ -1021,7 +1064,7 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 		// events param stays nil — emitEvent now fans out via the
 		// streamCtx attached above (persist + hub). The legacy channel
 		// path is no longer needed for this handler.
-		_ = ag.HandleWebChatStream(agentCtx, req.SessionID, req.ProjectID, uid, msgText, images, req.Params, nil)
+		_ = ag.HandleWebChatStream(agentCtx, req.SessionID, req.ProjectID, uid, msgText, imageURLs, req.Params, nil)
 	}()
 
 	// Heartbeat keeps proxies (nginx 60s default, Cloudflare 100s, ELB

--- a/internal/setup/handlers_attachments_test.go
+++ b/internal/setup/handlers_attachments_test.go
@@ -1,0 +1,102 @@
+package setup
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Wire round-trip: the JSON a real API client would POST decodes into
+// the expected chatRequest fields, including the new Attachments shape.
+func TestChatRequestJSONRoundTrip(t *testing.T) {
+	body := []byte(`{
+		"agentId": "a1",
+		"sessionId": "s1",
+		"message": "look at this",
+		"imageUrls": ["https://x/foo.png"],
+		"attachments": [
+			{"url": "data:application/pdf;base64,AAA", "name": "report.pdf"},
+			{"url": "https://x/file.zip"}
+		]
+	}`)
+	var req chatRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(req.ImageURLs) != 1 || req.ImageURLs[0] != "https://x/foo.png" {
+		t.Errorf("ImageURLs = %v", req.ImageURLs)
+	}
+	if len(req.Attachments) != 2 {
+		t.Fatalf("Attachments len = %d, want 2", len(req.Attachments))
+	}
+	if req.Attachments[0].Name != "report.pdf" || req.Attachments[1].Name != "" {
+		t.Errorf("Attachments = %+v", req.Attachments)
+	}
+	// And the derived slices route correctly:
+	if got := req.inlineImageURLs(); len(got) != 1 {
+		t.Errorf("inlineImageURLs len = %d, want 1 (Attachments must be excluded)", len(got))
+	}
+	if got := req.allAttachments(); len(got) != 3 {
+		t.Errorf("allAttachments len = %d, want 3", len(got))
+	}
+}
+
+// inlineImageURLs must include legacy image-only fields and must NOT
+// include the general-purpose Attachments field. A PDF URL leaking
+// into PhotoURLs would be wrapped as `image_url` content part and
+// sink the whole turn upstream.
+func TestInlineImageURLsExcludesAttachments(t *testing.T) {
+	req := chatRequest{
+		Images:    []string{"data:image/png;base64,AAA"},
+		ImageURLs: []string{"https://x/photo.jpg"},
+		Attachments: []attachmentRequest{
+			{URL: "data:application/pdf;base64,BBB", Name: "report.pdf"},
+		},
+	}
+	got := req.inlineImageURLs()
+	want := []string{"data:image/png;base64,AAA", "https://x/photo.jpg"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// allAttachments must include all three sources so the workspace gets
+// every byte the caller sent (regardless of whether vision inlines it).
+func TestAllAttachmentsCoversAllSources(t *testing.T) {
+	req := chatRequest{
+		Images:    []string{"u1"},
+		ImageURLs: []string{"u2"},
+		Attachments: []attachmentRequest{
+			{URL: "u3", Name: "a.pdf"},
+		},
+	}
+	got := req.allAttachments()
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[0].URL != "u1" || got[1].URL != "u2" || got[2].URL != "u3" {
+		t.Errorf("URLs out of order: %+v", got)
+	}
+	if got[2].Name != "a.pdf" {
+		t.Errorf("Name not propagated: %+v", got[2])
+	}
+	if got[0].Name != "" || got[1].Name != "" {
+		t.Errorf("legacy entries should have empty Name: %+v", got)
+	}
+}
+
+// Empty input round-trips to nil rather than empty slice, so the
+// downstream `len(imageURLs)==0` short-circuit fires the same way it
+// did before this refactor.
+func TestInlineImageURLsEmptyIsNil(t *testing.T) {
+	req := chatRequest{
+		Attachments: []attachmentRequest{{URL: "u", Name: "a.pdf"}},
+	}
+	if got := req.inlineImageURLs(); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}

--- a/internal/setup/server.go
+++ b/internal/setup/server.go
@@ -43,11 +43,11 @@ type AgentHandle interface {
 	// the next turn cold-starts at the new bind-mount path.
 	MoveWebChatSession(ctx context.Context, sessionId, projectID string) error
 	ReloadWorkspaceFiles()
-	// WriteSessionAttachments materializes user-uploaded image bytes (data
+	// WriteSessionAttachments materializes user-uploaded bytes (data
 	// URLs / HTTPS URLs) into the agent's session workspace so skills can
 	// read them via /workspace/<filename>. Returns the relative filenames
-	// in input order; per-image errors are skipped.
-	WriteSessionAttachments(ctx context.Context, sessionID, projectID string, urls []string) []string
+	// in input order; per-item errors are skipped.
+	WriteSessionAttachments(ctx context.Context, sessionID, projectID string, atts []agent.Attachment) []string
 	// RegisteredTools returns the live tool registry projection — what
 	// this agent currently has loaded (built-ins + MCP + plugin tools).
 	// Used by the Tools tab to render the allowlist checkbox picker.


### PR DESCRIPTION
## Summary

When an API caller posts a non-image attachment (PDF, zip, txt, csv, …) via `/v1/chat/completions` or the web-chat endpoints, fastclaw mishandles it in several ways. This PR fixes those and lands a typed `attachments` field so callers can pass an optional `name` that survives to disk.

### What's broken today
- `extFromMIME` only knows 7 image MIME types — every PDF / zip / txt data URL lands on disk as `image_<token>_<i>.bin`, and the LLM reaches for `file` / `identify` to "verify" the upload instead of using the right reader.
- The HTTP path caps attachments at 25 MB but the data URL path has no cap at all — a pathological base64 payload sails through.
- `/v1/chat/completions` accepts `images` but silently drops `imageUrls`, so a client wired against the web endpoint loses its attachments here.
- The web endpoint accepts both, but the wire shape forces the on-disk filename to `image_<token>_<i>.<ext>` — a `quarterly-report.pdf` upload becomes `image_3jk7l_0.pdf` and the LLM has no idea what it is.
- Any URL in the merged image slice gets wrapped as a vision `image_url` content part. A PDF URL there is rejected by upstream providers and sinks the whole turn.

### What this PR changes

**Wire shape (additive, fully backward-compat)**
- Both endpoints accept `attachments: [{url, name?}]` alongside the existing `images` / `imageUrls`.
- `/v1/chat/completions` now accepts `imageUrls` as an alias for `images` (so one client lib works against both endpoints).

**Filenames**
- New `agent.Attachment{URL, Name}` type carries the optional Name through to disk.
- `sanitizeAttachmentName` strips path separators (incl. Windows `\` on a Linux gateway via `path.Base` after slash-normalization), control chars, leading dots, and caps length at 96 while preserving the extension.
- Empty / unsafe Names fall back to the historical `image_<token>_<i><ext>` so existing callers see zero behavior change.
- Within-batch duplicate Names get `<stem>-<idx><ext>`; a token-spliced fallback rescues the case where that also collides.
- Cross-turn same-Name is an intentional overwrite (matches the "drag the same name onto a folder" mental model); documented on the `Attachment.Name` doc.

**MIME table**
- Adds `pdf / txt / md / csv / html / json / xml / zip` to both `extFromMIME` and `contentTypeFromExt`.

**Vision channel guard**
- `attachments` field is workspace-only — **not** wrapped as a vision `image_url` content part. Only the legacy `images` / `imageUrls` fields (which are by contract caller-asserted images) feed `PhotoURLs`.
- A new `inlineImageURLs()` helper on both request types makes the split explicit.

**Misc**
- Data URL path now shares the 25 MB cap with the HTTP path.
- `AgentHandle.WriteSessionAttachments` signature updated to `[]agent.Attachment`; the only implementer in the repo is `*agent.Agent`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New tests:
  - `internal/agent/attachments_test.go` — sanitize edge cases (`..`, Windows paths, control chars, length truncation), `buildAttachmentName` four branches + secondary-collision regression, extended MIME table, data URL size cap, PDF data URL decode
  - `internal/setup/handlers_attachments_test.go` — `inlineImageURLs` excludes `attachments`, `allAttachments` covers all three sources, JSON wire round-trip
  - `internal/api/openai_attachments_test.go` — JSON round-trip with all three sources, `imageUrls`-alias-alone (regression for the silent-drop bug)
- [x] `go test ./internal/agent/... ./internal/setup/... ./internal/api/... -count=1` passes (14 attachment-related tests + existing suite)
- [ ] Manual: post a PDF data URL via `/v1/chat/completions` with `attachments: [{url, name}]` and verify it lands as `/workspace/<name>.pdf` and the LLM reads it directly without `file`/`identify` probes
- [ ] Manual: post a PDF URL inside `attachments` and confirm it no longer triggers an upstream 400 from the vision channel

## Web client compat
The web client (`web/src/components/chat-screen.tsx`) uses `uploadAgentFiles` + the manual `[Attached: /workspace/<file>]` breadcrumb path, and only sends data URLs through `imageUrls` after filtering by `f.type.startsWith("image/")`. It does not use the new `attachments` field and is unaffected.

## Out of scope (deliberately)
A few things came up during review that are real concerns but don't belong in this PR:
- **SSRF**: `decodeAttachment` will GET any http(s) URL. Auth-gated, so the risk profile depends on deployment mode (self-hosted single-tenant ≈ no risk; multi-tenant SaaS would need a private-network blocklist). Worth a separate hardening pass if the deployment story changes.
- **HTTP body size cap**: fastclaw has no `MaxBytesReader` middleware. Capping at the attachments layer alone is whack-a-mole; the right fix is at the middleware layer and is broader than attachments.