### PR TITLE
feat: backend-agnostic project runtime + multi-template + preview UX

### DIFF
--- a/cmd/fastclaw/main.go
+++ b/cmd/fastclaw/main.go
@@ -194,9 +194,14 @@ func runGateway(port int) error {
 	// env-overridable so fastclaw stays template-agnostic — the default
 	// targets a ShipAny image with the template baked at /template.
 	if home, herr := config.HomeDir(); herr == nil {
+		// backend + shared pool let the runtime host previews through the
+		// agent's pooled executor on non-docker backends (e2b/boxlite);
+		// docker keeps its dedicated-container path. Pool is nil when
+		// sandboxing is disabled, which keeps the docker path.
 		rtMgr := coderuntime.NewManager(
 			gw.Store(), home, env.Sandbox.Image,
-			&sandbox.Policy{}, os.Getenv("FASTCLAW_PREVIEW_BASE"))
+			&sandbox.Policy{}, os.Getenv("FASTCLAW_PREVIEW_BASE"),
+			env.Sandbox.Backend, gw.SandboxPool())
 		rtMgr.RegisterTemplate("shipany-tanstack", coderuntime.TemplateSpec{
 			DevPort: 3000,
 			// Default scaffold, validated end-to-end against
@@ -217,13 +222,75 @@ func runGateway(port int) error {
 					"--exclude=node_modules --exclude=.git --exclude=.output --exclude=dist "+
 					"-cf - . | tar -C /workspace -xf -; fi; cd /workspace; "+
 					"command -v pnpm >/dev/null 2>&1 || npm i -g pnpm; "+
+					// Point pnpm at the shared store volume so installs after the
+					// first reuse downloaded packages instead of re-fetching.
+					"pnpm config set store-dir /pnpm-store 2>/dev/null || true; "+
 					"pnpm config set verify-deps-before-run false; "+
-					"pnpm install || true; pnpm rebuild"),
-			DevCmd: envOr("FASTCLAW_SHIPANY_DEV", "pnpm dev --host 0.0.0.0 --port 3000"),
+					"pnpm install || true; pnpm rebuild; "+
+					// Snapshot the pristine template as a git baseline so the UI
+					// can later show ONLY the files the agent changed (git status
+					// vs this commit). .gitignore already excludes node_modules /
+					// build output, so the diff stays clean.
+					"git config --global --add safe.directory '*' 2>/dev/null || true; "+
+					"git init -q 2>/dev/null || true; git add -A 2>/dev/null || true; "+
+					"git -c user.email=bot@fastclaw -c user.name=fastclaw commit -q -m baseline 2>/dev/null || true"),
+			// Self-heal pnpm before running: the base image ships node+npm
+			// only, and pnpm is installed globally (container FS, NOT the
+			// bind-mounted /workspace). On a wake/re-up the container is
+			// recreated but the workspace already has files, so scaffold is
+			// skipped and the global pnpm is gone — `pnpm dev` would then
+			// fail "pnpm: not found". Ensuring it here makes DevCmd robust
+			// across container recreation without re-running the scaffold.
+			// Self-heal pnpm + its run-time config before starting dev. Both
+			// live in the container FS (global pnpm install + ~/.pnpmrc), NOT
+			// the bind-mounted /workspace, so a wake/re-up that recreates the
+			// container loses them while scaffold is skipped (workspace
+			// non-empty). Without `verify-deps-before-run false`, pnpm 11
+			// re-runs a deps-status check before `dev` that fails against the
+			// volume-mounted node_modules and aborts the server.
+			// Self-heal pnpm, its config, AND deps before dev. All three live
+			// outside the bind-mounted /workspace (global pnpm in container
+			// FS; node_modules in a per-scope volume that Stop removes), so a
+			// re-up after Stop recreates the container with files present
+			// (scaffold skipped) but no deps — `pnpm dev` would then die with
+			// "vite: not found". Reinstalling when node_modules/.bin/vite is
+			// missing makes every boot self-correct (fast: the shared pnpm
+			// store volume hard-links, no re-download).
+			DevCmd: envOr("FASTCLAW_SHIPANY_DEV",
+				"command -v pnpm >/dev/null 2>&1 || npm i -g pnpm; "+
+					"pnpm config set verify-deps-before-run false 2>/dev/null || true; "+
+					"[ -x node_modules/.bin/vite ] || pnpm install || true; "+
+					"pnpm dev --host 0.0.0.0 --port 3000"),
 			// Local template checkout bind-mounted at /template (option C):
 			// set FASTCLAW_SHIPANY_TEMPLATE_DIR=~/code/shipany-tanstack to
 			// scaffold from disk without baking the image or cloning.
 			TemplateMount: os.Getenv("FASTCLAW_SHIPANY_TEMPLATE_DIR"),
+		})
+		// A second, lighter template demonstrating multi-template support:
+		// a plain Vite + React + TS starter. It needs no baked /template and
+		// no R2 source — it self-scaffolds with `npm create vite` — and shares
+		// the SAME sandbox image as shipany (Node toolchain), so it proves the
+		// "one e2b image, many templates differing only by ScaffoldCmd" model
+		// (no per-template image needed for same-stack templates). Vite's HMR
+		// client follows the page origin, so it works through both docker's
+		// host-port map and e2b's <port>-<id>.e2b.app proxy with no extra
+		// config. shipany-tanstack above is untouched.
+		rtMgr.RegisterTemplate("vite-react", coderuntime.TemplateSpec{
+			DevPort: 5173,
+			ScaffoldCmd: envOr("FASTCLAW_VITE_REACT_SCAFFOLD",
+				"set -e; cd /workspace; "+
+					"if [ ! -f package.json ]; then "+
+					"npm create vite@latest .fctmp -- --template react-ts && "+
+					"cp -a .fctmp/. ./ && rm -rf .fctmp; fi; "+
+					"npm install; "+
+					// Git baseline so the UI's changed-files view diffs against
+					// the pristine scaffold — same pattern as shipany above.
+					"git config --global --add safe.directory '*' 2>/dev/null || true; "+
+					"git init -q 2>/dev/null || true; git add -A 2>/dev/null || true; "+
+					"git -c user.email=bot@fastclaw -c user.name=fastclaw commit -q -m baseline 2>/dev/null || true"),
+			DevCmd: envOr("FASTCLAW_VITE_REACT_DEV",
+				"[ -x node_modules/.bin/vite ] || npm install; "+
+					"npm run dev -- --host 0.0.0.0 --port 5173"),
 		})
 		webSrv.SetRuntimeManager(rtMgr) // HTTP /runtime endpoints
 		gw.SetProjectRuntime(rtMgr)     // agent preview tools

--- a/docs/coding-agent-runtime.md
+++ b/docs/coding-agent-runtime.md
@@ -145,7 +145,57 @@ Template commands are env-overridable so fastclaw stays template-agnostic:
 
 To add another template (e.g. a Next.js starter), call
 `rtMgr.RegisterTemplate("my-template", coderuntime.TemplateSpec{…})` —
