### PR TITLE
[codex] fix global skill install authorization

### DIFF
--- a/internal/setup/skill_install.go
+++ b/internal/setup/skill_install.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fastclaw-ai/fastclaw/internal/auth"
 	"github.com/fastclaw-ai/fastclaw/internal/config"
 	"github.com/fastclaw-ai/fastclaw/internal/skills"
 )
@@ -52,13 +53,8 @@ func (s *Server) handleInstallSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Agent != "" {
-		// Owner-only — Identity.CanAccessAgent is a deferred-true for
-		// session callers, so without an explicit owner check anyone
-		// could push a skill into anyone else's agent home dir.
-		if s.requireAgentOwner(w, r, req.Agent) == nil {
-			return
-		}
+	if !s.authorizeSkillInstallTarget(w, r, req.Agent) {
+		return
 	}
 	targetDir, err := resolveInstallTarget(r, req.Agent)
 	if err != nil {
@@ -106,8 +102,33 @@ func (s *Server) handleInstallSkill(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// resolveInstallTarget picks the target directory for an install and enforces
-// the admin-only rule for global installs.
+// authorizeSkillInstallTarget enforces the mutation and target-scope rules
+// shared by registry installs and zip uploads.
+func (s *Server) authorizeSkillInstallTarget(w http.ResponseWriter, r *http.Request, agentID string) bool {
+	if !s.requireWritable(w, r) {
+		return false
+	}
+	if agentID != "" {
+		// Owner-only — Identity.CanAccessAgent is a deferred-true for
+		// session callers, so without an explicit owner check anyone
+		// could push a skill into anyone else's agent home dir.
+		return s.requireAgentOwner(w, r, agentID) != nil
+	}
+	ident, ok := auth.FromContext(r.Context())
+	if !ok {
+		jsonResponse(w, http.StatusUnauthorized, map[string]any{"ok": false, "error": "unauthorized"})
+		return false
+	}
+	if !ident.CanAdminPlatform() {
+		jsonResponse(w, http.StatusForbidden, map[string]any{"ok": false, "error": "platform admin required"})
+		return false
+	}
+	return true
+}
+
+// resolveInstallTarget picks the target directory for an install. Authorization
+// happens before this helper is called: agent installs are owner-only; global
+// installs are platform-admin-only.
 func resolveInstallTarget(r *http.Request, agentID string) (string, error) {
 	if agentID != "" {
 		// agents.id is globally unique, so the home dir doesn't need a
@@ -122,9 +143,6 @@ func resolveInstallTarget(r *http.Request, agentID string) (string, error) {
 		}
 		return dir, nil
 	}
-	// Global install — super_admin only. Caller has already been
-	// validated by the route's RequireSuperAdmin middleware when this
-	// path is reached for global installs.
 	home, err := config.HomeDir()
 	if err != nil {
 		return "", err
@@ -188,6 +206,11 @@ func runInstall(source, name, repo, targetDir string) (*skills.Result, error) {
 // doesn't auto-follow them but we also refuse to recreate them on disk.
 func (s *Server) handleUploadSkill(w http.ResponseWriter, r *http.Request) {
 	const maxUploadSize = 64 << 20 // 64 MiB
+	agentID := r.URL.Query().Get("agent")
+	if !s.authorizeSkillInstallTarget(w, r, agentID) {
+		return
+	}
+
 	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
 		jsonResponse(w, http.StatusBadRequest, map[string]any{"ok": false, "error": err.Error()})
 		return
@@ -204,13 +227,6 @@ func (s *Server) handleUploadSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	agentID := r.URL.Query().Get("agent")
-	if agentID != "" {
-		// Owner-only — see comment on the JSON-install path above.
-		if s.requireAgentOwner(w, r, agentID) == nil {
-			return
-		}
-	}
 	targetDir, err := resolveInstallTarget(r, agentID)
 	if err != nil {
 		jsonResponse(w, http.StatusForbidden, map[string]any{"ok": false, "error": err.Error()})

--- a/internal/setup/skill_install_test.go
+++ b/internal/setup/skill_install_test.go
@@ -1,0 +1,186 @@
+package setup
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/auth"
+	"github.com/fastclaw-ai/fastclaw/internal/store"
+	"github.com/fastclaw-ai/fastclaw/internal/users"
+)
+
+func TestAuthorizeSkillInstallTargetRequiresAdminForGlobalInstalls(t *testing.T) {
+	s := NewServer(0)
+
+	tests := []struct {
+		name       string
+		ident      auth.Identity
+		wantOK     bool
+		wantStatus int
+	}{
+		{
+			name: "regular user session rejected",
+			ident: auth.Identity{
+				UserID:     "u_user",
+				Role:       users.RoleUser,
+				AuthMethod: "session",
+			},
+			wantOK:     false,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "super admin session allowed",
+			ident: auth.Identity{
+				UserID:     "u_admin",
+				Role:       users.RoleSuperAdmin,
+				AuthMethod: "session",
+			},
+			wantOK: true,
+		},
+		{
+			name: "admin api key allowed",
+			ident: auth.Identity{
+				UserID:     "u_user",
+				Role:       users.RoleUser,
+				AuthMethod: "apikey",
+				APIKeyType: users.APIKeyTypeAdmin,
+			},
+			wantOK: true,
+		},
+		{
+			name: "actAs super admin rejected as read only",
+			ident: auth.Identity{
+				UserID:      "u_admin",
+				Role:        users.RoleSuperAdmin,
+				AuthMethod:  "session",
+				ActAsUserID: "u_other",
+			},
+			wantOK:     false,
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			ok := s.authorizeSkillInstallTarget(rr, skillInstallRequest(tt.ident), "")
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK && rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rr.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestAuthorizeSkillInstallTargetKeepsAgentInstallsOwnerScoped(t *testing.T) {
+	ctx := context.Background()
+	s, st, accts := newSkillInstallAuthServer(t, ctx)
+	owner := createSkillInstallTestUser(t, ctx, accts, "owner", users.RoleUser)
+	other := createSkillInstallTestUser(t, ctx, accts, "other", users.RoleUser)
+	if err := st.SaveAgent(ctx, &store.AgentRecord{
+		ID:     "agt_owner",
+		UserID: owner.ID,
+		Name:   "Owner Agent",
+	}); err != nil {
+		t.Fatalf("SaveAgent: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		ident      auth.Identity
+		wantOK     bool
+		wantStatus int
+	}{
+		{
+			name: "owner allowed",
+			ident: auth.Identity{
+				UserID:     owner.ID,
+				Role:       users.RoleUser,
+				AuthMethod: "session",
+			},
+			wantOK: true,
+		},
+		{
+			name: "non owner rejected",
+			ident: auth.Identity{
+				UserID:     other.ID,
+				Role:       users.RoleUser,
+				AuthMethod: "session",
+			},
+			wantOK:     false,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "read only owner rejected",
+			ident: auth.Identity{
+				UserID:      "u_admin",
+				Role:        users.RoleSuperAdmin,
+				AuthMethod:  "session",
+				ActAsUserID: owner.ID,
+			},
+			wantOK:     false,
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			ok := s.authorizeSkillInstallTarget(rr, skillInstallRequest(tt.ident), "agt_owner")
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK && rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rr.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func skillInstallRequest(ident auth.Identity) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/install", nil)
+	return req.WithContext(auth.WithIdentity(req.Context(), ident))
+}
+
+func newSkillInstallAuthServer(t *testing.T, ctx context.Context) (*Server, store.Store, *users.Accounts) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "fastclaw.db")
+	st, err := store.NewDBStore("sqlite", "file:"+dbPath+"?cache=shared")
+	if err != nil {
+		t.Fatalf("NewDBStore: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = st.Close()
+	})
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	accts, err := users.NewAccounts(st)
+	if err != nil {
+		t.Fatalf("NewAccounts: %v", err)
+	}
+	s := NewServer(0)
+	s.SetStore(st)
+	return s, st, accts
+}
+
+func createSkillInstallTestUser(t *testing.T, ctx context.Context, accts *users.Accounts, username, role string) *users.Account {
+	t.Helper()
+
+	acct, err := accts.Create(ctx, users.CreateInput{
+		Username: username,
+		Email:    username + "@example.test",
+		Password: "password",
+		Role:     role,
+	})
+	if err != nil {
+		t.Fatalf("Create(%s): %v", username, err)
+	}
+	return acct
+}


### PR DESCRIPTION
## Summary

- require platform-admin authorization for global skill installs and uploads
- keep agent-scoped skill installs owner-gated instead of making the whole endpoint admin-only
- add focused setup tests for global admin gating, actAs read-only rejection, and agent owner behavior

## Root Cause

The skill install handlers documented global installs as admin-only, but `/api/skills/install` and `/api/skills/upload` were only behind normal auth. The target resolver returned the global skills directory when no agent was provided without checking platform-admin privileges.

## Validation

- `go test ./internal/setup`
- `go test ./...`