### PR TITLE
feat(agent): model fallback chain on provider availability errors

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -31,8 +31,17 @@ import (
 
 // Agent is the ReAct agent loop.
 type Agent struct {
-	name                 string
-	provider             provider.Provider
+	name     string
+	provider provider.Provider
+	// modelFallbacks are pre-built (model, provider) pairs tried in
+	// order when the primary model's initial ChatStream call fails
+	// with an availability error (5xx / 429 / transport) — see
+	// chatStreamWithFallback. Resolved once from rc.ModelFallbacks at
+	// construction (fallbacksForAgent); empty for agents without the
+	// config, which keeps the failover wrapper on the zero-overhead
+	// path. Note /model only rewrites a.model — a session-switched
+	// primary keeps the statically configured fallback chain.
+	modelFallbacks       []fallbackClient
 	registry             *tools.Registry
 	sessions             *session.Manager
 	memory               *Memory
@@ -296,6 +305,7 @@ func NewAgentWithSkillsCfg(rc config.ResolvedAgent, prov provider.Provider, mb *
 	ag := &Agent{
 		name:                 rc.ID,
 		provider:             prov,
+		modelFallbacks:       fallbacksForAgent(rc),
 		registry:             registry,
 		sessions:             session.NewManager(rc.Home + "/sessions"),
 		memory:               memory,
@@ -646,6 +656,38 @@ func (a *Agent) meterTokens(ctx context.Context, sessionKey string, u provider.U
 	}
 }
 
+// chatStreamWithFallback opens the turn's LLM stream: the primary model
+// first, then each configured fallback in order. Failover triggers only
+// on availability errors — 5xx / 429 / transport failures, see
+// provider.IsAvailabilityError — from the *initial* call. Once a stream
+// is open, mid-stream failures keep surfacing through StreamReader.Err
+// as before: re-driving a half-delivered answer through a different
+// model would duplicate output the user already saw.
+//
+// Returns the model that actually served the stream alongside the
+// reader; callers that don't need it ignore it (a.model stays the
+// display/session truth — fallbacks are a per-call retry, not a model
+// switch). When every fallback fails, the LAST error is returned — by
+// then the primary's cause has already been logged once per attempted
+// fallback. With no fallbacks configured this is exactly the old direct
+// ChatStream call: no extra allocations, no log lines.
+func (a *Agent) chatStreamWithFallback(ctx context.Context, messages []provider.Message, tools []provider.Tool) (*provider.StreamReader, string, error) {
+	sr, err := a.provider.ChatStream(ctx, messages, tools, a.model, a.maxTokens, a.temperature)
+	if err == nil || len(a.modelFallbacks) == 0 || !provider.IsAvailabilityError(err) {
+		return sr, a.model, err
+	}
+	from := a.model
+	for _, fb := range a.modelFallbacks {
+		slog.Warn("model fallback", "agent", a.name, "from", from, "to", fb.model, "cause", err)
+		sr, err = fb.prov.ChatStream(ctx, messages, tools, fb.model, a.maxTokens, a.temperature)
+		if err == nil {
+			return sr, fb.model, nil
+		}
+		from = fb.model
+	}
+	return nil, from, err
+}
+
 // streamChatToResponse is a drop-in replacement for provider.Chat that
 // pipes text chunks to the chat-event channel in real time via
 // content_delta events. The web UI subscriber appends each delta to
@@ -663,7 +705,7 @@ func (a *Agent) meterTokens(ctx context.Context, sessionKey string, u provider.U
 // HandleMessage path. Providers that don't actually stream still work
 // — they just deliver one big chunk on Done.
 func (a *Agent) streamChatToResponse(ctx context.Context, messages []provider.Message, tools []provider.Tool) (*provider.Response, error) {
-	sr, err := a.provider.ChatStream(ctx, messages, tools, a.model, a.maxTokens, a.temperature)
+	sr, _, err := a.chatStreamWithFallback(ctx, messages, tools)
 	if err != nil {
 		return nil, err
 	}
@@ -2606,7 +2648,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 
 		if !resp.HasToolCalls() {
 			// Final response - use streaming
-			sr, err := a.provider.ChatStream(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
+			sr, _, err := a.chatStreamWithFallback(ctx, messages, toolDefs)
 			if err != nil {
 				slog.Error("LLM stream failed, falling back", "agent", a.name, "error", err)
 				sess.Append(provider.Message{Role: "assistant", Content: resp.Content})

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -29,13 +29,62 @@ import (
 // builds its own provider.Provider from its own API key+base, not the
 // user-space-wide one.
 func providerForAgent(rc config.ResolvedAgent, shared provider.Provider) provider.Provider {
-	parts := strings.SplitN(rc.Model, "/", 2)
+	if p := providerForModel(rc, rc.Model); p != nil {
+		return p
+	}
+	return shared
+}
+
+// providerForModel resolves one "<providerKey>/<modelId>" string against
+// the agent's merged provider map (steps 1–2 of providerForAgent).
+// Returns nil when the model has no provider prefix, the prefix isn't in
+// rc.Providers, or the entry has no API key — callers pick the fallback
+// behavior (shared provider for the primary model, skip-with-warning for
+// fallback models).
+func providerForModel(rc config.ResolvedAgent, model string) provider.Provider {
+	parts := strings.SplitN(model, "/", 2)
 	if len(parts) == 2 {
 		if pc, ok := rc.Providers[parts[0]]; ok && pc.APIKey != "" {
 			return provider.NewProvider(pc.APIKey, pc.APIBase, pc.APIType)
 		}
 	}
-	return shared
+	return nil
+}
+
+// fallbackClient pairs a fallback model with the provider instance built
+// to serve it. Resolved once at agent construction — same lifecycle as
+// the primary provider — so chatStreamWithFallback never touches config
+// on the hot path.
+type fallbackClient struct {
+	model string
+	prov  provider.Provider
+}
+
+// fallbacksForAgent resolves rc.ModelFallbacks into ready-to-call
+// clients. Unresolvable entries are skipped with a warning instead of
+// failing agent construction: a typo'd fallback shouldn't take down an
+// agent whose primary model works. Unlike providerForAgent there is no
+// shared-provider fallback here — firing a fallback model id at
+// whatever base URL the shared provider points at would turn every
+// failover into a confusing 400 from the wrong vendor.
+func fallbacksForAgent(rc config.ResolvedAgent) []fallbackClient {
+	if len(rc.ModelFallbacks) == 0 {
+		return nil
+	}
+	out := make([]fallbackClient, 0, len(rc.ModelFallbacks))
+	for _, m := range rc.ModelFallbacks {
+		if m == rc.Model {
+			slog.Warn("model fallback skipped", "agent", rc.ID, "model", m, "reason", "same as primary model")
+			continue
+		}
+		prov := providerForModel(rc, m)
+		if prov == nil {
+			slog.Warn("model fallback skipped", "agent", rc.ID, "model", m, "reason", "no provider with an API key for prefix")
+			continue
+		}
+		out = append(out, fallbackClient{model: m, prov: prov})
+	}
+	return out
 }
 
 // ManagerOption configures optional Manager behavior.

--- a/internal/agent/model_fallback_test.go
+++ b/internal/agent/model_fallback_test.go
@@ -1,0 +1,195 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+)
+
+// scriptedStreamProvider fails or succeeds ChatStream with a canned
+// payload and records every model it was asked for, so tests can
+// assert exactly which links of the fallback chain were exercised.
+type scriptedStreamProvider struct {
+	content string
+	err     error
+	models  []string
+}
+
+func (p *scriptedStreamProvider) Chat(_ context.Context, _ []provider.Message, _ []provider.Tool, _ string, _ int, _ float64) (*provider.Response, error) {
+	return nil, errors.New("scriptedStreamProvider: Chat not used by these tests")
+}
+
+func (p *scriptedStreamProvider) ChatStream(_ context.Context, _ []provider.Message, _ []provider.Tool, model string, _ int, _ float64) (*provider.StreamReader, error) {
+	p.models = append(p.models, model)
+	if p.err != nil {
+		return nil, p.err
+	}
+	ch := make(chan provider.StreamChunk, 1)
+	ch <- provider.StreamChunk{Content: p.content, Done: true}
+	close(ch)
+	return provider.NewStreamReader(ch), nil
+}
+
+func drainStream(t *testing.T, sr *provider.StreamReader) string {
+	t.Helper()
+	var b strings.Builder
+	for {
+		chunk, ok := sr.Next()
+		if !ok {
+			break
+		}
+		b.WriteString(chunk.Content)
+	}
+	if err := sr.Err(); err != nil {
+		t.Fatalf("stream err: %v", err)
+	}
+	return b.String()
+}
+
+// fallbackAgent builds the minimal Agent chatStreamWithFallback needs.
+// The full constructor drags in skills/memory/filesystem wiring and
+// none of it participates in the failover decision.
+func fallbackAgent(primary provider.Provider, fallbacks ...fallbackClient) *Agent {
+	return &Agent{
+		name:           "test-agent",
+		provider:       primary,
+		model:          "primary/model-a",
+		maxTokens:      128,
+		modelFallbacks: fallbacks,
+	}
+}
+
+// An availability failure on the primary (503) must fail over and
+// deliver the fallback's stream — the user gets an answer instead of
+// the generic apology line.
+func TestChatStreamFallsBackOnAvailabilityError(t *testing.T) {
+	primary := &scriptedStreamProvider{err: &provider.APIError{StatusCode: 503, Body: "overloaded"}}
+	fb := &scriptedStreamProvider{content: "from fallback"}
+	a := fallbackAgent(primary, fallbackClient{model: "backup/model-b", prov: fb})
+
+	sr, served, err := a.chatStreamWithFallback(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got %v", err)
+	}
+	if served != "backup/model-b" {
+		t.Errorf("served model = %q, want backup/model-b", served)
+	}
+	if got := drainStream(t, sr); got != "from fallback" {
+		t.Errorf("content = %q, want %q", got, "from fallback")
+	}
+	if len(fb.models) != 1 || fb.models[0] != "backup/model-b" {
+		t.Errorf("fallback should be called once with its own model, got %v", fb.models)
+	}
+}
+
+// A 400 is the request's fault, not the provider's — replaying the
+// same payload at another vendor would just burn quota on a second
+// rejection. The fallback must never be touched.
+func TestChatStreamNoFallbackOnRequestError(t *testing.T) {
+	primary := &scriptedStreamProvider{err: &provider.APIError{StatusCode: 400, Body: "bad request"}}
+	fb := &scriptedStreamProvider{content: "never delivered"}
+	a := fallbackAgent(primary, fallbackClient{model: "backup/model-b", prov: fb})
+
+	_, _, err := a.chatStreamWithFallback(context.Background(), nil, nil)
+	var apiErr *provider.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 400 {
+		t.Fatalf("want the original 400 back, got %v", err)
+	}
+	if len(fb.models) != 0 {
+		t.Fatalf("fallback must not be called on 4xx, got calls for %v", fb.models)
+	}
+}
+
+// No fallbacks configured → identical to the old direct ChatStream
+// call: the primary's error propagates unchanged.
+func TestChatStreamErrorUnchangedWithoutFallbacks(t *testing.T) {
+	primaryErr := &provider.APIError{StatusCode: 503, Body: "overloaded"}
+	primary := &scriptedStreamProvider{err: primaryErr}
+	a := fallbackAgent(primary)
+
+	_, _, err := a.chatStreamWithFallback(context.Background(), nil, nil)
+	if !errors.Is(err, primaryErr) {
+		t.Fatalf("error should propagate unchanged, got %v", err)
+	}
+	if len(primary.models) != 1 || primary.models[0] != "primary/model-a" {
+		t.Errorf("primary should be called exactly once, got %v", primary.models)
+	}
+}
+
+// Healthy primary: the wrapper is a pass-through and the fallback
+// chain stays cold.
+func TestChatStreamPrimaryHealthySkipsFallbacks(t *testing.T) {
+	primary := &scriptedStreamProvider{content: "from primary"}
+	fb := &scriptedStreamProvider{content: "never delivered"}
+	a := fallbackAgent(primary, fallbackClient{model: "backup/model-b", prov: fb})
+
+	sr, served, err := a.chatStreamWithFallback(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("primary should succeed, got %v", err)
+	}
+	if served != "primary/model-a" {
+		t.Errorf("served model = %q, want primary/model-a", served)
+	}
+	if got := drainStream(t, sr); got != "from primary" {
+		t.Errorf("content = %q, want %q", got, "from primary")
+	}
+	if len(fb.models) != 0 {
+		t.Errorf("fallback must stay cold when primary works, got %v", fb.models)
+	}
+}
+
+// Every link down → the LAST error surfaces (each hop's cause was
+// already logged) and every fallback was tried in order.
+func TestChatStreamAllFallbacksFailReturnsLastError(t *testing.T) {
+	primary := &scriptedStreamProvider{err: &provider.APIError{StatusCode: 503, Body: "primary down"}}
+	fb1 := &scriptedStreamProvider{err: &provider.APIError{StatusCode: 502, Body: "fb1 down"}}
+	lastErr := &provider.APIError{StatusCode: 529, Body: "fb2 down"}
+	fb2 := &scriptedStreamProvider{err: lastErr}
+	a := fallbackAgent(primary,
+		fallbackClient{model: "backup/one", prov: fb1},
+		fallbackClient{model: "backup/two", prov: fb2},
+	)
+
+	sr, _, err := a.chatStreamWithFallback(context.Background(), nil, nil)
+	if sr != nil {
+		t.Fatal("no stream should be returned when every model fails")
+	}
+	if !errors.Is(err, lastErr) {
+		t.Fatalf("want the last fallback's error, got %v", err)
+	}
+	if len(fb1.models) != 1 || len(fb2.models) != 1 {
+		t.Errorf("both fallbacks should be tried once, got fb1=%v fb2=%v", fb1.models, fb2.models)
+	}
+}
+
+// fallbacksForAgent must skip entries it can't build a provider for —
+// a typo'd fallback degrades to a logged skip, never a broken agent or
+// a request fired at the wrong vendor's base URL.
+func TestFallbacksForAgentSkipsUnresolvable(t *testing.T) {
+	rc := config.ResolvedAgent{
+		ID:    "a1",
+		Model: "openai/gpt-5.5",
+		ModelFallbacks: []string{
+			"openai/gpt-5.5",           // same as primary → skip
+			"missing/model",            // no provider entry → skip
+			"nokey/model",              // provider has no API key → skip
+			"anthropic/claude-fable-5", // resolvable → kept
+		},
+		Providers: map[string]config.ProviderConfig{
+			"openai":    {APIKey: "k1"},
+			"nokey":     {},
+			"anthropic": {APIKey: "k2", APIType: "anthropic-messages"},
+		},
+	}
+	fbs := fallbacksForAgent(rc)
+	if len(fbs) != 1 {
+		t.Fatalf("want exactly one resolvable fallback, got %d", len(fbs))
+	}
+	if fbs[0].model != "anthropic/claude-fable-5" || fbs[0].prov == nil {
+		t.Fatalf("want the anthropic fallback with a built provider, got %+v", fbs[0])
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -347,10 +347,18 @@ type AgentsConfig struct {
 }
 
 type AgentDefaults struct {
-	Model             string  `json:"model,omitempty"`
-	MaxTokens         int     `json:"maxTokens,omitempty"`
-	Temperature       float64 `json:"temperature,omitempty"`
-	MaxToolIterations int     `json:"maxToolIterations,omitempty"`
+	Model string `json:"model,omitempty"`
+	// ModelFallbacks are tried in order when the primary Model's
+	// provider fails the initial call of a turn with an availability
+	// error (HTTP 5xx, 429, or a transport failure). Same
+	// "<providerKey>/<modelId>" format as Model; entries whose
+	// provider key has no usable credentials are skipped at agent
+	// build time. See agent.chatStreamWithFallback for the failover
+	// policy (never mid-stream, never on caller cancellation).
+	ModelFallbacks    []string `json:"modelFallbacks,omitempty"`
+	MaxTokens         int      `json:"maxTokens,omitempty"`
+	Temperature       float64  `json:"temperature,omitempty"`
+	MaxToolIterations int      `json:"maxToolIterations,omitempty"`
 	// MaxParallelToolCalls caps how many tool calls a single LLM
 	// response is allowed to execute concurrently in one round. The
 	// LLM still decides how many tools to emit; we just refuse to
@@ -599,10 +607,15 @@ type ResolvedAgent struct {
 	// operator gave the agent ("Bob", "tdj", "Sonny"). Used as a
 	// fallback identity line in the system prompt when IDENTITY.md
 	// is empty so the model doesn't introduce itself as "Claude".
-	DisplayName          string
-	Home                 string
-	Workspace            string
-	Model                string
+	DisplayName string
+	Home        string
+	Workspace   string
+	Model       string
+	// ModelFallbacks — see AgentDefaults.ModelFallbacks. Resolved into
+	// per-model provider clients at agent build time
+	// (agent.fallbacksForAgent), not here, so a bad entry degrades to
+	// a logged skip instead of failing resolution.
+	ModelFallbacks       []string
 	MaxTokens            int
 	Temperature          float64
 	MaxToolIterations    int
@@ -728,6 +741,7 @@ func (cfg *Config) MergedAgentConfig(entry AgentEntry) ResolvedAgent {
 		Home:                 home,
 		Workspace:            workspace,
 		Model:                cfg.Agents.Defaults.Model,
+		ModelFallbacks:       cfg.Agents.Defaults.ModelFallbacks,
 		MaxTokens:            cfg.Agents.Defaults.MaxTokens,
 		Temperature:          cfg.Agents.Defaults.Temperature,
 		MaxToolIterations:    cfg.Agents.Defaults.MaxToolIterations,

--- a/internal/gateway/userspace.go
+++ b/internal/gateway/userspace.go
@@ -461,6 +461,9 @@ func (sp *UserSpace) EnsureAgent(ctx context.Context, st store.Store, mb *bus.Me
 			if ovr.Model != "" {
 				rc.Model = ovr.Model
 			}
+			if len(ovr.ModelFallbacks) > 0 {
+				rc.ModelFallbacks = ovr.ModelFallbacks
+			}
 			if ovr.MaxTokens > 0 {
 				rc.MaxTokens = ovr.MaxTokens
 			}
@@ -670,6 +673,9 @@ func loadUserSpace(ctx context.Context, userID string, mb *bus.MessageBus, st st
 			_ = json.Unmarshal(blob, &agentOverride)
 			if agentOverride.Model != "" {
 				rc.Model = agentOverride.Model
+			}
+			if len(agentOverride.ModelFallbacks) > 0 {
+				rc.ModelFallbacks = agentOverride.ModelFallbacks
 			}
 			if agentOverride.MaxTokens > 0 {
 				rc.MaxTokens = agentOverride.MaxTokens

--- a/internal/gateway/userspace_test.go
+++ b/internal/gateway/userspace_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/fastclaw-ai/fastclaw/internal/bus"
+	"github.com/fastclaw-ai/fastclaw/internal/config"
 	"github.com/fastclaw-ai/fastclaw/internal/scope"
 	"github.com/fastclaw-ai/fastclaw/internal/store"
 	"github.com/fastclaw-ai/fastclaw/internal/users"
@@ -137,5 +138,59 @@ func TestResolveChatterSeparatesIMSendersForRegularOwner(t *testing.T) {
 	}
 	if aliceAccount.ExternalID != "telegram:bot-a:111" {
 		t.Fatalf("unexpected external id: %q", aliceAccount.ExternalID)
+	}
+}
+
+// ModelFallbacks ride the same agents.defaults override row as Model.
+// Pin the whole data path the loadUserSpace / EnsureAgent overlays
+// rely on: row data (map[string]interface{}) → AgentDefaults's
+// modelFallbacks JSON key → ResolvedAgent via MergedAgentConfig. A
+// silent break anywhere here means a configured fallback chain never
+// reaches the agent and the first provider outage goes user-visible
+// again.
+func TestAgentScopeModelFallbacksMerge(t *testing.T) {
+	db, err := store.NewDBStore("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	ctx := context.Background()
+
+	if err := scope.SaveSetting(ctx, db, "", "agent-x", NSAgentDefaults,
+		map[string]interface{}{
+			"model":          "openai/gpt-5.5",
+			"modelFallbacks": []interface{}{"anthropic/claude-fable-5", "openrouter/llama-4"},
+		}); err != nil {
+		t.Fatalf("save agent row: %v", err)
+	}
+
+	cfg, err := assembleConfig(ctx, db, "", "agent-x")
+	if err != nil {
+		t.Fatalf("assemble config: %v", err)
+	}
+	want := []string{"anthropic/claude-fable-5", "openrouter/llama-4"}
+	got := cfg.Agents.Defaults.ModelFallbacks
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("defaults fallbacks = %v, want %v", got, want)
+	}
+
+	// The defaults must carry through to the per-agent resolved view —
+	// that's what fallbacksForAgent reads at agent build time.
+	rc := cfg.MergedAgentConfig(config.AgentEntry{ID: "agent-x"})
+	got = rc.ModelFallbacks
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("resolved fallbacks = %v, want %v", got, want)
+	}
+
+	// A row without the key must not invent a chain for other agents.
+	cfgOther, err := assembleConfig(ctx, db, "", "agent-y")
+	if err != nil {
+		t.Fatalf("assemble config (other agent): %v", err)
+	}
+	if n := len(cfgOther.Agents.Defaults.ModelFallbacks); n != 0 {
+		t.Fatalf("agent without override row should have no fallbacks, got %d", n)
 	}
 }

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -418,7 +418,7 @@ func (p *AnthropicProvider) Chat(ctx context.Context, messages []Message, tools 
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	return p.parseSSE(resp.Body)
@@ -438,7 +438,7 @@ func (p *AnthropicProvider) ChatStream(ctx context.Context, messages []Message, 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	ch := make(chan StreamChunk, 64)

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// APIError is a non-2xx HTTP response from an LLM provider API. It
+// replaces the fmt.Errorf("API error %d: %s", ...) strings the Chat /
+// ChatStream sites used to return, keeping the status code machine-
+// readable so callers (agent model fallback) can tell "the provider is
+// down" apart from "the request is wrong" without string matching.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error preserves the exact legacy format — logs, the chat-UI error
+// surfaces, and anything keyed on the old string see no change.
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error %d: %s", e.StatusCode, e.Body)
+}
+
+// IsAvailabilityError reports whether err means the provider was
+// unavailable, as opposed to the request itself being rejected. This is
+// the failover gate for the agent's model fallback chain: only errors a
+// *different* provider could plausibly fix should trigger it.
+//
+//   - *APIError 5xx / 429: the provider is overloaded, broken, or rate
+//     limiting us — retrying elsewhere can help.
+//   - *APIError other 4xx: bad request, bad auth, oversized context —
+//     replaying the same payload at another provider just burns quota
+//     on a second rejection (or worse, a different model "fixes" a
+//     malformed request by silently accepting it).
+//   - Non-APIError, non-nil: the provider never answered at all
+//     (connection refused, DNS failure, TLS error, net/http timeout).
+//     Request-shaped problems always come back as *APIError, so
+//     anything else is transport-level and worth a failover.
+//   - context.Canceled / DeadlineExceeded: the CALLER gave up, not the
+//     provider — firing the same doomed request at the next provider
+//     would only waste tokens. Checked first because net/http wraps
+//     ctx errors and they would otherwise fall into the transport case.
+func IsAvailabilityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == 429 || apiErr.StatusCode >= 500
+	}
+	return true
+}

--- a/internal/provider/errors_test.go
+++ b/internal/provider/errors_test.go
@@ -1,0 +1,49 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// The fmt.Errorf sites APIError replaced produced exactly
+// "API error %d: %s" — logs, the chat-UI error bubble, and the stream-
+// fallback warnings all surface that string. Pin it so the move to a
+// typed error stays invisible to those consumers.
+func TestAPIErrorPreservesLegacyFormat(t *testing.T) {
+	err := &APIError{StatusCode: 503, Body: "body"}
+	if got, want := err.Error(), "API error 503: body"; got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+// IsAvailabilityError is the failover gate for the model fallback
+// chain: provider-down signals (5xx / 429 / transport) pass, request
+// rejections (other 4xx) and caller cancellation do not.
+func TestIsAvailabilityError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"api 503", &APIError{StatusCode: 503, Body: "overloaded"}, true},
+		{"api 500", &APIError{StatusCode: 500, Body: "boom"}, true},
+		{"api 429", &APIError{StatusCode: 429, Body: "rate limited"}, true},
+		{"api 400", &APIError{StatusCode: 400, Body: "bad request"}, false},
+		{"api 401", &APIError{StatusCode: 401, Body: "bad key"}, false},
+		{"wrapped api 503", fmt.Errorf("send request: %w", &APIError{StatusCode: 503}), true},
+		{"wrapped api 400", fmt.Errorf("send request: %w", &APIError{StatusCode: 400}), false},
+		{"transport", fmt.Errorf("connection refused"), true},
+		{"caller cancel", context.Canceled, false},
+		{"caller deadline", context.DeadlineExceeded, false},
+		{"wrapped cancel", fmt.Errorf("send request: %w", context.Canceled), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsAvailabilityError(tc.err); got != tc.want {
+				t.Fatalf("IsAvailabilityError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -290,7 +290,7 @@ func (p *OpenAIProvider) Chat(ctx context.Context, messages []Message, tools []T
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	return p.parseSSE(resp.Body)
@@ -311,7 +311,7 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, too
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	ch := make(chan StreamChunk, 64)


### PR DESCRIPTION
Implements #64.

## Why

Agents are pinned to a single LLM provider via `agents.defaults.model`. When that provider has an availability incident (5xx, 429, upstream account-pool exhaustion), every turn on every channel fails with the canned error — even when another configured provider serving the same model is healthy. Relay/pool-style providers make this a regular occurrence, not an edge case.

## What

`modelFallbacks` next to `model` in agent defaults (system scope and per-agent override):

```jsonc
{
  "model": "relay/gpt-5.5",
  "modelFallbacks": ["openai/gpt-5.5"]
}
```

- **`provider.APIError`** — typed error for non-2xx provider responses, replacing the `fmt.Errorf("API error %d: %s", ...)` strings at the four Chat/ChatStream sites. `Error()` preserves the exact legacy format, so logs, the chat-UI error surface, and anything keyed on the old string are unchanged. This makes the status code machine-readable, which the failover gate needs.
- **`provider.IsAvailabilityError`** — the failover policy: `*APIError` 5xx/429 and transport-level failures (connection refused, DNS, TLS, timeouts) fail over; other 4xx do not (replaying a rejected request elsewhere just burns quota); caller cancellation (`context.Canceled` / `DeadlineExceeded`) never fails over.
- **`chatStreamWithFallback`** — wraps the two user-facing ChatStream call sites (`streamChatToResponse` and the tool-loop final response). Tries the primary, then each fallback in order, one `slog.Warn("model fallback", ...)` per attempt. Mid-stream failures (after first tokens) intentionally do NOT fail over — re-driving a half-delivered answer through a different model would duplicate output the user already saw. With no fallbacks configured the path is byte-for-byte the old direct call: no allocations, no log lines.
- **Config plumbing** — `AgentDefaults.ModelFallbacks` → `ResolvedAgent` → both agent-scope overlay sites (`loadUserSpace` and the `EnsureAgent` overlay, which the code comments require to stay aligned). Fallback (model, provider) clients are resolved once at agent construction; entries with a missing provider key or empty API key are skipped with a warning at boot. `/model` keeps working unchanged — it rewrites the session's primary, and the static fallback chain applies to whatever the current primary is.

## Testing

- `internal/provider`: `APIError` format compatibility + `IsAvailabilityError` table tests (5xx/429/transport true; 4xx/cancellation/nil false)
- `internal/agent`: failover succeeds on 503 → fallback content returned; 400 does not trigger fallback (fallback provider never called); empty chain propagates the original error unchanged
- `internal/gateway`: `modelFallbacks` merges from an agent-scope `agents.defaults` row through the real `assembleConfig` → `MergedAgentConfig` path
- `go build ./...`, `go vet`, and the provider/agent/gateway/config test suites pass; the only failure in a full `go test ./...` is the pre-existing date-sensitive `internal/cron` case, untouched by this change

Out of scope, can follow up if wanted: failover for background LLM calls (compaction, auto-persist memory), per-call failover chat events, cooldown for flapping primaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