-nothing in the runtime is ShipAny-specific.
+nothing in the runtime is ShipAny-specific. The **first** registered ref is
+the default the preview tool uses when the agent omits one, so registering
+more templates never changes an existing deployment's default. A second
+template ships out of the box — `vite-react`, a plain Vite + React + TS
+starter that self-scaffolds with `npm create vite` (no baked `/template`, no
+source fetch) — as a worked example of multi-template support.
+
+## Sandbox backends (docker vs e2b/boxlite)
+
+The preview path depends on `FASTCLAW_SANDBOX_BACKEND`:
+
+- **docker (default)** — the runtime owns a dedicated long-lived container
+  per project, publishes the dev port to a host port, and the agent's edits
+  reach the dev server through a shared host bind mount. Unchanged.
+- **e2b / boxlite (cloud, no host mount)** — the runtime runs the dev server
+  inside the **same pooled sandbox the agent writes files to** (so HMR works
+  with no bind mount) and exposes the port via the backend's own URL scheme
+  (e2b: `https://<port>-<sandboxID>.e2b.app`). Coding writes route to
+  `workspace.Store`; for a remote-workspace backend they're additionally
+  mirrored into the live sandbox so the dev server sees them.
+
+### Cloud template provisioning (where `/template` comes from)
+
+The scaffold needs the template source at `/template` in the sandbox. On a
+cloud backend there is no host bind mount, so pick one of:
+
+1. **Bake into the sandbox image / e2b template (recommended).** Build the
+   e2b template (or docker image) with the toolchain (node/pnpm + camoufox
+   for copyweb) **and** the template at `/template` — ideally with a warm
+   pnpm store so scaffold installs offline and fast. Rebuild only when deps
+   change. Set the e2b template id via the `e2bTemplate` setting (falls back
+   to `FASTCLAW_SANDBOX_IMAGE`).
+2. **Pull source at scaffold time (image stays stable).** Override
+   `FASTCLAW_SHIPANY_SCAFFOLD` to `curl` a pinned tarball from object storage
+   (R2/S3, via a short-lived presigned URL — no long-lived creds in a sandbox
+   that runs LLM code) into `/workspace`, then `pnpm install --offline`
+   against a warm store baked in the image. Decouples template content from
+   the image; only dep changes need an image rebuild. Prefer this over
+   `git clone` for private templates (no token to exfiltrate, pinned snapshot).
+3. **Upload from the fastclaw host.** When `FASTCLAW_SHIPANY_TEMPLATE_DIR`
+   points at a checkout on the fastclaw server, the e2b path uploads it into
+   the sandbox `/template` (`TemplateProvisioner.ProvisionDir`). Convenient
+   for local e2b testing; costs a per-cold-sandbox upload.
+
+**Multi-template, one image:** same-stack templates (e.g. several ShipAny
+variants) share ONE backend image and differ only by `ScaffoldCmd` / source —
+you do **not** need an e2b image per template. A genuinely different stack
+(Python vs Node) is the only reason to vary the image; `TemplateSpec.Image`
+pins a per-template image on the **docker** path (the e2b path uses the one
+pool image, so per-template e2b images would need a pool per-project override
+— not wired yet).
 
 ### Sandbox image requirements
 

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -321,7 +321,11 @@ func (cb *ContextBuilder) BuildSystemPromptAs(chatterUID string, chatterMem *Mem
 	loc := cb.chatterLocation(chatterUID)
 	now := time.Now().In(loc)
 	wd := now.Weekday().String()
-	dateLine := fmt.Sprintf("Current date/time: %s (%s, %s — the chatter's local timezone). Use this — do NOT call `date` to learn what day it is.",
+	dateLine := fmt.Sprintf("Current date/time: %s (%s, %s — the chatter's local timezone). This is NOW; do NOT call `date`. "+
+		"Each past user message in the history is prefixed with its own send time in [brackets] (e.g. [2026-06-13 22:15 Fri]). "+
+		"Reason about time from NOW and those prefixes: tell today apart from earlier days (never treat a past day's events as today's), "+
+		"and before ANY time-of-day remark check NOW — e.g. don't say \"good night\" in the middle of the day. "+
+		"If the chatter states a timezone or local time that disagrees with the above, call set_timezone to correct it.",
 		now.Format("2006-01-02 15:04:05 -0700"), wd, now.Location().String())
 
 	switch mode {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1668,7 +1668,7 @@ func (a *Agent) handlePlanMode(ctx context.Context, msg bus.InboundMessage) stri
 	if catalog != "" {
 		messages = append(messages, provider.Message{Role: "system", Content: catalog})
 	}
-	messages = append(messages, sess.GetMessages()...)
+	messages = append(messages, a.withMessageTimestamps(sess.GetMessages())...)
 	if a.piiScrubEnabled {
 		messages = privacy.ScrubMessages(messages)
 	}
@@ -1905,7 +1905,7 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 	if reminder := renderChatbotPersistenceReminder(a.promptMode, a.displayName, chatterMem.LoadUserFile(), chatterMem.LoadMemory()); reminder != "" {
 		messages = append(messages, provider.Message{Role: "system", Content: reminder})
 	}
-	messages = append(messages, sessionMsgs...)
+	messages = append(messages, a.withMessageTimestamps(sessionMsgs)...)
 
 	toolDefs := a.registry.DefinitionsForMode(builtinAllowForMode(a.promptMode))
 
@@ -2601,7 +2601,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 	if reminder := renderChatbotPersistenceReminder(a.promptMode, a.displayName, chatterMem.LoadUserFile(), chatterMem.LoadMemory()); reminder != "" {
 		messages = append(messages, provider.Message{Role: "system", Content: reminder})
 	}
-	messages = append(messages, sessionMsgs...)
+	messages = append(messages, a.withMessageTimestamps(sessionMsgs)...)
 
 	toolDefs := a.registry.DefinitionsForMode(builtinAllowForMode(a.promptMode))
 
@@ -3061,6 +3061,30 @@ func (a *Agent) chatterLocation(chatterUID string) *time.Location {
 	}
 	tz := scope.Timezone(context.Background(), a.dataStore, chatterUID, a.agentID)
 	return scope.LoadLocationOrLocal(tz)
+}
+
+// withMessageTimestamps returns a COPY of msgs where each user message is
+// prefixed with its send time in the chatter's timezone, e.g.
+// "[2026-06-13 22:15 Fri] …". This is what lets the model reason about
+// time across a conversation — tell today from earlier days, and not say
+// "good night" at midday. The originals are never mutated (the prefix is
+// a read-time view for the LLM, not stored history), so the session store
+// stays clean and the next turn doesn't double-prefix. The system prompt
+// (context.go dateLine) tells the model what the bracketed prefix means.
+func (a *Agent) withMessageTimestamps(msgs []provider.Message) []provider.Message {
+	if len(msgs) == 0 {
+		return msgs
+	}
+	loc := a.chatterLocation(a.registry.ChatterUserID())
+	out := make([]provider.Message, len(msgs))
+	for i, m := range msgs {
+		if m.Role == "user" && m.Timestamp > 0 && m.Content != "" {
+			t := time.UnixMilli(m.Timestamp).In(loc)
+			m.Content = "[" + t.Format("2006-01-02 15:04 Mon") + "] " + m.Content
+		}
+		out[i] = m
+	}
+	return out
 }
 
 // UpdateConfig updates the agent's runtime config (model, temperature, etc.)

--- a/internal/agent/runtime_tools.go
+++ b/internal/agent/runtime_tools.go
@@ -29,6 +29,15 @@ func (a *Agent) SetProjectRuntime(m *coderuntime.Manager) {
 func (a *Agent) registerProjectRuntimeTools() {
 	reg := a.registry
 
+	// Surface the registered templates so the model can pick one by name
+	// (and knows the default). Built at registration time — the manager has
+	// every RegisterTemplate applied before SetProjectRuntime runs.
+	tmplDesc := "Template ref to scaffold from on first boot (e.g. \"shipany-tanstack\"). Optional once a runtime already exists; the deployment's default is used when omitted."
+	if refs := a.projectRuntime.Templates(); len(refs) > 0 {
+		tmplDesc = fmt.Sprintf("Template ref to scaffold from on first boot. Available: %s — the first is the default, used when omitted. Optional once a runtime already exists.",
+			strings.Join(refs, ", "))
+	}
+
 	reg.Register(
 		"start_app_preview",
 		"PRIMARY tool for building a web app / website / landing page / dashboard — INCLUDING requests like 'use template X to make Y' or '用某模板做个…'. "+
@@ -40,7 +49,7 @@ func (a *Agent) registerProjectRuntimeTools() {
 			"properties": map[string]any{
 				"template": map[string]any{
 					"type":        "string",
-					"description": "Template ref to scaffold from on first boot (e.g. \"shipany-tanstack\"). Optional once a runtime already exists; the deployment's default is used when omitted.",
+					"description": tmplDesc,
 				},
 			},
 		},

--- a/internal/agent/tools/file.go
+++ b/internal/agent/tools/file.go
@@ -863,6 +863,29 @@ func makeListDir(r *Registry) ToolFunc {
 // the path (absolute paths, `skills/...`, ad-hoc scripts, etc.). The
 // sandbox badge is emitted only for the executor-fallback path — store
 // hits intentionally don't badge, since they didn't run in the sandbox.
+// mirrorCodingWriteToSandbox pushes a coding-agent workspace write into the
+// live preview sandbox. Coding writes route to workspace.Store (host), which
+// docker bind-mounts into the dev-server container — but a remote backend
+// (E2B) shares no host mount, so without this the dev server never sees the
+// edit and HMR looks dead. Guarded on RemoteWorkspace, so it's a no-op for
+// docker (whose executor isn't remote). Best-effort: the user-visible write
+// already hit the store, so a mirror failure only degrades live-reload — we
+// log and move on. Destination is ABSOLUTE /workspace/<path> because the
+// dev server serves the sandbox /workspace root and envd resolves a bare
+// path against $HOME, not /workspace.
+func (r *Registry) mirrorCodingWriteToSandbox(ctx context.Context, path, content string) {
+	if r.codingSubdir == "" || r.executor == nil {
+		return
+	}
+	if _, ok := r.executor.(sandbox.RemoteWorkspace); !ok {
+		return
+	}
+	dest := "/workspace/" + strings.TrimPrefix(filepath.ToSlash(filepath.Clean(path)), "/")
+	if _, err := r.executor.WriteFile(ctx, dest, content); err != nil {
+		slog.Warn("coding preview mirror to sandbox failed", "path", dest, "err", err)
+	}
+}
+
 func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 	r.Register("read_file", "Read the contents of a file", map[string]interface{}{
 		"type": "object",
@@ -995,6 +1018,7 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 				}
 				return "", fmt.Errorf("workspace put: %w", err)
 			}
+			r.mirrorCodingWriteToSandbox(ctx, args.Path, args.Content)
 			return fmt.Sprintf("Written %d bytes to %s", len(args.Content), args.Path), nil
 		case RouteSkillStore:
 			// Skill scaffolding (skill-creator's `skills/<name>/...`) lands
@@ -1175,6 +1199,7 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 						}
 						return "", fmt.Errorf("workspace put: %w", err)
 					}
+					r.mirrorCodingWriteToSandbox(ctx, args.Path, updated)
 					return fmt.Sprintf("Edited %s (%d replacement(s))", args.Path, count), nil
 				}
 			}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -226,6 +226,13 @@ func (g *Gateway) Usage() usage.Meter { return g.usage }
 // Store returns the gateway's storage backend.
 func (g *Gateway) Store() store.Store { return g.store }
 
+// SandboxPool returns the gateway's shared system sandbox pool (nil when
+// sandboxing is disabled). The project runtime borrows it so a dev-server
+// preview runs in the SAME executor the coding agent writes files to —
+// the only way edits reach the server on backends (E2B) without a shared
+// host mount.
+func (g *Gateway) SandboxPool() sandbox.ExecutorPool { return g.sandboxPool }
+
 // TaskQueue returns the gateway's task queue.
 func (g *Gateway) TaskQueue() *taskqueue.Queue { return g.taskQueue }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -29,7 +29,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -49,8 +51,30 @@ const (
 )
 
 // devLogPath is where each runtime tees its dev-server output inside the
-// container, so Logs() can tail it without attaching to the process.
+// container, so Logs() can tail it without attaching to the process. The
+// scaffold (pnpm install) also streams here first (scaffoldToLog), so the
+// preview panel shows live build progress, then the dev server APPENDS.
 const devLogPath = "/workspace/.fastclaw-dev.log"
+
+// scaffoldToLog wraps a scaffold command so its combined stdout/stderr
+// streams to the dev log AS IT RUNS — a concurrent Logs() tail surfaces the
+// live pnpm-install output while Up() is still blocked on the scaffold. A
+// subshell + plain redirect (no pipe) preserves the scaffold's exit code,
+// and the leading `>` truncates so each fresh Up starts a clean log (the
+// dev server then appends with `>>`).
+func scaffoldToLog(cmd string) string {
+	return "( " + cmd + " ) > " + devLogPath + " 2>&1"
+}
+
+// pnpmStoreVolume is a shared Docker named volume mounted at
+// pnpmStorePath in every runtime container. pnpm points its content store
+// here (scaffold sets store-dir), so after the first install populates it
+// every later install across any chat/project skips re-downloading. Named
+// volumes live in the Docker VM — fast on macOS, unlike bind mounts.
+const (
+	pnpmStoreVolume = "fastclaw-pnpm-store"
+	pnpmStorePath   = "/pnpm-store"
+)
 
 // AppSubdir is the folder, under a scope's workspace, that the app is
 // scaffolded into and served from — so the template doesn't pollute the
@@ -84,6 +108,18 @@ type TemplateSpec struct {
 	// (no image bake, no git clone). Empty → scaffold must self-source
 	// (git clone, or /template already baked into the image).
 	TemplateMount string
+	// Image overrides the sandbox image/backend-template used for THIS
+	// template, for the rare case a template needs a genuinely different
+	// toolchain base (e.g. a Python stack vs the Node default). Empty →
+	// the deployment default (Manager.image / the pool's backend image).
+	//
+	// Honored on the DOCKER path (the runtime owns the container, so it
+	// just runs a different image). On the pooled/e2b path the dev server
+	// shares the agent's pooled sandbox — one backend image per deployment
+	// — so same-stack templates (the common case) differ only by ScaffoldCmd
+	// / source, not Image; per-template e2b images would need a pool
+	// per-project override (not wired yet). See docs/coding-agent-runtime.md.
+	Image string
 }
 
 // Manager owns every project runtime. Safe for concurrent use.
@@ -100,16 +136,33 @@ type Manager struct {
 	//     port: "http://127.0.0.1:<hostPort>"
 	previewBase string
 
+	// backend mirrors cfg.Sandbox.Backend ("docker", "e2b", "boxlite", or
+	// "" for the legacy docker default). When it names a non-docker backend
+	// AND pool is set, Up() drives the dev-server preview through the shared
+	// turn-sandbox pool (the SAME executor the coding agent writes files to,
+	// so edits reach the server with no host bind mount). Docker keeps its
+	// own long-lived container path below — unchanged, no regression.
+	backend string
+	// pool is the gateway's shared system sandbox pool, borrowed for the
+	// non-docker preview path. nil for docker / when sandboxing is off.
+	pool sandbox.ExecutorPool
+
 	mu        sync.Mutex
 	templates map[string]TemplateSpec
-	live      map[string]*sandbox.DockerSandbox // rtKey → container
+	// defaultRef is the template the preview tool picks when the agent
+	// omits one — the FIRST registered ref, so adding more templates never
+	// silently changes the default for an existing deployment.
+	defaultRef string
+	live       map[string]*sandbox.DockerSandbox // rtKey → container (docker path)
 }
 
 // NewManager builds a runtime manager. image is the sandbox container
 // image (same one the turn pool uses is fine, as long as it has the
 // template toolchain — node/pnpm for ShipAny). previewBase is documented
-// on Manager.previewBase.
-func NewManager(st store.Store, workspaceRoot, image string, policy *sandbox.Policy, previewBase string) *Manager {
+// on Manager.previewBase. backend + pool select the preview path: a
+// non-docker backend with a non-nil pool runs the dev server inside the
+// agent's pooled executor; otherwise the docker container path is used.
+func NewManager(st store.Store, workspaceRoot, image string, policy *sandbox.Policy, previewBase, backend string, pool sandbox.ExecutorPool) *Manager {
 	if image == "" {
 		image = "thinkany/fastclaw-sandbox:latest"
 	}
@@ -119,9 +172,20 @@ func NewManager(st store.Store, workspaceRoot, image string, policy *sandbox.Pol
 		image:         image,
 		policy:        policy,
 		previewBase:   previewBase,
+		backend:       backend,
+		pool:          pool,
 		templates:     make(map[string]TemplateSpec),
 		live:          make(map[string]*sandbox.DockerSandbox),
 	}
+}
+
+// usesPool reports whether the preview should run through the shared
+// turn-sandbox pool (non-docker backend) rather than a dedicated docker
+// container. Requires a pool to borrow; without one we fall back to the
+// docker path even if the backend string says otherwise (and that path
+// will fail loudly if docker is absent, which is the honest signal).
+func (m *Manager) usesPool() bool {
+	return m.pool != nil && m.backend != "" && m.backend != "docker"
 }
 
 // RegisterTemplate registers (or overrides) how a template ref is
@@ -130,27 +194,66 @@ func (m *Manager) RegisterTemplate(ref string, spec TemplateSpec) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.templates[ref] = spec
+	if m.defaultRef == "" {
+		m.defaultRef = ref
+	}
 }
 
-// DefaultTemplate returns the sole registered template ref, or "" when
-// zero or more than one are registered (the caller must then pass an
-// explicit ref). Lets the agent tool default sensibly in the common
-// single-template deployment without baking a template name into the
-// agent package.
+// DefaultTemplate returns the template the preview tool uses when the agent
+// omits a ref: the first registered ref. Returns "" only when nothing is
+// registered. Keeping it stable as the first registration (rather than
+// "the sole one") means adding a second template doesn't suddenly force
+// every caller to pass an explicit ref.
 func (m *Manager) DefaultTemplate() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m.templates) != 1 {
-		return ""
-	}
+	return m.defaultRef
+}
+
+// Templates returns the registered template refs, default first then the
+// rest sorted — for surfacing the menu in the preview tool's description so
+// the model knows which templates exist.
+func (m *Manager) Templates() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rest := make([]string, 0, len(m.templates))
 	for ref := range m.templates {
-		return ref
+		if ref != m.defaultRef {
+			rest = append(rest, ref)
+		}
 	}
