### PR TITLE
Protect tasks list endpoint

### DIFF
--- a/internal/setup/handlers_skills_test.go
+++ b/internal/setup/handlers_skills_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestListSkillsRequiresAuth(t *testing.T) {
 	ctx := context.Background()
-	s, resolver, adminUser, regularUser := newSkillsAuthTestServer(t, ctx)
+	s, resolver, adminUser, regularUser := newAuthTestServer(t, ctx)
 	t.Setenv("FASTCLAW_HOME", t.TempDir())
 
 	handler := s.authMiddleware(s.handleListSkills)
@@ -30,7 +30,7 @@ func TestListSkillsRequiresAuth(t *testing.T) {
 
 	t.Run("regular user is allowed", func(t *testing.T) {
 		rr := httptest.NewRecorder()
-		handler(rr, skillsListRequest(t, ctx, resolver, regularUser.ID))
+		handler(rr, authTestRequest(t, ctx, resolver, http.MethodGet, "/api/skills", regularUser.ID))
 		if rr.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 		}
@@ -41,7 +41,7 @@ func TestListSkillsRequiresAuth(t *testing.T) {
 
 	t.Run("super admin is allowed", func(t *testing.T) {
 		rr := httptest.NewRecorder()
-		handler(rr, skillsListRequest(t, ctx, resolver, adminUser.ID))
+		handler(rr, authTestRequest(t, ctx, resolver, http.MethodGet, "/api/skills", adminUser.ID))
 		if rr.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 		}
@@ -51,7 +51,7 @@ func TestListSkillsRequiresAuth(t *testing.T) {
 	})
 }
 
-func newSkillsAuthTestServer(t *testing.T, ctx context.Context) (*Server, *auth.Resolver, *users.Account, *users.Account) {
+func newAuthTestServer(t *testing.T, ctx context.Context) (*Server, *auth.Resolver, *users.Account, *users.Account) {
 	t.Helper()
 
 	dbPath := filepath.Join(t.TempDir(), "fastclaw.db")
@@ -70,8 +70,8 @@ func newSkillsAuthTestServer(t *testing.T, ctx context.Context) (*Server, *auth.
 	if err != nil {
 		t.Fatalf("NewAccounts: %v", err)
 	}
-	adminUser := createSkillsTestUser(t, ctx, accts, "admin", users.RoleSuperAdmin)
-	regularUser := createSkillsTestUser(t, ctx, accts, "user", users.RoleUser)
+	adminUser := createAuthTestUser(t, ctx, accts, "admin", users.RoleSuperAdmin)
+	regularUser := createAuthTestUser(t, ctx, accts, "user", users.RoleUser)
 	resolver, err := auth.NewResolver(st)
 	if err != nil {
 		t.Fatalf("NewResolver: %v", err)
@@ -83,7 +83,7 @@ func newSkillsAuthTestServer(t *testing.T, ctx context.Context) (*Server, *auth.
 	return s, resolver, adminUser, regularUser
 }
 
-func createSkillsTestUser(t *testing.T, ctx context.Context, accts *users.Accounts, username, role string) *users.Account {
+func createAuthTestUser(t *testing.T, ctx context.Context, accts *users.Accounts, username, role string) *users.Account {
 	t.Helper()
 
 	acct, err := accts.Create(ctx, users.CreateInput{
@@ -98,14 +98,14 @@ func createSkillsTestUser(t *testing.T, ctx context.Context, accts *users.Accoun
 	return acct
 }
 
-func skillsListRequest(t *testing.T, ctx context.Context, resolver *auth.Resolver, userID string) *http.Request {
+func authTestRequest(t *testing.T, ctx context.Context, resolver *auth.Resolver, method, path, userID string) *http.Request {
 	t.Helper()
 
 	cookie, err := resolver.IssueSession(ctx, userID)
 	if err != nil {
 		t.Fatalf("IssueSession: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodGet, "/api/skills", nil)
+	req := httptest.NewRequest(method, path, nil)
 	req.AddCookie(cookie)
 	return req
 }

--- a/internal/setup/handlers_tasks_test.go
+++ b/internal/setup/handlers_tasks_test.go
@@ -1,0 +1,162 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fastclaw-ai/fastclaw/internal/users"
+)
+
+var setupRouteTestHTTPClient = &http.Client{Timeout: 2 * time.Second}
+
+func TestListTasksRouteRequiresPlatformAdmin(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, adminUser, regularUser := newAuthTestServer(t, ctx)
+	s.port = freeTCPPort(t)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Run(runCtx)
+	}()
+	baseURL := "http://127.0.0.1:" + strconv.Itoa(s.port)
+	waitForSetupServer(t, baseURL, errCh)
+
+	t.Run("unauthenticated request is rejected", func(t *testing.T) {
+		resp := tasksListHTTPResponse(t, baseURL, nil)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("regular user is rejected", func(t *testing.T) {
+		cookie, err := resolver.IssueSession(ctx, regularUser.ID)
+		if err != nil {
+			t.Fatalf("IssueSession: %v", err)
+		}
+		resp := tasksListHTTPResponse(t, baseURL, cookie)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+
+	t.Run("super admin is allowed", func(t *testing.T) {
+		cookie, err := resolver.IssueSession(ctx, adminUser.ID)
+		if err != nil {
+			t.Fatalf("IssueSession: %v", err)
+		}
+		resp := tasksListHTTPResponse(t, baseURL, cookie)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if got := strings.TrimSpace(string(body)); got != "[]" {
+			t.Fatalf("body = %q, want []", got)
+		}
+	})
+
+	t.Run("admin api key is allowed", func(t *testing.T) {
+		if s.apikeys == nil {
+			t.Fatal("apikeys not configured")
+		}
+		_, token, err := s.apikeys.Create(ctx, adminUser.ID, "tasks-admin", users.APIKeyTypeAdmin, nil)
+		if err != nil {
+			t.Fatalf("Create admin apikey: %v", err)
+		}
+		resp := tasksListBearerHTTPResponse(t, baseURL, token)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+	})
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop after context cancellation")
+	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func waitForSetupServer(t *testing.T, baseURL string, errCh <-chan error) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			t.Fatalf("Run exited before server was ready: %v", err)
+		default:
+		}
+		resp, err := setupRouteTestHTTPClient.Get(baseURL + "/healthz")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("server did not become ready at %s", baseURL)
+}
+
+func tasksListHTTPResponse(t *testing.T, baseURL string, cookie *http.Cookie) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/tasks", baseURL), nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	resp, err := setupRouteTestHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	return resp
+}
+
+func tasksListBearerHTTPResponse(t *testing.T, baseURL, token string) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/tasks", baseURL), nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := setupRouteTestHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	return resp
+}

--- a/internal/setup/server.go
+++ b/internal/setup/server.go
@@ -351,7 +351,7 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.HandleFunc("PUT /api/agents/{id}/cron/{jobId}", auth(s.handleToggleAgentCronJob))
 
 	// Tasks
-	mux.HandleFunc("GET /api/tasks", auth(s.handleListTasks))
+	mux.HandleFunc("GET /api/tasks", admin(s.handleListTasks))
 
 	// Apikeys (per-user, with agent multi-select).
 	mux.HandleFunc("GET /api/apikeys", auth(s.handleListAPIKeys))


### PR DESCRIPTION
## Summary
- Restrict `GET /api/tasks` to platform admins.
- Add route-level coverage for unauthenticated users, regular users, super admin sessions, and admin API keys.
- Reuse the existing setup auth test fixture across skills and tasks tests.

## Why
`handleListTasks` returns global recent task metadata, including agent IDs, chat keys, statuses, and errors. That is platform-level observability data, so ordinary authenticated users should not be able to inspect it.

## Testing
- `go test ./...`