-	return ""
+	sort.Strings(rest)
+	out := make([]string, 0, len(m.templates))
+	if m.defaultRef != "" {
+		out = append(out, m.defaultRef)
+	}
+	return append(out, rest...)
 }
 
 func rtKey(userID, agentID, scopeID string) string {
 	return userID + "|" + agentID + "|" + scopeID
+}
+
+// nmVolumeName is the per-scope node_modules Docker volume. Deterministic
+// from scopeID so wake reuses the same install. Non-volume-safe chars
+// (the "sess:" colon) are replaced so it satisfies Docker's name rules.
+func nmVolumeName(scopeID string) string {
+	safe := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '.' || r == '-' {
+			return r
+		}
+		return '-'
+	}, scopeID)
+	return "fastclaw-nm-" + safe
+}
+
+// removeVolume best-effort deletes a Docker named volume (the per-scope
+// node_modules) after its container is gone. Failure is logged, not fatal
+// — an orphaned volume only costs disk.
+func removeVolume(name string) {
+	if err := exec.Command("docker", "volume", "rm", "-f", name).Run(); err != nil {
+		slog.Warn("runtime: remove node_modules volume", "volume", name, "error", err)
+	}
 }
 
 // scopeFor resolves how a runtime is addressed. A project, when present,
@@ -178,12 +281,37 @@ func (m *Manager) scopeFor(agentID, projectID, sessionID string) (scopeID, works
 // Get returns the persisted runtime record for a project (or session)
 // scope, or store.ErrNotFound when none exists yet. Pass sessionID="" for
 // the project-addressed (HTTP/SaaS) path.
+//
+// Liveness reconcile: a record can say "running" while no container is
+// actually serving — a daemon restart wipes the in-memory live map but
+// leaves the persisted row (and its now-dead host port) untouched. Returning
+// that verbatim points the client's preview iframe at a dead port. So when
+// the docker path has no live handle for a "running"/"starting" record, we
+// report it as "sleeping" (host port cleared) — the client then offers to
+// wake/re-up, which boots a fresh container. The stored row is left as-is;
+// the next Up reconciles it.
 func (m *Manager) Get(ctx context.Context, userID, agentID, projectID, sessionID string) (*store.ProjectRuntimeRecord, error) {
 	scopeID, _, err := m.scopeFor(agentID, projectID, sessionID)
 	if err != nil {
 		return nil, err
 	}
-	return m.store.GetProjectRuntime(ctx, userID, agentID, scopeID)
+	rec, err := m.store.GetProjectRuntime(ctx, userID, agentID, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	// Pool-backed (e2b/boxlite) runtimes don't use the live map; trust the
+	// stored status there.
+	if !m.usesPool() && (rec.Status == StatusRunning || rec.Status == StatusStarting) {
+		m.mu.Lock()
+		live := m.live[rtKey(userID, agentID, scopeID)]
+		m.mu.Unlock()
+		if live == nil {
+			rec.Status = StatusSleeping
+			rec.HostPort = 0
+			rec.PreviewURL = ""
+		}
+	}
+	return rec, nil
 }
 
 // Up brings a runtime to StatusRunning and returns the record with a live
@@ -236,6 +364,14 @@ func (m *Manager) Up(ctx context.Context, userID, agentID, projectID, sessionID,
 		spec.DevPort = 3000
 	}
 
+	// Non-docker backend: run the dev server inside the agent's pooled
+	// executor (same sandbox the coding file tools write to) and expose
+	// the port via the backend's URL scheme. Branches off before any
+	// docker-specific machinery so the docker path below is untouched.
+	if m.usesPool() {
+		return m.upViaPool(ctx, rec, spec, agentID, projectID, sessionID)
+	}
+
 	// Already live? Re-read host port and return without churning the
 	// container.
 	m.mu.Lock()
@@ -268,12 +404,30 @@ func (m *Manager) Up(ctx context.Context, userID, agentID, projectID, sessionID,
 	}
 
 	// Create + start a fresh long-lived container with the dev port
-	// published, homed on the app subdir.
-	sb = sandbox.NewDockerSandbox(m.image, ws, m.policy)
+	// published, homed on the app subdir. A template may pin its own image
+	// (different toolchain base); fall back to the deployment default.
+	img := m.image
+	if spec.Image != "" {
+		img = spec.Image
+	}
+	sb = sandbox.NewDockerSandbox(img, ws, m.policy)
 	sb.SetPublishPorts(map[int]int{spec.DevPort: 0})
 	if spec.TemplateMount != "" {
 		sb.SetTemplateMount(spec.TemplateMount)
 	}
+	// Two named volumes (Docker-VM filesystem, fast on macOS):
+	//   - a SHARED pnpm content store so installs after the first skip
+	//     re-downloading (scaffold points pnpm at pnpmStorePath).
+	//   - a PER-SCOPE node_modules volume mounted over /workspace/node_modules
+	//     so the 1GB+ dep tree never touches the slow bind mount AND can
+	//     hard-link from the store (same filesystem). Persists across
+	//     sleep/wake; removed on Stop. The host's app/node_modules stays
+	//     empty (shadowed) — fine, the UI filters it and only the runtime
+	//     container needs it.
+	sb.SetExtraVolumes([]string{
+		pnpmStoreVolume + ":" + pnpmStorePath,
+		nmVolumeName(scopeID) + ":/workspace/node_modules",
+	})
 
 	rec.Status = StatusStarting
 	rec.DevPort = spec.DevPort
@@ -291,13 +445,15 @@ func (m *Manager) Up(ctx context.Context, userID, agentID, projectID, sessionID,
 	m.live[rtKey(userID, agentID, scopeID)] = sb
 	m.mu.Unlock()
 
-	// Scaffold on an empty workspace.
+	// Scaffold on an empty workspace. Output streams to the dev log so the
+	// preview panel can tail the live pnpm-install progress (scaffoldToLog).
 	if m.needsScaffold(ctx, sb) && spec.ScaffoldCmd != "" {
 		rec.Status = StatusScaffolding
 		_ = m.store.SaveProjectRuntime(ctx, rec)
-		if out, serr := sb.Exec(ctx, spec.ScaffoldCmd, "/workspace"); serr != nil {
+		if _, serr := sb.Exec(ctx, scaffoldToLog(spec.ScaffoldCmd), "/workspace"); serr != nil {
+			logTail, _ := sb.Exec(ctx, "tail -n 60 "+devLogPath+" 2>/dev/null", "/workspace")
 			rec.Status = StatusCrashed
-			rec.LastError = "scaffold: " + serr.Error() + ": " + tail(out, 500)
+			rec.LastError = "scaffold: " + serr.Error() + ": " + tail(logTail, 500)
 			_ = m.store.SaveProjectRuntime(ctx, rec)
 			return nil, fmt.Errorf("runtime: scaffold: %w", serr)
 		}
@@ -384,6 +540,8 @@ func (m *Manager) Stop(ctx context.Context, userID, agentID, projectID, sessionI
 		return err
 	}
 	m.evict(userID, agentID, scopeID)
+	// The container is gone; reclaim its per-scope node_modules volume.
+	removeVolume(nmVolumeName(scopeID))
 	return m.store.DeleteProjectRuntime(ctx, userID, agentID, scopeID)
 }
 
@@ -394,6 +552,9 @@ func (m *Manager) Exec(ctx context.Context, userID, agentID, projectID, sessionI
 	scopeID, _, err := m.scopeFor(agentID, projectID, sessionID)
 	if err != nil {
 		return "", err
+	}
+	if m.usesPool() {
+		return m.poolExec(ctx, agentID, projectID, sessionID, command, timeout)
 	}
 	m.mu.Lock()
 	sb := m.live[rtKey(userID, agentID, scopeID)]
@@ -416,17 +577,229 @@ func (m *Manager) Logs(ctx context.Context, userID, agentID, projectID, sessionI
 	if err != nil {
 		return "", err
 	}
+	cmd := "cat " + devLogPath
+	if tailLines > 0 {
+		cmd = fmt.Sprintf("tail -n %d %s", tailLines, devLogPath)
+	}
+	cmd += " 2>/dev/null || true"
+	if m.usesPool() {
+		return m.poolExec(ctx, agentID, projectID, sessionID, cmd, 30*time.Second)
+	}
 	m.mu.Lock()
 	sb := m.live[rtKey(userID, agentID, scopeID)]
 	m.mu.Unlock()
 	if sb == nil {
 		return "", errors.New("runtime: not live")
 	}
-	cmd := "cat " + devLogPath
-	if tailLines > 0 {
-		cmd = fmt.Sprintf("tail -n %d %s", tailLines, devLogPath)
+	return sb.Exec(ctx, cmd, "/workspace")
+}
+
+// ChangedFile is one path the agent created or modified since the
+// template baseline. Path is workspace-relative in the same scheme the
+// file API uses (e.g. "sessions/<sid>/app/src/routes/index.tsx").
+type ChangedFile struct {
+	Path string `json:"path"`
+}
+
+// ChangedFiles returns only the files that differ from the pristine
+// template baseline the scaffold committed — i.e. what THIS task
+// generated. It runs `git status` in the running app (git's .gitignore
+// already excludes node_modules / build output, so the list is clean).
+// Returns an error when no live runtime / no git baseline exists; callers
+// treat that as "fall back to the full file list".
+func (m *Manager) ChangedFiles(ctx context.Context, userID, agentID, projectID, sessionID string) ([]ChangedFile, error) {
+	out, err := m.Exec(ctx, userID, agentID, projectID, sessionID,
+		"git config --global --add safe.directory '*' >/dev/null 2>&1; "+
+			"if ! git -C /workspace rev-parse --git-dir >/dev/null 2>&1; then echo __NO_BASELINE__; exit 0; fi; "+
+			"git -C /workspace status --porcelain -uall 2>/dev/null", 20*time.Second)
+	if err != nil {
+		return nil, err
 	}
-	return sb.Exec(ctx, cmd+" 2>/dev/null || true", "/workspace")
+	// No git baseline (app scaffolded before the baseline feature) — signal
+	// "unavailable" so the UI lists all files instead of claiming no changes.
+	if strings.Contains(out, "__NO_BASELINE__") {
+		return nil, errors.New("runtime: no git baseline for this app")
+	}
+	rel := "sessions/" + sessionID
+	if projectID != "" {
+		rel = "projects/" + projectID
+	}
+	prefix := rel + "/" + AppSubdir + "/"
+	var files []ChangedFile
+	for _, line := range strings.Split(out, "\n") {
+		// Porcelain v1: 2 status chars + a space, then the path at index 3.
+		if len(line) < 4 {
+			continue
+		}
+		p := line[3:]
+		// Renames render as "old -> new"; the new name is what exists.
+		if i := strings.Index(p, " -> "); i >= 0 {
+			p = p[i+4:]
+		}
+		p = strings.TrimSpace(p)
+		p = strings.Trim(p, "\"") // git quotes paths with special chars
+		if p == "" {
+			continue
+		}
+		files = append(files, ChangedFile{Path: prefix + p})
+	}
+	return files, nil
+}
+
+// --- non-docker (pooled-executor) preview path ---
+
+// upViaPool runs the dev server inside the agent's pooled executor and
+// exposes its port via the backend's URL scheme. Because the runtime and
+// the agent share the SAME executor (same pool key: agent+project), files
+// the coding agent writes are already on the dev server's disk, so HMR
+// works with no host bind mount and no file sync — the property that makes
+// the preview work on cloud backends like E2B.
+func (m *Manager) upViaPool(ctx context.Context, rec *store.ProjectRuntimeRecord, spec TemplateSpec, agentID, projectID, sessionID string) (*store.ProjectRuntimeRecord, error) {
+	ex, err := m.pool.Get(ctx, agentID, projectID, sessionID)
+	if err != nil {
+		rec.Status = StatusCrashed
+		rec.LastError = "sandbox acquire: " + err.Error()
+		_ = m.store.SaveProjectRuntime(ctx, rec)
+		return rec, fmt.Errorf("runtime: sandbox acquire: %w", err)
+	}
+	exposer, ok := ex.(sandbox.PortExposer)
+	if !ok {
+		rec.Status = StatusCrashed
+		rec.LastError = fmt.Sprintf("sandbox backend %q can't expose preview ports", m.backend)
+		_ = m.store.SaveProjectRuntime(ctx, rec)
+		return rec, errors.New(rec.LastError)
+	}
+
+	rec.Status = StatusStarting
+	rec.DevPort = spec.DevPort
+	rec.HostPort = 0
+	_ = m.store.SaveProjectRuntime(ctx, rec)
+
+	// Seed the template into the sandbox when a local checkout is set and
+	// the backend can upload it (cloud sandboxes have no host bind mount).
+	// Otherwise the scaffold's `[ -d /template ]` guard falls back to a
+	// template baked into the sandbox image.
+	if spec.TemplateMount != "" {
+		if tp, ok := ex.(sandbox.TemplateProvisioner); ok {
+			if fi, statErr := os.Stat(spec.TemplateMount); statErr == nil && fi.IsDir() {
+				if perr := tp.ProvisionDir(ctx, spec.TemplateMount, "/template"); perr != nil {
+					slog.Warn("runtime: template provision failed; relying on baked /template", "err", perr)
+				}
+			}
+		}
+	}
+
+	// Scaffold an empty workspace. Output streams to the dev log so the
+	// preview panel can tail the live pnpm-install progress (scaffoldToLog).
+	if spec.ScaffoldCmd != "" && m.needsScaffoldExec(ctx, ex) {
+		rec.Status = StatusScaffolding
+		_ = m.store.SaveProjectRuntime(ctx, rec)
+		if _, serr := ex.Exec(ctx, scaffoldToLog(spec.ScaffoldCmd), 10*time.Minute); serr != nil {
+			logTail, _ := ex.Exec(ctx, "tail -n 60 "+devLogPath+" 2>/dev/null", 30*time.Second)
+			rec.Status = StatusCrashed
+			rec.LastError = "scaffold: " + serr.Error() + ": " + tail(logTail, 500)
+			_ = m.store.SaveProjectRuntime(ctx, rec)
+			return rec, fmt.Errorf("runtime: scaffold: %w", serr)
+		}
+	}
+
+	// Start the dev server (backgrounded) and wait until it answers.
+	if serr := m.startDevServerExec(ctx, ex, spec.DevCmd, spec.DevPort); serr != nil {
+		rec.Status = StatusCrashed
+		rec.LastError = "start dev server: " + serr.Error()
+		_ = m.store.SaveProjectRuntime(ctx, rec)
+		return rec, fmt.Errorf("runtime: start dev server: %w", serr)
+	}
+	if werr := m.waitForDevServerExec(ctx, ex, spec.DevPort, 5*time.Minute); werr != nil {
+		rec.Status = StatusCrashed
+		rec.LastError = werr.Error()
+		_ = m.store.SaveProjectRuntime(ctx, rec)
+		return rec, fmt.Errorf("runtime: %w", werr)
+	}
+
+	url, perr := exposer.ExposePort(ctx, spec.DevPort)
+	if perr != nil {
+		rec.Status = StatusCrashed
+		rec.LastError = "expose port: " + perr.Error()
+		_ = m.store.SaveProjectRuntime(ctx, rec)
+		return rec, fmt.Errorf("runtime: expose port: %w", perr)
+	}
+	rec.PreviewURL = url
+	rec.Status = StatusRunning
+	rec.LastError = ""
+	if serr := m.store.SaveProjectRuntime(ctx, rec); serr != nil {
+		return rec, serr
+	}
+	slog.Info("project runtime up (pooled)", "agent", agentID, "scope", rec.ProjectID,
+		"backend", m.backend, "preview", url)
+	return rec, nil
+}
+
+// poolExec runs a one-shot command in the project's pooled executor.
+func (m *Manager) poolExec(ctx context.Context, agentID, projectID, sessionID, command string, timeout time.Duration) (string, error) {
+	ex, err := m.pool.Get(ctx, agentID, projectID, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("runtime: sandbox acquire: %w", err)
+	}
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	return ex.Exec(ctx, command, timeout)
+}
+
+// needsScaffoldExec reports whether /workspace still needs scaffolding
+// (no package.json). Errs toward scaffolding when the probe itself fails —
+// an empty FS is the common first-Up case.
+func (m *Manager) needsScaffoldExec(ctx context.Context, ex sandbox.Executor) bool {
+	out, err := ex.Exec(ctx, "test -f /workspace/package.json && echo FOUND || echo MISSING", 30*time.Second)
+	if err != nil {
+		return true
+	}
+	return !strings.Contains(out, "FOUND")
+}
+
+// startDevServerExec launches the dev server backgrounded in the executor,
+// skipping if something already answers on the port (a re-Up on a live
+// sandbox) so we don't stack a second server that fails to bind.
+func (m *Manager) startDevServerExec(ctx context.Context, ex sandbox.Executor, devCmd string, port int) error {
+	if devCmd == "" {
+		return errors.New("template DevCmd is empty")
+	}
+	probe := fmt.Sprintf(`curl -s --noproxy '*' -o /dev/null -w '%%{http_code}' --max-time 5 http://127.0.0.1:%d/ 2>/dev/null || echo 000`, port)
+	if out, _ := ex.Exec(ctx, probe, 15*time.Second); func() bool {
+		c := strings.TrimSpace(out)
+		return len(c) == 3 && c != "000"
+	}() {
+		return nil
+	}
+	wrapped := fmt.Sprintf("setsid sh -c %s >> %s 2>&1 < /dev/null & echo started",
+		shellSingleQuote(devCmd), devLogPath)
+	_, err := ex.Exec(ctx, wrapped, 30*time.Second)
+	return err
+}
+
+// waitForDevServerExec mirrors waitForDevServer for the Executor interface:
+// poll the dev port from inside the sandbox until it answers (any 2xx–5xx,
+// since a half-finished edit legitimately 500s), then return. On timeout
+// surface the port Vite actually bound for an actionable error.
+func (m *Manager) waitForDevServerExec(ctx context.Context, ex sandbox.Executor, port int, timeout time.Duration) error {
+	probe := fmt.Sprintf(`curl -s --noproxy '*' -o /dev/null -w '%%{http_code}' --max-time 60 http://127.0.0.1:%d/ 2>/dev/null || echo 000`, port)
+	const step = 3 * time.Second
+	for waited := time.Duration(0); waited < timeout; waited += step {
+		out, _ := ex.Exec(ctx, probe, 90*time.Second)
+		code := strings.TrimSpace(out)
+		if len(code) == 3 && code[0] >= '2' && code[0] <= '5' {
+			return nil
+		}
+		_, _ = ex.Exec(ctx, fmt.Sprintf("sleep %d", int(step.Seconds())), step+10*time.Second)
+	}
+	logTail, _ := ex.Exec(ctx, "tail -n 40 "+devLogPath+" 2>/dev/null", 30*time.Second)
+	if boundPort := detectVitePort(logTail); boundPort != 0 && boundPort != port {
+		return fmt.Errorf("dev server bound port %d, not %d — revert any server.port override in the framework config so the preview maps correctly. Log tail:\n%s",
+			boundPort, port, tail(logTail, 600))
+	}
+	return fmt.Errorf("dev server did not come up on port %d within %s. Log tail:\n%s",
+		port, timeout, tail(logTail, 600))
 }
 
 // --- internals ---
@@ -442,16 +815,21 @@ func (m *Manager) waitForDevServer(ctx context.Context, sb *sandbox.DockerSandbo
 	// short cap every probe aborts mid-compile and the server never gets to
 	// answer, even though it's healthy.
 	probe := fmt.Sprintf(
-		`curl -s -o /dev/null -w '%%{http_code}' --max-time 60 http://127.0.0.1:%d/ 2>/dev/null || echo 000`,
+		`curl -s --noproxy '*' -o /dev/null -w '%%{http_code}' --max-time 60 http://127.0.0.1:%d/ 2>/dev/null || echo 000`,
 		port)
 	deadline := timeout
 	const step = 3 * time.Second
 	for waited := time.Duration(0); waited < deadline; waited += step {
 		out, _ := sb.Exec(ctx, probe, "/workspace")
 		code := strings.TrimSpace(out)
-		// Any HTTP response (even a redirect/4xx) means the server is up
-		// and the published port reaches it.
-		if len(code) == 3 && code[0] >= '2' && code[0] <= '4' {
+		// Any real HTTP response means the dev server is up and the
+		// published port reaches it — INCLUDING 5xx. A coding agent's
+		// half-finished edit makes SSR templates answer 500; that's a
+		// build error the user fixes via more chat, not a dead preview.
+		// Treating it as "not up" would 5-min-timeout the whole boot and
+		// hide the very error overlay the user needs to see. Only "000"
+		// (curl couldn't connect at all) keeps waiting.
+		if len(code) == 3 && code[0] >= '2' && code[0] <= '5' {
 			return nil
 		}
 		// Cheap sleep without importing a timer into the loop body: a
@@ -500,7 +878,7 @@ func (m *Manager) startDevServer(ctx context.Context, sb *sandbox.DockerSandbox,
 	}
 	// nohup + & so the dev server outlives this docker exec; tee output
 	// to the log file for Logs(). setsid keeps it off our process group.
-	wrapped := fmt.Sprintf("setsid sh -c %s > %s 2>&1 < /dev/null & echo started",
+	wrapped := fmt.Sprintf("setsid sh -c %s >> %s 2>&1 < /dev/null & echo started",
 		shellSingleQuote(devCmd), devLogPath)
 	_, err := sb.Exec(ctx, wrapped, "/workspace")
 	return err

--- a/internal/runtime/scope_test.go
+++ b/internal/runtime/scope_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestScopeFor(t *testing.T) {
-	m := NewManager(nil, "/home", "img", nil, "")
+	m := NewManager(nil, "/home", "img", nil, "", "", nil)
 	const agent = "agt_1"
 
 	t.Run("project wins", func(t *testing.T) {
@@ -44,12 +44,12 @@ func TestScopeFor(t *testing.T) {
 
 func TestPreviewURLHostSanitizesSessionScope(t *testing.T) {
 	// Local mode: scope id never appears in the URL.
-	local := NewManager(nil, "/home", "img", nil, "")
+	local := NewManager(nil, "/home", "img", nil, "", "", nil)
 	if got := local.previewURL("sess:abc", 4321); got != "http://127.0.0.1:4321" {
 		t.Fatalf("local previewURL: got %q", got)
 	}
 	// Gateway mode: the "sess:" colon must not leak into a hostname.
-	gw := NewManager(nil, "/home", "img", nil, "https://{project}.preview.example.com")
+	gw := NewManager(nil, "/home", "img", nil, "https://{project}.preview.example.com", "", nil)
 	if got := gw.previewURL("sess:abc", 0); got != "https://sess-abc.preview.example.com" {
 		t.Fatalf("gateway previewURL: want colon sanitized to dash, got %q", got)
 	}

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -49,6 +49,12 @@ type DockerSandbox struct {
 	// without baking it into the image or cloning over the network. Empty
 	// for ordinary sandboxes.
 	templateMount string
+	// extraVolumes are raw `-v` specs appended verbatim to docker create
+	// (e.g. "fastclaw-pnpm-store:/pnpm-store" to share a pnpm content store
+	// across runtimes so installs skip re-downloading). Named volumes live
+	// in the Docker VM (fast on macOS, unlike bind mounts) and persist
+	// across container recreation.
+	extraVolumes []string
 	// publishPorts maps a container-internal port to a host port. A host
 	// value of 0 asks Docker to pick a free ephemeral port, which is then
 	// read back with HostPortFor after Create. Used by the coding-agent
@@ -124,6 +130,14 @@ func (s *DockerSandbox) SetTemplateMount(hostDir string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.templateMount = hostDir
+}
+
+// SetExtraVolumes appends raw `docker -v` specs (e.g.
+// "fastclaw-pnpm-store:/pnpm-store"). Must be called before Create().
+func (s *DockerSandbox) SetExtraVolumes(specs []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.extraVolumes = append(s.extraVolumes[:0], specs...)
 }
 
 // SetPublishPorts configures container→host port publishing. Keys are
@@ -312,6 +326,11 @@ func (s *DockerSandbox) Create() error {
 	// /workspace bind mount.
 	if s.templateMount != "" {
 		args = append(args, "-v", fmt.Sprintf("%s:/template:ro", s.templateMount))
+	}
+
+	// Extra volumes (e.g. the shared pnpm store).
+	for _, v := range s.extraVolumes {
+		args = append(args, "-v", v)
 	}
 
 	// Port publishing (coding-agent runtime previews). Bind to 127.0.0.1

--- a/internal/sandbox/e2b_executor.go
+++ b/internal/sandbox/e2b_executor.go
@@ -705,6 +705,92 @@ func (e *E2BExecutor) ListDir(ctx context.Context, path string) (string, error) 
 // idle eviction. See sandbox.RemoteWorkspace.
 func (e *E2BExecutor) IsRemoteWorkspace() {}
 
+// ExposePort implements PortExposer. E2B serves every sandbox port at
+// https://<port>-<sandboxID>.e2b.app with no publish step (same scheme
+// envdURL uses for the control port), so the dev server bound to 0.0.0.0
+// is reachable the moment it listens.
+func (e *E2BExecutor) ExposePort(_ context.Context, port int) (string, error) {
+	if e.sandboxID == "" {
+		return "", fmt.Errorf("e2b: sandbox not created")
+	}
+	return fmt.Sprintf("https://%d-%s.e2b.app", port, e.sandboxID), nil
+}
+
+// ProvisionDir implements TemplateProvisioner: tar localDir (skipping the
+// heavy, host-specific trees the scaffold reinstalls anyway), upload it
+// over the same /files channel Hydrate uses, and extract it into destDir
+// inside the sandbox. This seeds a coding template into an E2B sandbox
+// that has no host bind mount to share it through.
+func (e *E2BExecutor) ProvisionDir(ctx context.Context, localDir, destDir string) error {
+	root := filepath.Clean(localDir)
+	skip := map[string]bool{"node_modules": true, ".git": true, ".output": true, "dist": true, ".next": true}
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	walkErr := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(root, p)
+		if rerr != nil {
+			return rerr
+		}
+		if rel == "." {
+			return nil
+		}
+		top := strings.SplitN(filepath.ToSlash(rel), "/", 2)[0]
+		if skip[top] {
+			if fi.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Symlinks (and other irregular files) can't be faithfully tarred
+		// without resolving targets; skip them — templates are plain trees.
+		if !fi.IsDir() && !fi.Mode().IsRegular() {
+			return nil
+		}
+		hdr, herr := tar.FileInfoHeader(fi, "")
+		if herr != nil {
+			return herr
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if fi.Mode().IsRegular() {
+			f, oerr := os.Open(p)
+			if oerr != nil {
+				return oerr
+			}
+			_, cerr := io.Copy(tw, f)
+			f.Close()
+			if cerr != nil {
+				return cerr
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	if err := gz.Close(); err != nil {
+		return err
+	}
+	const tmp = "/tmp/fc-template.tar.gz"
+	if err := e.uploadBytes(ctx, tmp, buf.Bytes()); err != nil {
+		return fmt.Errorf("upload template: %w", err)
+	}
+	cmd := fmt.Sprintf("mkdir -p %q && tar -C %q -xzf %s && rm -f %s", destDir, destDir, tmp, tmp)
+	if out, err := e.Exec(ctx, cmd, 3*time.Minute); err != nil {
+		return fmt.Errorf("extract template: %w: %s", err, out)
+	}
+	return nil
+}
+
 // SnapshotWorkspace tars /workspace and ships the bytes back as base64 over
 // stdout. This is the inverse of Hydrate's tar+base64 push — used by the
 // LifecyclePool to flush sandbox-side files back to the durable

--- a/internal/sandbox/executor.go
+++ b/internal/sandbox/executor.go
@@ -76,6 +76,25 @@ type RemoteWorkspace interface {
 	IsRemoteWorkspace()
 }
 
+// PortExposer is an optional Executor capability: given a port a process
+// inside the sandbox is listening on, return an externally reachable URL.
+// Docker publishes the port to a host port; E2B serves it at
+// <port>-<sandboxID>.e2b.app with no extra step. The project runtime
+// type-asserts this to build a live-preview URL; a backend that doesn't
+// implement it can't host a preview (the runtime returns a clear error).
+type PortExposer interface {
+	ExposePort(ctx context.Context, port int) (string, error)
+}
+
+// TemplateProvisioner is an optional Executor capability: copy a local
+// directory tree into the sandbox at destDir. Used to seed a coding
+// template (e.g. shipany-tanstack) when the backend has no host bind
+// mount to share it through. Docker doesn't implement it (it bind-mounts
+// the template); remote backends (E2B) upload a tarball and extract it.
+type TemplateProvisioner interface {
+	ProvisionDir(ctx context.Context, localDir, destDir string) error
+}
+
 // PoolConfig holds configuration for creating sandbox pools.
 type PoolConfig struct {
 	Backend   string // "docker", "e2b" (future)

--- a/internal/setup/handlers_runtime.go
+++ b/internal/setup/handlers_runtime.go
@@ -245,3 +245,71 @@ func (s *Server) handleScopePreview(w http.ResponseWriter, r *http.Request) {
 		"status":     rec.Status,
 	})
 }
+
+// handleScopePreviewLogs tails the build/dev log for the CURRENT chat scope
+// (sessionId or projectId query, like handleScopePreview). The preview panel
+// polls it while the app is scaffolding so the user sees the live
+// pnpm-install output instead of an opaque "Building…" spinner. Always 200
+// so the client can render conditionally; "logs" is "" when there's nothing
+// yet (no runtime, or scaffold hasn't written a line).
+func (s *Server) handleScopePreviewLogs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if s.runtimeMgr == nil {
+		jsonResponse(w, http.StatusOK, map[string]any{"logs": ""})
+		return
+	}
+	if !s.requireAgentReadable(w, r, id) {
+		return
+	}
+	uid := s.effectiveUserID(r)
+	if uid == "" {
+		jsonResponse(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+		return
+	}
+	tailLines := 400
+	if v := r.URL.Query().Get("tail"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			tailLines = n
+		}
+	}
+	out, err := s.runtimeMgr.Logs(r.Context(), uid, id,
+		r.URL.Query().Get("projectId"), r.URL.Query().Get("sessionId"), tailLines)
+	if err != nil {
+		// Not live yet / no scope → nothing to show, not an error to the UI.
+		jsonResponse(w, http.StatusOK, map[string]any{"logs": ""})
+		return
+	}
+	jsonResponse(w, http.StatusOK, map[string]any{"logs": out})
+}
+
+// handleChangedFiles returns only the files the agent created/modified vs
+// the template baseline (git diff inside the running app), so the file
+// tree can show just THIS task's output instead of the whole template.
+// `available` is false when there's no live runtime / git baseline — the
+// UI then falls back to listing all workspace files.
+func (s *Server) handleChangedFiles(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if s.runtimeMgr == nil {
+		jsonResponse(w, http.StatusOK, map[string]any{"available": false, "files": []any{}})
+		return
+	}
+	if !s.requireAgentReadable(w, r, id) {
+		return
+	}
+	uid := s.effectiveUserID(r)
+	if uid == "" {
+		jsonResponse(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+		return
+	}
+	changed, err := s.runtimeMgr.ChangedFiles(r.Context(), uid, id,
+		r.URL.Query().Get("projectId"), r.URL.Query().Get("sessionId"))
+	if err != nil {
+		jsonResponse(w, http.StatusOK, map[string]any{"available": false, "files": []any{}})
+		return
+	}
+	files := make([]map[string]any, 0, len(changed))
+	for _, f := range changed {
+		files = append(files, map[string]any{"path": f.Path, "size": 0, "modTime": 0})
+	}
+	jsonResponse(w, http.StatusOK, map[string]any{"available": true, "files": files})
+}

--- a/internal/setup/server.go
+++ b/internal/setup/server.go
@@ -302,6 +302,12 @@ func (s *Server) Run(ctx context.Context) error {
 	// lets the chat workspace panel surface an "open preview" entry for the
 	// current chat, including loose chats that have no project.
 	mux.HandleFunc("GET /api/agents/{id}/preview", auth(s.handleScopePreview))
+	// Scope-flexible build/dev log tail — the preview panel polls this while
+	// the app scaffolds so the user sees the live pnpm-install output.
+	mux.HandleFunc("GET /api/agents/{id}/preview/logs", auth(s.handleScopePreviewLogs))
+	// Files the agent changed vs the template baseline (git diff in the
+	// running app) — lets the workspace tree show only this task's output.
+	mux.HandleFunc("GET /api/agents/{id}/changed-files", auth(s.handleChangedFiles))
 	mux.HandleFunc("GET /api/agents/{id}/projects/{pid}/runtime/logs", auth(s.handleRuntimeLogs))
 
 	// Per-agent channels (IM bot bindings)

--- a/web/src/components/chat-markdown.tsx
+++ b/web/src/components/chat-markdown.tsx
@@ -45,13 +45,17 @@ const components: Components = {
 // mirroring the former CHAT_PROSE_CLASS. The bulky overrides that flatten
 // Streamdown's card chrome live in globals.css under the `.chat-md` class.
 const PROSE_CLASS =
-  "chat-md text-[15px] leading-relaxed prose prose-sm max-w-none dark:prose-invert min-w-0 wrap-anywhere " +
-  "prose-p:my-1 prose-ul:my-1 prose-ol:my-1 " +
-  "prose-headings:font-semibold prose-headings:mt-3 prose-headings:mb-1 " +
-  "prose-h1:text-[16px] prose-h2:text-[15.5px] prose-h3:text-[15px] prose-h4:text-[15px] prose-h5:text-[15px] prose-h6:text-[15px] " +
+  "chat-md text-[13.5px] leading-normal prose prose-sm max-w-none dark:prose-invert min-w-0 wrap-anywhere " +
+  "prose-p:my-1.5 " +
+  // Tighter, shallower lists: smaller indent (pl-5 ≈ 20px vs prose's ~26px),
+  // less gap between the marker and text, and snug item spacing.
+  "prose-ul:my-1.5 prose-ol:my-1.5 prose-ul:pl-4 prose-ol:pl-4 " +
+  "prose-li:my-0.5 prose-li:pl-0 prose-li:marker:text-muted-foreground/60 " +
+  "prose-headings:font-semibold prose-headings:mt-2.5 prose-headings:mb-1 " +
+  "prose-h1:text-[15px] prose-h2:text-[14px] prose-h3:text-[13.5px] prose-h4:text-[13.5px] prose-h5:text-[13.5px] prose-h6:text-[13.5px] " +
   "prose-blockquote:border-l-primary/60 prose-blockquote:bg-muted/20 prose-blockquote:px-3 prose-blockquote:not-italic " +
   "prose-a:text-primary prose-a:underline-offset-2 hover:prose-a:opacity-80 " +
-  "prose-table:my-2 prose-table:text-[14px] prose-th:bg-muted/40 prose-th:font-medium prose-th:border-border prose-td:border-border " +
+  "prose-table:my-2 prose-table:text-[13px] prose-th:bg-muted/40 prose-th:font-medium prose-th:border-border prose-td:border-border " +
   "prose-th:py-1 prose-th:px-2 prose-td:py-1 prose-td:px-2 prose-td:leading-snug " +
   "prose-hr:my-3";
 

--- a/web/src/components/chat-screen.tsx
+++ b/web/src/components/chat-screen.tsx
@@ -5,8 +5,9 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useAgentIdFromURL } from "@/hooks/use-agent-id";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { fileUrl, getAgent, getChatHistoryWithCursor, getChatSessions, getChatTodo, getMe, getScopePreview, listAgentFiles, listProjects, renameChatSession, revealAgentWorkspace, sendChatStream, steerChat, uploadAgentFiles, getSkills, type ChatHistoryMessage, type ChatStreamEvent, type ScopePreview, type SkillInfo, type TodoItem, type ToolResultMetadata, type WorkspaceFile } from "@/lib/api";
-import { Bot, Send, Copy, Check, Pencil, Wrench, ChevronDown, ChevronRight, Download, X, File, FileText, Folder, FolderSearch, Image as ImageIcon, FileCode, Film, Music, Puzzle, SlidersHorizontal, ShieldCheck, Paperclip, Square, FolderOpen, RefreshCw, Eye, Code2, RotateCcw, ListChecks, Terminal, ExternalLink } from "lucide-react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { fileUrl, getAgent, getChangedFiles, getChatHistoryWithCursor, getChatSessions, getChatTodo, getMe, getScopePreview, getScopePreviewLogs, listAgentFiles, listProjects, renameChatSession, revealAgentWorkspace, sendChatStream, steerChat, uploadAgentFiles, getSkills, type ChatHistoryMessage, type ChatStreamEvent, type ScopePreview, type SkillInfo, type TodoItem, type ToolResultMetadata, type WorkspaceFile } from "@/lib/api";
+import { Bot, Send, Copy, Check, Pencil, Wrench, ChevronDown, ChevronRight, Download, X, File, FileText, Folder, FolderSearch, Image as ImageIcon, FileCode, Film, Music, Puzzle, SlidersHorizontal, ShieldCheck, Paperclip, Square, FolderOpen, RefreshCw, Eye, Code2, RotateCcw, ListChecks, Terminal, ExternalLink, MoreHorizontal } from "lucide-react";
 import Link from "next/link";
 import { ChatMarkdown } from "@/components/chat-markdown";
 
@@ -88,6 +89,7 @@ function renderContentWithDataImages(
 }
 
 import { usePageHeader } from "@/components/sidebar";
+import { useSidebarOptional } from "@/components/ui/sidebar";
 import { channelLabel } from "@/components/channel-icon";
 
 interface ProducedFile {
@@ -509,6 +511,15 @@ export function ChatScreen() {
   }>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [filesSheetOpen, setFilesSheetOpen] = useState(false);
+  // Opening the workspace/preview panel collapses the platform sidebar to
+  // free horizontal room (null when there's no provider, e.g. act-as view).
+  const sidebar = useSidebarOptional();
+  useEffect(() => {
+    if (filesSheetOpen) sidebar?.setOpen(false);
+    // Intentionally keyed only on filesSheetOpen: collapse once when the
+    // panel opens; don't fight the user if they re-expand while it's open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filesSheetOpen]);
   const [sessionTitle, setSessionTitle] = useState<string>("");
   const [attachments, setAttachments] = useState<File[]>([]);
   // Lightbox for clicking either an attachment thumbnail (compose box)
@@ -2927,6 +2938,24 @@ function zipUrl(agentId: string, sessionId: string, projectId?: string): string 
 // reply. Instead it surfaces a single "Open files" affordance that opens
 // the WorkspacePanel side sheet, which already handles the tree, preview,
 // and download. onOpen is wired to setFilesSheetOpen(true) at the call site.
+// BuildLogView renders the live scaffold/dev log as a scrolling terminal,
+// auto-pinned to the bottom so the latest pnpm-install lines stay visible.
+function BuildLogView({ text }: { text: string }) {
+  const ref = useRef<HTMLPreElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [text]);
+  return (
+    <pre
+      ref={ref}
+      className="h-full w-full overflow-auto whitespace-pre-wrap break-words bg-zinc-950 px-4 py-3 text-left font-mono text-[11px] leading-relaxed text-zinc-300"
+    >
+      {text || "Starting build…"}
+    </pre>
+  );
+}
+
 function FilesPanel({ files, onOpen }: { files: ProducedFile[]; onOpen: () => void }) {
   return (
     <div className="mt-2 max-w-[85%]">
@@ -2947,9 +2976,13 @@ function FilesPanel({ files, onOpen }: { files: ProducedFile[]; onOpen: () => vo
 }
 
 const FILES_PANEL_MIN = 280;
-const FILES_PANEL_MAX = 640;
+const FILES_PANEL_MAX = 1000; // wide enough to view a desktop preview iframe
 const FILES_PANEL_DEFAULT = 280;
 const FILES_PANEL_KEY = "chat:filesPanelWidth";
+// When the user switches to the Preview tab and the panel is still narrow,
+// auto-grow to this so the embedded site isn't cramped. Transient (not
+// persisted), so the Code tab keeps its own saved width.
+const PREVIEW_AUTO_WIDTH = 760;
 
 // WorkspacePanel renders the files in the active scope:
 //   - chat scope (sessionId set): files produced in this conversation.
@@ -3148,6 +3181,15 @@ function WorkspacePanel({
   const [previewing, setPreviewing] = useState<ProducedFile | null>(null);
   // Live dev-server preview for this chat scope (from start_app_preview).
   const [appPreview, setAppPreview] = useState<ScopePreview>({ status: "none" });
+  // Live build/dev log tail, shown in the preview pane while the app is
+  // scaffolding so "Building…" isn't an opaque spinner.
+  const [buildLogs, setBuildLogs] = useState("");
+  // Code (file tree) vs Preview (embedded iframe of the running dev server).
+  const [tab, setTab] = useState<"code" | "preview">("code");
+  // Files the agent changed vs the template baseline (so the tree can show
+  // just this task's output), and whether to show all files instead.
+  const [changed, setChanged] = useState<{ files: WorkspaceFile[]; available: boolean }>({ files: [], available: false });
+  const [showAll, setShowAll] = useState(false);
   // Self-hosted-only "open in Finder" affordance. We learn the deploy
   // mode from /api/me on mount; it doesn't change at runtime, so one
   // fetch per panel instance is enough. Hosted deployments leave this
@@ -3177,6 +3219,24 @@ function WorkspacePanel({
     return FILES_PANEL_DEFAULT;
   });
   const [resizing, setResizing] = useState(false);
+
+  // Measure the panel's ACTUAL rendered width (not the `width` state, which
+  // the CSS maxWidth cap can shrink below on small viewports) so the header
+  // can collapse its toolbar before it overflows and pushes a page scroll.
+  const asideRef = useRef<HTMLElement>(null);
+  const [panelW, setPanelW] = useState<number>(FILES_PANEL_DEFAULT);
+  useEffect(() => {
+    const el = asideRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) setPanelW(e.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  // Below this the secondary action icons fold into a "⋯" menu and the
+  // "Files" label drops, so the header always fits the narrow panel.
+  const compactHeader = panelW < 480;
 
   useEffect(() => {
     if (!resizing) return;
@@ -3243,6 +3303,10 @@ function WorkspacePanel({
       getScopePreview(agentId, projectId ? undefined : sessionId, projectId)
         .then(setAppPreview)
         .catch(() => setAppPreview({ status: "none" }));
+      // Best-effort: which files did the agent change vs the template?
+      getChangedFiles(agentId, projectId ? undefined : sessionId, projectId)
+        .then(setChanged)
+        .catch(() => setChanged({ files: [], available: false }));
     } finally {
       setLoading(false);
     }
@@ -3252,15 +3316,56 @@ function WorkspacePanel({
     refresh();
   }, [refresh]);
 
+  // While the Preview tab is open, poll the runtime so a "building" preview
+  // flips to the live iframe on its own (and reflects sleep/crash). Cheap
+  // local call; stops when the tab closes.
+  useEffect(() => {
+    if (tab !== "preview") return;
+    let active = true;
+    const sid = projectId ? undefined : sessionId;
+    const poll = async () => {
+      const p = await getScopePreview(agentId, sid, projectId).catch(() => null);
+      if (!active || !p) return;
+      setAppPreview(p);
+      // While building, tail the live install/dev output for the log pane.
+      if (p.status === "scaffolding" || p.status === "starting") {
+        const logs = await getScopePreviewLogs(agentId, sid, projectId).catch(() => "");
+        if (active) setBuildLogs(logs);
+      }
+    };
+    poll();
+    const t = setInterval(poll, 4000);
+    return () => {
+      active = false;
+      clearInterval(t);
+    };
+  }, [tab, agentId, sessionId, projectId]);
+
+  // Auto-grow the panel when entering Preview so the embedded site isn't
+  // cramped. Transient — not written to localStorage, so the Code tab keeps
+  // its own saved width and dragging still wins.
+  useEffect(() => {
+    if (tab === "preview") {
+      setWidth((w) => (w < PREVIEW_AUTO_WIDTH ? Math.min(PREVIEW_AUTO_WIDTH, FILES_PANEL_MAX) : w));
+    }
+  }, [tab]);
+
   return (
     <>
       <aside
-        style={{ width }}
-        className="relative z-30 hidden md:flex shrink-0 flex-col border-l border-border bg-background -mt-12 h-screen"
+        ref={asideRef}
+        // width is the dragged/auto px width, but cap it to the viewport so
+        // the panel (shrink-0) + the platform sidebar can never exceed the
+        // window and force a horizontal page scroll. 26rem reserve keeps the
+        // sidebar (~16rem) plus a usable chat sliver visible; min() lets it
+        // grow to FILES_PANEL_MAX on wide screens. overflow-hidden is the
+        // belt-and-suspenders so no inner content can push the page wide.
+        style={{ width, maxWidth: `min(${FILES_PANEL_MAX}px, calc(100vw - 26rem))` }}
+        className="relative z-30 hidden md:flex shrink-0 flex-col overflow-hidden border-l border-border bg-background -mt-12 h-screen"
       >
         <div
           onMouseDown={(e) => { e.preventDefault(); setResizing(true); }}
-          className={`absolute -left-1 top-0 bottom-0 w-2 cursor-col-resize z-10 group ${resizing ? "" : ""}`}
+          className={`absolute left-0 top-0 bottom-0 w-2 cursor-col-resize z-10 group ${resizing ? "" : ""}`}
           title="Drag to resize"
         >
           <div
@@ -3269,100 +3374,236 @@ function WorkspacePanel({
             }`}
           />
         </div>
-        <div className="flex items-center justify-between gap-2 px-4 h-12 border-b border-border">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <FolderOpen className="h-4 w-4" />
-            Workspace
+        <div className="flex h-12 items-center justify-between gap-2 border-b border-border px-4">
+          <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+            <FolderOpen className="h-4 w-4 shrink-0" />
+            {!compactHeader && <span className="truncate">Files</span>}
           </div>
-          <div className="flex items-center gap-1">
-            {/* Live app preview entry — opens the running dev server from
-                start_app_preview in a new tab. Only shown when there's a
-                runtime for this chat scope. */}
-            {appPreview.status === "running" && appPreview.previewUrl && (
-              <a
-                href={appPreview.previewUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1.5 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90"
-                title={`Open live preview: ${appPreview.previewUrl}`}
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-                Preview
-              </a>
-            )}
-            {(appPreview.status === "starting" || appPreview.status === "scaffolding") && (
-              <span
-                className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground"
-                title="Preview is starting…"
-              >
-                <RefreshCw className="h-3.5 w-3.5 animate-spin" />
-                Starting…
-              </span>
-            )}
-            <a
-              href={
-                files.length > 0
-                  ? zipUrl(agentId, sessionId, projectId)
-                  : undefined
-              }
-              aria-disabled={files.length === 0}
-              className={`p-1.5 rounded-md transition-colors ${
-                files.length === 0
-                  ? "text-muted-foreground/40 pointer-events-none"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-              }`}
-              title="Download all as zip"
-            >
-              <Download className="h-4 w-4" />
-            </a>
-            {/* Open the workspace folder in the operator's native file
-                browser. Self-hosted only — hosted deployments don't
-                expose a meaningful "local folder" so the button is
-                hidden entirely (we learned the mode from /api/me at
-                mount). */}
-            {deployMode === "self-hosted" && (
+          <div className="flex shrink-0 items-center gap-1">
+            {/* Code (file tree) ⇄ Preview (live dev server iframe) toggle. */}
+            <div className="mr-1 flex items-center rounded-md bg-muted p-0.5 text-xs">
               <button
-                onClick={handleReveal}
-                disabled={revealing || (!sessionId && !projectId)}
-                className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50"
-                title="Open folder in Finder"
+                onClick={() => setTab("code")}
+                className={`rounded px-2.5 py-1 transition-colors ${
+                  tab === "code"
+                    ? "bg-background font-medium text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
               >
-                <FolderSearch className="h-4 w-4" />
+                Code
               </button>
+              <button
+                onClick={() => setTab("preview")}
+                className={`flex items-center gap-1 rounded px-2.5 py-1 transition-colors ${
+                  tab === "preview"
+                    ? "bg-background font-medium text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                Preview
+                {(appPreview.status === "starting" || appPreview.status === "scaffolding") && (
+                  <RefreshCw className="h-3 w-3 animate-spin" />
+                )}
+              </button>
+            </div>
+            {/* Secondary actions: inline on a wide panel, folded into a "⋯"
+                menu when the panel is narrow so the toolbar never overflows
+                and pushes a horizontal page scroll. */}
+            {compactHeader ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <button
+                      className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                      title="More actions"
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                    </button>
+                  }
+                />
+                <DropdownMenuContent align="end" className="w-44 rounded-lg">
+                  {appPreview.status === "running" && appPreview.previewUrl && (
+                    <DropdownMenuItem
+                      onClick={() =>
+                        window.open(appPreview.previewUrl!, "_blank", "noopener,noreferrer")
+                      }
+                    >
+                      <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                      <span>Open in new tab</span>
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem
+                    disabled={files.length === 0}
+                    onClick={() => {
+                      if (files.length === 0) return;
+                      const a = document.createElement("a");
+                      a.href = zipUrl(agentId, sessionId, projectId);
+                      a.rel = "noopener";
+                      a.click();
+                    }}
+                  >
+                    <Download className="h-4 w-4 text-muted-foreground" />
+                    <span>Download zip</span>
+                  </DropdownMenuItem>
+                  {deployMode === "self-hosted" && (
+                    <DropdownMenuItem
+                      disabled={revealing || (!sessionId && !projectId)}
+                      onClick={handleReveal}
+                    >
+                      <FolderSearch className="h-4 w-4 text-muted-foreground" />
+                      <span>Open in Finder</span>
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem disabled={loading} onClick={refresh}>
+                    <RefreshCw className="h-4 w-4 text-muted-foreground" />
+                    <span>Refresh</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <>
+                {appPreview.status === "running" && appPreview.previewUrl && (
+                  <a
+                    href={appPreview.previewUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                    title={`Open preview in new tab: ${appPreview.previewUrl}`}
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </a>
+                )}
+                <a
+                  href={files.length > 0 ? zipUrl(agentId, sessionId, projectId) : undefined}
+                  aria-disabled={files.length === 0}
+                  className={`rounded-md p-1.5 transition-colors ${
+                    files.length === 0
+                      ? "pointer-events-none text-muted-foreground/40"
+                      : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                  }`}
+                  title="Download all as zip"
+                >
+                  <Download className="h-4 w-4" />
+                </a>
+                {deployMode === "self-hosted" && (
+                  <button
+                    onClick={handleReveal}
+                    disabled={revealing || (!sessionId && !projectId)}
+                    className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+                    title="Open folder in Finder"
+                  >
+                    <FolderSearch className="h-4 w-4" />
+                  </button>
+                )}
+                <button
+                  onClick={refresh}
+                  disabled={loading}
+                  className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+                  title="Refresh"
+                >
+                  <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+                </button>
+              </>
             )}
-            <button
-              onClick={refresh}
-              disabled={loading}
-              className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50"
-              title="Refresh"
-            >
-              <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
-            </button>
             <button
               onClick={onClose}
-              className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
               title="Close"
             >
               <X className="h-4 w-4" />
             </button>
           </div>
         </div>
-        <div className="flex-1 overflow-y-auto p-2">
-          {!loading && files.length === 0 ? (
-            <p className="px-3 py-8 text-center text-sm text-muted-foreground">
-              {projectId
-                ? "No files in this project yet."
-                : "No files in this session yet."}
-            </p>
-          ) : (
-            <FileTreeView
-              files={files}
-              rootPrefix={projectId ? `projects/${projectId}/` : `sessions/${sessionId}/`}
-              selectedPath={previewing?.path}
-              onSelect={(f) => setPreviewing(f)}
-            />
-          )}
-        </div>
+        {tab === "code" ? (
+          <div className="flex flex-1 min-h-0 flex-col">
+            {/* When there's a template baseline, default to showing only the
+                files THIS task changed; let the user flip to the full tree. */}
+            {changed.available && (
+              <div className="flex items-center gap-1 border-b border-border px-3 py-1.5 text-xs">
+                <button
+                  onClick={() => setShowAll(false)}
+                  className={`rounded px-2 py-0.5 transition-colors ${
+                    !showAll ? "bg-muted font-medium text-foreground" : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Changed{changed.files.length ? ` (${changed.files.length})` : ""}
+                </button>
+                <button
+                  onClick={() => setShowAll(true)}
+                  className={`rounded px-2 py-0.5 transition-colors ${
+                    showAll ? "bg-muted font-medium text-foreground" : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  All files
+                </button>
+              </div>
+            )}
+            <div className="flex-1 overflow-y-auto p-2">
+              {(() => {
+                const showChanged = changed.available && !showAll;
+                const list = showChanged ? changed.files : files;
+                if (!loading && list.length === 0) {
+                  return (
+                    <p className="px-3 py-8 text-center text-sm text-muted-foreground">
+                      {showChanged
+                        ? "No changes yet — the agent hasn't edited any files."
+                        : projectId
+                          ? "No files in this project yet."
+                          : "No files in this session yet."}
+                    </p>
+                  );
+                }
+                return (
+                  <FileTreeView
+                    files={list}
+                    rootPrefix={projectId ? `projects/${projectId}/` : `sessions/${sessionId}/`}
+                    selectedPath={previewing?.path}
+                    onSelect={(f) => setPreviewing(f)}
+                  />
+                );
+              })()}
+            </div>
+          </div>
+        ) : (
+          <div className="flex-1 min-h-0">
+            {appPreview.status === "running" && appPreview.previewUrl ? (
+              <iframe
+                src={appPreview.previewUrl}
+                className="h-full w-full border-0 bg-white"
+                title="App preview"
+              />
+            ) : appPreview.status === "starting" || appPreview.status === "scaffolding" ? (
+              <div className="flex h-full flex-col">
+                <div className="flex items-center gap-2 border-b border-border px-4 py-2 text-xs text-muted-foreground">
+                  <RefreshCw className="h-4 w-4 shrink-0 animate-spin" />
+                  <span>
+                    {appPreview.status === "scaffolding"
+                      ? "Installing dependencies — this can take a few minutes…"
+                      : "Starting the dev server…"}
+                  </span>
+                </div>
+                <div className="min-h-0 flex-1">
+                  <BuildLogView text={buildLogs} />
+                </div>
+              </div>
+            ) : appPreview.status === "crashed" ? (
+              <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+                <p className="text-sm text-destructive">Preview failed to start.</p>
+                <p className="text-xs text-muted-foreground">
+                  Ask the agent to check the dev-server logs (app_preview_logs).
+                </p>
+              </div>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-muted-foreground">
+                <Eye className="h-6 w-6" />
+                <p className="text-sm">No preview yet.</p>
+                <p className="text-xs">
+                  Ask the agent to build an app, and it shows up here.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
       </aside>
       {previewing && (
         <FilePreview

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -53,6 +53,14 @@ function useSidebar() {
   return context
 }
 
+// useSidebarOptional returns the sidebar context, or null when there is no
+// provider (e.g. the act-as read-only view renders without one). Lets a
+// page collapse the platform sidebar when it can, without crashing where
+// the sidebar isn't mounted.
+function useSidebarOptional() {
+  return React.useContext(SidebarContext)
+}
+
 function SidebarProvider({
   defaultOpen = true,
   open: openProp,
@@ -720,4 +728,5 @@ export {
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,
+  useSidebarOptional,
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -756,6 +756,49 @@ export async function getScopePreview(
   return { previewUrl: data.previewUrl as string | undefined, status: (data.status as string) || "none" };
 }
 
+// getScopePreviewLogs tails the build/dev log for the current chat scope.
+// The preview panel polls it while the app is scaffolding so the user sees
+// the live pnpm-install output instead of an opaque spinner. Returns "" when
+// there's nothing yet (no runtime, or the scaffold hasn't written a line).
+export async function getScopePreviewLogs(
+  agentId: string,
+  sessionId?: string,
+  projectId?: string,
+  tail = 400,
+): Promise<string> {
+  const params = new URLSearchParams();
+  if (sessionId) params.set("sessionId", sessionId);
+  if (projectId) params.set("projectId", projectId);
+  if (tail > 0) params.set("tail", String(tail));
+  const qs = params.toString();
+  const res = await apiFetch(
+    `/api/agents/${encodeURIComponent(agentId)}/preview/logs${qs ? "?" + qs : ""}`,
+  );
+  if (!res.ok) return "";
+  const data = await res.json().catch(() => ({ logs: "" }));
+  return (data.logs as string) || "";
+}
+
+// getChangedFiles returns only the files the agent created/modified vs the
+// template baseline (git diff in the running app). `available` is false when
+// there's no live runtime/baseline — the caller then lists all files.
+export async function getChangedFiles(
+  agentId: string,
+  sessionId?: string,
+  projectId?: string,
+): Promise<{ files: WorkspaceFile[]; available: boolean }> {
+  const params = new URLSearchParams();
+  if (sessionId) params.set("sessionId", sessionId);
+  if (projectId) params.set("projectId", projectId);
+  const qs = params.toString();
+  const res = await apiFetch(
+    `/api/agents/${encodeURIComponent(agentId)}/changed-files${qs ? "?" + qs : ""}`,
+  );
+  if (!res.ok) return { files: [], available: false };
+  const data = await res.json().catch(() => ({ files: [], available: false }));
+  return { files: (data.files || []) as WorkspaceFile[], available: !!data.available };
+}
+
 // Chat
 export interface ChatHistoryMessage {
   role: "user" | "assistant" | "tool";


### PR DESCRIPTION
## Runtime / sandbox
- **Decouple preview from Docker.** `NewManager` takes the sandbox backend + shared turn pool; non-docker backends (e2b/boxlite) run the dev server inside the agent's **pooled executor** (same sandbox it writes files to → HMR with no host mount) and expose the port via the backend URL scheme. Docker keeps its dedicated-container path **unchanged**.
- `PortExposer` + `TemplateProvisioner` optional executor capabilities; e2b implements `ExposePort` (`<port>-<id>.e2b.app`) + `ProvisionDir` (tar upload).
- Mirror coding `write_file`/`edit_file` into the remote sandbox so e2b previews see live edits.
- **Multi-template:** `TemplateSpec.Image` (docker per-template image), first-registered ref is the stable default, `Templates()` surfaces the menu in `start_app_preview`. New self-scaffolding **`vite-react`** template; `shipany-tanstack` untouched.
- Cloud template-provisioning + backend docs.

## Preview UX
- **Live build logs:** stream scaffold (pnpm install) output to the dev log + new scope logs endpoint + terminal view in the preview panel while building.
- **Responsive preview panel:** viewport-capped width, toolbar folds secondary actions into a `⋯` menu when narrow, opening the panel auto-collapses the platform sidebar — no more horizontal page scroll.

## Verification
- `go build ./...` ✅ · `go test ./...` ✅ · `npx tsc --noEmit` ✅ · `make install` ✅
- e2b paths are compile/test-verified but **not** live-tested here (no E2B key in env); docker path + all unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)