### PR TITLE
Add global and agent MCP configuration management pages.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is FastClaw
+
+A single-binary, multi-user AI Agent runtime in Go. Creates, manages, and runs AI agents — each with its own personality (SOUL.md), memory, skills, tools, and LLM provider. Handles LLM communication, tool execution, sandbox isolation, session management, and IM channel routing.
+
+## Build & Dev
+
+```bash
+make build            # builds web UI (Next.js) + Go binary → bin/fastclaw
+make build-web        # web UI only: cd web && pnpm install && pnpm build → internal/setup/web/
+make bundle-skills    # sync repo-root skills/ → internal/agent/bundled_skills/ (go:embed requires real copy)
+make test             # go test ./...
+make dev              # build-web + air (hot reload)
+make install          # build + install to ~/.local/bin
+make release-local    # cross-compile all platforms → dist/
+```
+
+Prerequisites: Go 1.25+, Node 24+, pnpm 10. CGO is disabled (`CGO_ENABLED=0`).
+
+Run a single test: `go test ./internal/store/ -run TestMigrate -v`
+
+Frontend changes require `make build-web` before the Go binary reflects them.
+
+## Architecture
+
+### Core flow
+
+```
+IM channels / Web UI / API
+        ↓
+    bus.MessageBus (Inbound/Outbound)
+        ↓
+    gateway.Gateway (orchestrator, lazy UserSpace loading)
+        ↓
+    taskqueue (per-channel+chat serialization)
+        ↓
+    agent.Agent.HandleMessage (ReAct loop)
+        ↓
+    provider.Provider (LLM call via open-agent-sdk-go)
+        ↓
+    tools.Registry (exec, file I/O, web, memory, skills, sub-agent, cron...)
+```
+
+### Key packages (internal/)
+
+| Package | Role |
+|---------|------|
+| `gateway` | Runtime orchestrator. Lazy-loads `UserSpace` per user, wires bus→taskqueue→agent. No agents loaded at boot. |
+| `agent` | ReAct loop (`loop.go`, ~3200 lines), context building, tool execution, memory, goals, skills, hooks |
+| `agent/tools` | Tool implementations: exec, file I/O, web_fetch/search, cron, sub-agent, goal, memory_search |
+| `store` | Persistence layer — SQLite (default, WAL mode) or Postgres. Single `DBStore` with dialect-aware SQL |
+| `config` | In-memory `Config` snapshot from env vars + DB. Three-layer agent config merge: defaults → agent entry → agent-file config |
+| `provider` | LLM abstraction — Anthropic and OpenAI-compatible implementations |
+| `api` | OpenAI-compatible HTTP surface (`/v1/chat/completions`, `/v1/agents`, `/v1/users`, WebSocket) |
+| `setup` | Web UI server + admin API handlers. Embeds built Next.js static export |
+| `channels` | IM adapters: Telegram, Discord, Slack, LINE, WeChat, Feishu, Web (SSE) |
+| `bus` | In-process message bus connecting channels ↔ gateway ↔ agents |
+| `sandbox` | Sandboxed execution: Docker, E2B, Boxlite backends |
+| `cron` | Scheduler reads jobs directly from DB each tick, fires onto bus |
+| `mcp` | MCP client manager (stdio + HTTP), maps external tools into agent registry |
+| `plugin` | Out-of-process plugin system (JSON-RPC subprocess) |
+| `scope` | Settings resolution — merges system/user/agent-scoped `configs` rows |
+| `skills` | Skill installation from ClawHub, GitHub, tarballs, skills.sh |
+| `taskqueue` | Bounded concurrent task queue, serializes per-(channel,chat) |
+| `workspace` | Durable blob store (local FS or S3) for agent artifacts |
+| `users` | User provisioning, lazy app_user minting per IM chatter, API key management |
+
+### Database-first config
+
+There is no `fastclaw.json`. Bootstrap settings come from `FASTCLAW_*` env vars. All runtime config (providers, channels, agent settings, defaults) lives in the `configs` DB table with `(kind, user_id, agent_id, name)` keys and layered scope-merge. Code modifying config should go through the store, not write files.
+
+### Multi-tenant model
+
+Every persisted row is keyed by a real `users.id`. `agents.id` is globally unique. Sessions are per-(user, agent). The gateway lazy-loads `UserSpace` per authenticated user and evicts on idle.
+
+### Provider/tool resolution
+
+Per-agent, falling back to shared/system defaults. Model field format: `"<providerKey>/<modelId>"` (e.g. `openai/gpt-4o`). Check `ResolvedAgent` for effective merged config.
+
+### Web frontend
+
+Next.js (App Router) + React + TypeScript + Tailwind CSS v4 in `web/`. Built to static export → `web/out` → embedded into Go binary via `internal/setup/web/`.
+
+### Skills layering
+
+Five layers: `bundled` → `managed` → `user` → `agent` → `extra`. Bundled skills (`skill-creator`, `find-skills`) are synced from `skills/` via `make bundle-skills` into `internal/agent/bundled_skills/` because `go:embed` cannot follow symlinks.
+
+## Code conventions
+
+- CLI uses `cobra`. Subcommands in `cmd/fastclaw/cmd_*.go`.
+- Build version stamped via `-ldflags` into both `main.*` and `internal/buildinfo.*` — keep them in sync.
+- `store.ErrNotFound` is the sentinel for missing records.
+- `config.WithUserID` / `config.UserIDFromContext` for request-scoped user identity.
+- Agent prompt mode (`PromptModeAgent` / `Chatbot` / `Customize`) controls system prompt shape and exposed tools.
+- Channel adapters share `SplitMessageMarker` (`<|split|>`) for multi-bubble replies and `FlattenMarkdownTables` for IM compatibility.
+- Hot-reload: CLI writes send `SIGHUP` to running gateway for cache invalidation.

--- a/internal/gateway/userspace.go
+++ b/internal/gateway/userspace.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -320,7 +321,7 @@ type UserSpace struct {
 	mu sync.Mutex
 }
 
-// readUserScopeAgentDefaults reads the (user=X, agent='') agents.defaults
+// readUserScopeAgentDefaults reads the (user=X, agent=”) agents.defaults
 // row raw — distinct from assembleConfig, which merges system + user and
 // can't tell apart "user explicitly chose the system value" from "no
 // user-scope row at all". EnsureAgent uses this to detect a chatter's
@@ -343,6 +344,29 @@ func readUserScopeAgentDefaults(ctx context.Context, st store.Store, userID stri
 	}
 	_ = json.Unmarshal(blob, &out)
 	return out
+}
+
+func overlayAgentScopeMCP(ctx context.Context, st store.Store, rc *config.ResolvedAgent) error {
+	if st == nil || rc == nil || rc.ID == "" {
+		return nil
+	}
+	sys, err := scope.SystemScopeMCPServers(ctx, st)
+	if err != nil {
+		return err
+	}
+	agentServers, err := scope.AgentScopeMCPServers(ctx, st, rc.ID)
+	if err != nil {
+		return err
+	}
+	if len(sys) == 0 && len(agentServers) == 0 {
+		return nil
+	}
+	if rc.MCPServers == nil {
+		rc.MCPServers = make(map[string]config.MCPServerConfig, len(sys)+len(agentServers))
+	}
+	maps.Copy(rc.MCPServers, sys)          // system base layer
+	maps.Copy(rc.MCPServers, agentServers) // per-agent rows shadow same-name system rows
+	return nil
 }
 
 // EnsureAgent attaches an agent the user does not own to this UserSpace.
@@ -526,6 +550,9 @@ func (sp *UserSpace) EnsureAgent(ctx context.Context, st store.Store, mb *bus.Me
 				rc.Providers[k] = v
 			}
 		}
+	}
+	if err := overlayAgentScopeMCP(ctx, st, &rc); err != nil {
+		slog.Warn("failed to load agent MCP config", "agent", rc.ID, "error", err)
 	}
 	ensureAgentHome(rc)
 	if ws != nil {
@@ -737,6 +764,9 @@ func loadUserSpace(ctx context.Context, userID string, mb *bus.MessageBus, st st
 				}
 				rc.Providers[k] = v
 			}
+		}
+		if err := overlayAgentScopeMCP(ctx, st, rc); err != nil {
+			slog.Warn("failed to load agent MCP config", "agent", rc.ID, "error", err)
 		}
 		ensureAgentHome(*rc)
 		if ws != nil {
@@ -1071,7 +1101,7 @@ func (r *userSpaceRegistry) startEvictor(ctx context.Context) {
 // per Account.
 //
 // Pulls rows from three ownership corners this user can route:
-//   - (user_id='', agent_id=Y): the agent's "official" rows for any
+//   - (user_id=”, agent_id=Y): the agent's "official" rows for any
 //     agent Y the user owns (legacy / pre-refactor data)
 //   - (user_id=userID, agent_id=Y) where user owns Y: this user's
 //     bindings on their own agent (the normal post-refactor pattern)

--- a/internal/gateway/userspace_test.go
+++ b/internal/gateway/userspace_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/fastclaw-ai/fastclaw/internal/bus"
+	"github.com/fastclaw-ai/fastclaw/internal/config"
 	"github.com/fastclaw-ai/fastclaw/internal/scope"
 	"github.com/fastclaw-ai/fastclaw/internal/store"
 	"github.com/fastclaw-ai/fastclaw/internal/users"
@@ -17,6 +18,155 @@ import (
 // overlays) and non-empty in case 2 (pin chatter's choice past the
 // overlay chain) — the only way to tell apart is reading the raw row,
 // not the merged Setting() view.
+func TestOverlayAgentScopeMCPDisabledRowPreservesExistingServer(t *testing.T) {
+	db, err := store.NewDBStore("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	ctx := context.Background()
+
+	rc := &config.ResolvedAgent{
+		ID: "agent-mcp",
+		MCPServers: map[string]config.MCPServerConfig{
+			"legacy": {Type: "http", URL: "https://legacy.example/mcp"},
+		},
+	}
+	if err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind:    store.KindMCP,
+		AgentID: rc.ID,
+		Name:    "legacy",
+		Enabled: false,
+		Data: map[string]interface{}{
+			"type": "http",
+			"url":  "https://disabled.example/mcp",
+		},
+	}); err != nil {
+		t.Fatalf("save disabled MCP row: %v", err)
+	}
+
+	if err := overlayAgentScopeMCP(ctx, db, rc); err != nil {
+		t.Fatalf("overlayAgentScopeMCP: %v", err)
+	}
+	if got := rc.MCPServers["legacy"].URL; got != "https://legacy.example/mcp" {
+		t.Fatalf("disabled DB row should preserve same-name legacy MCP server, got %q", got)
+	}
+}
+
+func TestOverlayAgentScopeMCPOverlaysDBRows(t *testing.T) {
+	db, err := store.NewDBStore("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	ctx := context.Background()
+
+	rc := &config.ResolvedAgent{
+		ID: "agent-mcp",
+		MCPServers: map[string]config.MCPServerConfig{
+			"existing": {Type: "http", URL: "https://existing.example/mcp"},
+			"db":       {Type: "http", URL: "https://old.example/mcp"},
+		},
+	}
+	if err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind:    store.KindMCP,
+		AgentID: rc.ID,
+		Name:    "db",
+		Enabled: true,
+		Data: map[string]interface{}{
+			"type": "http",
+			"url":  "https://db.example/mcp",
+		},
+	}); err != nil {
+		t.Fatalf("save db MCP row: %v", err)
+	}
+	if err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind:    store.KindMCP,
+		AgentID: rc.ID,
+		Name:    "disabled",
+		Enabled: false,
+		Data: map[string]interface{}{
+			"type": "http",
+			"url":  "https://disabled.example/mcp",
+		},
+	}); err != nil {
+		t.Fatalf("save disabled MCP row: %v", err)
+	}
+
+	if err := overlayAgentScopeMCP(ctx, db, rc); err != nil {
+		t.Fatalf("overlayAgentScopeMCP: %v", err)
+	}
+	if got := rc.MCPServers["existing"].URL; got != "https://existing.example/mcp" {
+		t.Fatalf("existing MCP should be preserved, got %q", got)
+	}
+	if got := rc.MCPServers["db"].URL; got != "https://db.example/mcp" {
+		t.Fatalf("db MCP should overlay existing entry, got %q", got)
+	}
+	if _, ok := rc.MCPServers["disabled"]; ok {
+		t.Fatalf("disabled MCP row should not be overlaid: %#v", rc.MCPServers)
+	}
+}
+
+func TestOverlayAgentScopeMCPMergesSystemAndAgentLayers(t *testing.T) {
+	db, err := store.NewDBStore("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	ctx := context.Background()
+
+	rc := &config.ResolvedAgent{ID: "agent-mcp"}
+
+	// System base layer: "shared" (also overridden by agent) + "sysonly".
+	if err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind: store.KindMCP, Name: "shared", Enabled: true,
+		Data: map[string]interface{}{"type": "http", "url": "https://system.example/mcp"},
+	}); err != nil {
+		t.Fatalf("save system shared row: %v", err)
+	}
+	if err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind: store.KindMCP, Name: "sysonly", Enabled: true,
+		Data: map[string]interface{}{"type": "http", "url": "https://sysonly.example/mcp"},
+	}); err != nil {
+		t.Fatalf("save system sysonly row: %v", err)
+	}
+	// Agent layer: same-name "shared" must win; "agentonly" coexists.
+	if err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind: store.KindMCP, AgentID: rc.ID, Name: "shared", Enabled: true,
+		Data: map[string]interface{}{"type": "http", "url": "https://agent.example/mcp"},
+	}); err != nil {
+		t.Fatalf("save agent shared row: %v", err)
+	}
+	if err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind: store.KindMCP, AgentID: rc.ID, Name: "agentonly", Enabled: true,
+		Data: map[string]interface{}{"type": "http", "url": "https://agentonly.example/mcp"},
+	}); err != nil {
+		t.Fatalf("save agent agentonly row: %v", err)
+	}
+
+	if err := overlayAgentScopeMCP(ctx, db, rc); err != nil {
+		t.Fatalf("overlayAgentScopeMCP: %v", err)
+	}
+	if got := rc.MCPServers["sysonly"].URL; got != "https://sysonly.example/mcp" {
+		t.Fatalf("system row should be injected, got %q", got)
+	}
+	if got := rc.MCPServers["agentonly"].URL; got != "https://agentonly.example/mcp" {
+		t.Fatalf("agent row should be injected, got %q", got)
+	}
+	if got := rc.MCPServers["shared"].URL; got != "https://agent.example/mcp" {
+		t.Fatalf("agent row should shadow same-name system row, got %q", got)
+	}
+}
+
 func TestReadUserScopeAgentDefaults(t *testing.T) {
 	db, err := store.NewDBStore("sqlite", "file::memory:?cache=shared")
 	if err != nil {

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -2,13 +2,16 @@ package mcp
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"strings"
 	"sync"
+	"time"
 )
 
 // HTTPClient implements the MCP client for HTTP (Streamable HTTP) servers.
@@ -24,25 +27,13 @@ type HTTPClient struct {
 func NewHTTPClient(url string, headers map[string]string) *HTTPClient {
 	return &HTTPClient{
 		url:     url,
-		headers: expandHeaders(headers),
-		client:  &http.Client{},
+		headers: maps.Clone(headers),
+		client:  &http.Client{Timeout: 15 * time.Second},
 		nextID:  1,
 	}
 }
 
-func expandHeaders(headers map[string]string) map[string]string {
-	expanded := make(map[string]string, len(headers))
-	for k, v := range headers {
-		if strings.HasPrefix(v, "$") {
-			expanded[k] = os.Getenv(v[1:])
-		} else {
-			expanded[k] = v
-		}
-	}
-	return expanded
-}
-
-func (c *HTTPClient) sendRequest(method string, params interface{}) (*jsonRPCResponse, error) {
+func (c *HTTPClient) sendRequest(method string, params any) (*jsonRPCResponse, error) {
 	c.mu.Lock()
 	id := c.nextID
 	c.nextID++
@@ -60,13 +51,18 @@ func (c *HTTPClient) sendRequest(method string, params interface{}) (*jsonRPCRes
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", c.url, bytes.NewReader(body))
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
 	for k, v := range c.headers {
+		if strings.HasPrefix(v, "$") {
+			v = os.Getenv(v[1:])
+		}
 		httpReq.Header.Set(k, v)
 	}
 
@@ -76,7 +72,7 @@ func (c *HTTPClient) sendRequest(method string, params interface{}) (*jsonRPCRes
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
 	}

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -16,11 +16,12 @@ import (
 
 // HTTPClient implements the MCP client for HTTP (Streamable HTTP) servers.
 type HTTPClient struct {
-	url     string
-	headers map[string]string
-	client  *http.Client
-	mu      sync.Mutex
-	nextID  int
+	url       string
+	headers   map[string]string
+	client    *http.Client
+	mu        sync.Mutex
+	nextID    int
+	sessionID string
 }
 
 // NewHTTPClient creates a new HTTP MCP client.
@@ -30,6 +31,30 @@ func NewHTTPClient(url string, headers map[string]string) *HTTPClient {
 		headers: maps.Clone(headers),
 		client:  &http.Client{Timeout: 15 * time.Second},
 		nextID:  1,
+	}
+}
+
+// applyHeaders sets the common request headers (content negotiation, user
+// headers with $ENV expansion, and the session ID once the server has
+// assigned one during initialization).
+func (c *HTTPClient) applyHeaders(httpReq *http.Request) {
+	httpReq.Header.Set("Content-Type", "application/json")
+	// MCP Streamable HTTP transport requires the client to advertise that
+	// it accepts both a plain JSON response and an SSE stream. Servers that
+	// follow the spec reject the request with HTTP 406 otherwise. Set this
+	// before applying user headers so an explicit Accept override still wins.
+	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	for k, v := range c.headers {
+		if strings.HasPrefix(v, "$") {
+			v = os.Getenv(v[1:])
+		}
+		httpReq.Header.Set(k, v)
+	}
+	c.mu.Lock()
+	sid := c.sessionID
+	c.mu.Unlock()
+	if sid != "" {
+		httpReq.Header.Set("Mcp-Session-Id", sid)
 	}
 }
 
@@ -58,19 +83,22 @@ func (c *HTTPClient) sendRequest(method string, params any) (*jsonRPCResponse, e
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	for k, v := range c.headers {
-		if strings.HasPrefix(v, "$") {
-			v = os.Getenv(v[1:])
-		}
-		httpReq.Header.Set(k, v)
-	}
+	c.applyHeaders(httpReq)
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("send request: %w", err)
 	}
 	defer resp.Body.Close()
+
+	// Capture the server-assigned session ID. Per the spec it appears on
+	// the InitializeResult response; once set, every subsequent request
+	// must echo it back via the Mcp-Session-Id header.
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		c.mu.Lock()
+		c.sessionID = sid
+		c.mu.Unlock()
+	}
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 	if err != nil {
@@ -81,8 +109,20 @@ func (c *HTTPClient) sendRequest(method string, params any) (*jsonRPCResponse, e
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 
+	// A spec-compliant server may answer either with a plain JSON object or
+	// with an SSE stream (Content-Type: text/event-stream) whose `data:`
+	// lines carry the JSON-RPC message. Extract the JSON payload from SSE
+	// before unmarshaling.
+	payload := respBody
+	if ct := resp.Header.Get("Content-Type"); strings.Contains(ct, "text/event-stream") {
+		payload = extractSSEData(respBody)
+		if payload == nil {
+			return nil, fmt.Errorf("no JSON-RPC payload in SSE response")
+		}
+	}
+
 	var rpcResp jsonRPCResponse
-	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+	if err := json.Unmarshal(payload, &rpcResp); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 
@@ -93,13 +133,52 @@ func (c *HTTPClient) sendRequest(method string, params any) (*jsonRPCResponse, e
 	return &rpcResp, nil
 }
 
-// Connect initializes the connection with the MCP server.
+// sendNotification posts a JSON-RPC notification (no id, no response body).
+// The MCP lifecycle requires the client to send notifications/initialized
+// after a successful initialize before issuing further requests.
+func (c *HTTPClient) sendNotification(method string, params any) error {
+	body, err := json.Marshal(struct {
+		JSONRPC string `json:"jsonrpc"`
+		Method  string `json:"method"`
+		Params  any    `json:"params,omitempty"`
+	}{JSONRPC: "2.0", Method: method, Params: params})
+	if err != nil {
+		return fmt.Errorf("marshal notification: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	c.applyHeaders(httpReq)
+
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("send notification: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 2<<20))
+	// Spec: a notification-only POST yields 202 Accepted; some servers
+	// reply 200. Anything >= 300 is a real failure.
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("notification %s: HTTP %d", method, resp.StatusCode)
+	}
+	return nil
+}
+
+// Connect runs the MCP initialization handshake: initialize, then the
+// notifications/initialized notification required by the lifecycle before
+// any further requests (e.g. tools/list) are accepted.
 func (c *HTTPClient) Connect() error {
-	_, err := c.sendRequest("initialize", initializeParams{
+	if _, err := c.sendRequest("initialize", initializeParams{
 		ProtocolVersion: "2024-11-05",
 		ClientInfo:      clientInfo{Name: "fastclaw", Version: "0.1.0"},
-	})
-	return err
+	}); err != nil {
+		return err
+	}
+	return c.sendNotification("notifications/initialized", nil)
 }
 
 // ListTools returns the list of tools available on the MCP server.
@@ -144,4 +223,36 @@ func (c *HTTPClient) CallTool(name string, args json.RawMessage) (string, error)
 // Close is a no-op for HTTP clients.
 func (c *HTTPClient) Close() error {
 	return nil
+}
+
+// extractSSEData pulls the JSON-RPC payload out of an SSE response body.
+// Per the SSE format, an event's data is one or more `data:` lines joined
+// with newlines, and events are separated by blank lines. A single
+// request/response exchange yields one event carrying the JSON-RPC reply;
+// if a server sends several events we return the last non-empty one (the
+// final response message). Returns nil when no data lines are present.
+func extractSSEData(body []byte) []byte {
+	var current []string
+	var last []string
+	flush := func() {
+		if len(current) > 0 {
+			last = current
+			current = nil
+		}
+	}
+	for _, raw := range strings.Split(string(body), "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if line == "" {
+			flush()
+			continue
+		}
+		if data, ok := strings.CutPrefix(line, "data:"); ok {
+			current = append(current, strings.TrimPrefix(data, " "))
+		}
+	}
+	flush()
+	if last == nil {
+		return nil
+	}
+	return []byte(strings.Join(last, "\n"))
 }

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/url"
 	"strings"
 
+	"github.com/fastclaw-ai/fastclaw/internal/buildinfo"
 	"github.com/fastclaw-ai/fastclaw/internal/config"
 )
 
@@ -34,8 +37,16 @@ func NewManager(servers map[string]config.MCPServerConfig) *Manager {
 		var client Client
 		switch cfg.Type {
 		case "http":
+			if buildinfo.IsHostedDeploy() && isBlockedHostedHTTPMCPURL(cfg.URL) {
+				slog.Warn("HTTP MCP server target disabled on hosted deployment, skipping", "server", name, "url", cfg.URL)
+				continue
+			}
 			client = NewHTTPClient(cfg.URL, cfg.Headers)
 		case "stdio":
+			if buildinfo.IsHostedDeploy() {
+				slog.Warn("stdio MCP server disabled on hosted deployment, skipping", "server", name)
+				continue
+			}
 			client = NewStdioClient(cfg.Command, cfg.Args, cfg.Env)
 		default:
 			slog.Warn("unknown MCP server type, skipping", "server", name, "type", cfg.Type)
@@ -117,6 +128,22 @@ func (m *Manager) Close() {
 			slog.Warn("error closing MCP server", "server", name, "error", err)
 		}
 	}
+}
+
+func isBlockedHostedHTTPMCPURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return true
+	}
+	host := strings.TrimSpace(strings.ToLower(u.Hostname()))
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") || strings.HasSuffix(host, ".local") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 
 func prefixToolName(serverName, toolName string) string {

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+)
+
+func TestHTTPClientExpandsHeaderEnvValues(t *testing.T) {
+	t.Setenv("TOKEN", "expanded-token")
+	gotAuth := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth <- r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, map[string]string{"Authorization": "$TOKEN"})
+	if err := client.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	select {
+	case got := <-gotAuth:
+		if got != "expanded-token" {
+			t.Fatalf("Authorization header: want expanded-token, got %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive request")
+	}
+}
+
+func TestNewManagerSkipsStdioOnHostedDeploy(t *testing.T) {
+	t.Setenv("FASTCLAW_DEPLOY", "hosted")
+	marker := filepath.Join(t.TempDir(), "stdio-ran")
+
+	mgr := NewManager(map[string]config.MCPServerConfig{
+		"local": {
+			Type:    "stdio",
+			Command: "sh",
+			Args:    []string{"-c", "touch " + marker},
+		},
+	})
+	defer mgr.Close()
+
+	if mgr.HasTools() {
+		t.Fatal("hosted stdio MCP should not register tools")
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("hosted stdio MCP should not start the configured local process")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat marker: %v", err)
+	}
+}

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -15,7 +15,13 @@ func TestHTTPClientExpandsHeaderEnvValues(t *testing.T) {
 	t.Setenv("TOKEN", "expanded-token")
 	gotAuth := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth <- r.Header.Get("Authorization")
+		// Connect() now makes two POSTs (initialize + notifications/
+		// initialized). Use a non-blocking send so the second one doesn't
+		// deadlock on the buffer-1 channel.
+		select {
+		case gotAuth <- r.Header.Get("Authorization"):
+		default:
+		}
 		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
 	}))
 	defer server.Close()

--- a/internal/mcp/test.go
+++ b/internal/mcp/test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/fastclaw-ai/fastclaw/internal/buildinfo"
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+)
+
+// TestResult reports the outcome of a one-shot MCP connection check.
+type TestResult struct {
+	OK        bool   `json:"ok"`
+	ToolCount int    `json:"toolCount"`
+	Error     string `json:"error,omitempty"`
+}
+
+// TestConnection performs a one-shot initialize + tools/list handshake
+// against an HTTP MCP server and reports how many tools it exposes. It
+// never starts a subprocess: stdio servers are rejected up front because
+// a dashboard dry-run shouldn't spawn local processes. The whole probe is
+// bounded by ctx so a hung server can't block the request goroutine.
+func TestConnection(ctx context.Context, cfg config.MCPServerConfig) TestResult {
+	switch cfg.Type {
+	case "http":
+		if buildinfo.IsHostedDeploy() && isBlockedHostedHTTPMCPURL(cfg.URL) {
+			return TestResult{Error: "hosted deployments cannot connect MCP servers to localhost, private, or link-local addresses"}
+		}
+	case "stdio":
+		return TestResult{Error: "connection test is only available for HTTP MCP servers"}
+	default:
+		return TestResult{Error: fmt.Sprintf("unknown MCP server type %q", cfg.Type)}
+	}
+
+	type probeOut struct {
+		tools int
+		err   error
+	}
+	done := make(chan probeOut, 1)
+	go func() {
+		client := NewHTTPClient(cfg.URL, cfg.Headers)
+		defer client.Close()
+		if err := client.Connect(); err != nil {
+			done <- probeOut{err: err}
+			return
+		}
+		tools, err := client.ListTools()
+		if err != nil {
+			done <- probeOut{err: err}
+			return
+		}
+		done <- probeOut{tools: len(tools)}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return TestResult{Error: contextError(ctx.Err())}
+	case out := <-done:
+		if out.err != nil {
+			return TestResult{Error: out.err.Error()}
+		}
+		return TestResult{OK: true, ToolCount: out.tools}
+	}
+}
+
+func contextError(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "connection timed out"
+	}
+	return err.Error()
+}

--- a/internal/mcp/test_test.go
+++ b/internal/mcp/test_test.go
@@ -1,0 +1,173 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+)
+
+func TestTestConnectionHTTPSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch req.Method {
+		case "initialize":
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		case "tools/list":
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"a"},{"name":"b"}]}}`))
+		default:
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":0,"result":{}}`))
+		}
+	}))
+	defer server.Close()
+
+	res := TestConnection(context.Background(), config.MCPServerConfig{Type: "http", URL: server.URL})
+	if !res.OK {
+		t.Fatalf("want ok, got error %q", res.Error)
+	}
+	if res.ToolCount != 2 {
+		t.Fatalf("want 2 tools, got %d", res.ToolCount)
+	}
+}
+
+func TestTestConnectionHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}`))
+	}))
+	defer server.Close()
+
+	res := TestConnection(context.Background(), config.MCPServerConfig{Type: "http", URL: server.URL})
+	if res.OK {
+		t.Fatal("want failure, got ok")
+	}
+	if res.Error == "" {
+		t.Fatal("want error message, got empty")
+	}
+}
+
+func TestHTTPClientPropagatesSessionID(t *testing.T) {
+	const sid = "sess-abc-123"
+	var (
+		mu        sync.Mutex
+		initSeen  bool
+		listAuth  string
+		listSawID string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch req.Method {
+		case "initialize":
+			// Assign the session ID on the InitializeResult response.
+			w.Header().Set("Mcp-Session-Id", sid)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		case "notifications/initialized":
+			mu.Lock()
+			initSeen = true
+			mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			// Reject when the client forgot the session header — mirrors a
+			// spec-compliant server's "Missing session ID" 400.
+			if r.Header.Get("Mcp-Session-Id") == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Missing session ID"}}`))
+				return
+			}
+			mu.Lock()
+			listSawID = r.Header.Get("Mcp-Session-Id")
+			listAuth = r.Header.Get("Accept")
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"a"}]}}`))
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
+	}))
+	defer server.Close()
+
+	res := TestConnection(context.Background(), config.MCPServerConfig{Type: "http", URL: server.URL})
+	if !res.OK {
+		t.Fatalf("want ok, got error %q", res.Error)
+	}
+	if res.ToolCount != 1 {
+		t.Fatalf("want 1 tool, got %d", res.ToolCount)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !initSeen {
+		t.Fatal("client must send notifications/initialized after initialize")
+	}
+	if listSawID != sid {
+		t.Fatalf("tools/list must carry session id %q, server saw %q", sid, listSawID)
+	}
+	if !strings.Contains(listAuth, "text/event-stream") {
+		t.Fatalf("tools/list Accept header lost SSE support: %q", listAuth)
+	}
+}
+
+func TestTestConnectionRejectsStdio(t *testing.T) {
+	res := TestConnection(context.Background(), config.MCPServerConfig{Type: "stdio", Command: "npx"})
+	if res.OK {
+		t.Fatal("stdio should not be testable")
+	}
+	if res.Error == "" {
+		t.Fatal("want rejection message, got empty")
+	}
+}
+
+func TestHTTPClientSendsAcceptHeader(t *testing.T) {
+	gotAccept := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case gotAccept <- r.Header.Get("Accept"):
+		default:
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, nil)
+	if err := client.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	got := <-gotAccept
+	if !strings.Contains(got, "application/json") || !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("Accept header must advertise json + sse, got %q", got)
+	}
+}
+
+func TestHTTPClientParsesSSEResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		switch req.Method {
+		case "initialize":
+			_, _ = w.Write([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n"))
+		default:
+			_, _ = w.Write([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"a\"}]}}\n\n"))
+		}
+	}))
+	defer server.Close()
+
+	res := TestConnection(context.Background(), config.MCPServerConfig{Type: "http", URL: server.URL})
+	if !res.OK {
+		t.Fatalf("want ok, got error %q", res.Error)
+	}
+	if res.ToolCount != 1 {
+		t.Fatalf("want 1 tool from SSE response, got %d", res.ToolCount)
+	}
+}

--- a/internal/scope/mcp_test.go
+++ b/internal/scope/mcp_test.go
@@ -1,0 +1,179 @@
+package scope
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/store"
+)
+
+func TestAgentScopeMCPServersReturnsEnabledAgentRows(t *testing.T) {
+	db := newMCPTestStore(t)
+	ctx := context.Background()
+	agentID := "agent-mcp"
+
+	saveMCPRow(t, ctx, db, agentID, "github", true, config.MCPServerConfig{
+		Type:    "http",
+		URL:     "https://example.com/mcp",
+		Headers: map[string]string{"Authorization": "Bearer token"},
+	})
+	saveMCPRow(t, ctx, db, agentID, "filesystem", true, config.MCPServerConfig{
+		Type:    "stdio",
+		Command: "npx",
+		Args:    []string{"-y", "@modelcontextprotocol/server-filesystem", "/workspace"},
+		Env:     map[string]string{"API_TOKEN": "secret"},
+	})
+
+	got, err := AgentScopeMCPServers(ctx, db, agentID)
+	if err != nil {
+		t.Fatalf("AgentScopeMCPServers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 MCP servers, got %d: %#v", len(got), got)
+	}
+	if got["github"].URL != "https://example.com/mcp" {
+		t.Fatalf("github URL: want https://example.com/mcp, got %q", got["github"].URL)
+	}
+	if got["filesystem"].Command != "npx" {
+		t.Fatalf("filesystem command: want npx, got %q", got["filesystem"].Command)
+	}
+}
+
+func TestAgentScopeMCPServersSkipsDisabledRows(t *testing.T) {
+	db := newMCPTestStore(t)
+	ctx := context.Background()
+	agentID := "agent-mcp"
+
+	saveMCPRow(t, ctx, db, agentID, "enabled", true, config.MCPServerConfig{Type: "http", URL: "https://enabled.example/mcp"})
+	saveMCPRow(t, ctx, db, agentID, "disabled", false, config.MCPServerConfig{Type: "http", URL: "https://disabled.example/mcp"})
+
+	got, err := AgentScopeMCPServers(ctx, db, agentID)
+	if err != nil {
+		t.Fatalf("AgentScopeMCPServers: %v", err)
+	}
+	if _, ok := got["disabled"]; ok {
+		t.Fatalf("disabled row should be omitted: %#v", got)
+	}
+	if _, ok := got["enabled"]; !ok {
+		t.Fatalf("enabled row missing: %#v", got)
+	}
+}
+
+func TestAgentScopeMCPServersEmptyAgentIDReturnsEmptyMap(t *testing.T) {
+	db := newMCPTestStore(t)
+	got, err := AgentScopeMCPServers(context.Background(), db, "")
+	if err != nil {
+		t.Fatalf("AgentScopeMCPServers: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want empty map, got %#v", got)
+	}
+}
+
+func TestAgentScopeMCPServersReturnsErrorForMalformedConfig(t *testing.T) {
+	db := newMCPTestStore(t)
+	ctx := context.Background()
+	err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind:    store.KindMCP,
+		AgentID: "agent-mcp",
+		Name:    "broken",
+		Enabled: true,
+		Data: map[string]interface{}{
+			"type": 123,
+		},
+	})
+	if err != nil {
+		t.Fatalf("save malformed row: %v", err)
+	}
+
+	_, err = AgentScopeMCPServers(ctx, db, "agent-mcp")
+	if err == nil {
+		t.Fatal("want malformed config error, got nil")
+	}
+	if !strings.Contains(err.Error(), "broken") {
+		t.Fatalf("error should name broken row, got %q", err.Error())
+	}
+}
+
+func TestSystemScopeMCPServersReturnsEnabledSystemRows(t *testing.T) {
+	db := newMCPTestStore(t)
+	ctx := context.Background()
+
+	saveMCPRow(t, ctx, db, "", "shared", true, config.MCPServerConfig{Type: "http", URL: "https://shared.example/mcp"})
+	saveMCPRow(t, ctx, db, "", "off", false, config.MCPServerConfig{Type: "http", URL: "https://off.example/mcp"})
+	// An agent-scoped row must not leak into the system view.
+	saveMCPRow(t, ctx, db, "agent-mcp", "agentonly", true, config.MCPServerConfig{Type: "http", URL: "https://agentonly.example/mcp"})
+
+	got, err := SystemScopeMCPServers(ctx, db)
+	if err != nil {
+		t.Fatalf("SystemScopeMCPServers: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 system MCP server, got %d: %#v", len(got), got)
+	}
+	if got["shared"].URL != "https://shared.example/mcp" {
+		t.Fatalf("shared URL: want https://shared.example/mcp, got %q", got["shared"].URL)
+	}
+	if _, ok := got["off"]; ok {
+		t.Fatalf("disabled system row should be omitted: %#v", got)
+	}
+	if _, ok := got["agentonly"]; ok {
+		t.Fatalf("agent-scoped row leaked into system view: %#v", got)
+	}
+}
+
+func TestSystemScopeMCPServersNilStoreReturnsEmptyMap(t *testing.T) {
+	got, err := SystemScopeMCPServers(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("SystemScopeMCPServers: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want empty map, got %#v", got)
+	}
+}
+
+func newMCPTestStore(t *testing.T) *store.DBStore {
+	t.Helper()
+	db, err := store.NewDBStore("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func saveMCPRow(t *testing.T, ctx context.Context, db *store.DBStore, agentID, name string, enabled bool, cfg config.MCPServerConfig) {
+	t.Helper()
+	data := map[string]interface{}{
+		"type": cfg.Type,
+	}
+	if cfg.URL != "" {
+		data["url"] = cfg.URL
+	}
+	if cfg.Headers != nil {
+		data["headers"] = cfg.Headers
+	}
+	if cfg.Command != "" {
+		data["command"] = cfg.Command
+	}
+	if cfg.Args != nil {
+		data["args"] = cfg.Args
+	}
+	if cfg.Env != nil {
+		data["env"] = cfg.Env
+	}
+	if err := db.SaveConfig(ctx, &store.ConfigRecord{
+		Kind:    store.KindMCP,
+		AgentID: agentID,
+		Name:    name,
+		Enabled: enabled,
+		Data:    data,
+	}); err != nil {
+		t.Fatalf("save MCP row %s: %v", name, err)
+	}
+}

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -11,17 +11,23 @@
 //	      per-(user, agent) (user=X, agent=Y)
 //
 // kind="provider": name is the provider key ("openai"). Inner rows
-//   replace outer entries entirely (no field-level merge).
+//
+//	replace outer entries entirely (no field-level merge).
+//
 // kind="channel":  name is the channel type ("telegram"). A disabled inner
-//   row erases the outer entry — lets a user opt out of a system-wide bot.
+//
+//	row erases the outer entry — lets a user opt out of a system-wide bot.
+//
 // kind="setting":  name is the namespace ("agents.defaults", "sandbox", …).
-//   Top-level keys merge field-wise; inner-scope keys win.
+//
+//	Top-level keys merge field-wise; inner-scope keys win.
 package scope
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/fastclaw-ai/fastclaw/internal/config"
 	"github.com/fastclaw-ai/fastclaw/internal/store"
@@ -160,6 +166,55 @@ func UserScopeProviders(ctx context.Context, st store.Store, userID string) (map
 	out := make(map[string]config.ProviderConfig, len(rows))
 	for _, r := range rows {
 		out[r.Name] = providerToConfig(r)
+	}
+	return out, nil
+}
+
+// AgentScopeMCPServers returns enabled MCP servers stored at
+// (user='', agent=Y) only. These rows are the dashboard-managed per-agent
+// MCP overlay and intentionally do not walk system/user layers.
+func AgentScopeMCPServers(ctx context.Context, st store.Store, agentID string) (map[string]config.MCPServerConfig, error) {
+	if st == nil || agentID == "" {
+		return map[string]config.MCPServerConfig{}, nil
+	}
+	rows, err := st.ListConfigs(ctx, store.KindMCP, "", agentID)
+	if err != nil {
+		return nil, err
+	}
+	return decodeMCPRows(rows)
+}
+
+// SystemScopeMCPServers returns enabled MCP servers stored at the system
+// layer (user='', agent=''). This is the broadcast base layer inherited
+// by every agent; per-agent rows with the same name shadow these.
+func SystemScopeMCPServers(ctx context.Context, st store.Store) (map[string]config.MCPServerConfig, error) {
+	if st == nil {
+		return map[string]config.MCPServerConfig{}, nil
+	}
+	rows, err := st.ListConfigs(ctx, store.KindMCP, "", "")
+	if err != nil {
+		return nil, err
+	}
+	return decodeMCPRows(rows)
+}
+
+// decodeMCPRows turns kind="mcp" config rows into the runtime map,
+// skipping disabled rows. Shared by the agent- and system-scope readers.
+func decodeMCPRows(rows []store.ConfigRecord) (map[string]config.MCPServerConfig, error) {
+	out := make(map[string]config.MCPServerConfig, len(rows))
+	for _, rec := range rows {
+		if !rec.Enabled {
+			continue
+		}
+		blob, err := json.Marshal(rec.Data)
+		if err != nil {
+			return nil, fmt.Errorf("marshal MCP config %q: %w", rec.Name, err)
+		}
+		var cfg config.MCPServerConfig
+		if err := json.Unmarshal(blob, &cfg); err != nil {
+			return nil, fmt.Errorf("decode MCP config %q: %w", rec.Name, err)
+		}
+		out[rec.Name] = cfg
 	}
 	return out, nil
 }

--- a/internal/setup/handlers_mcp.go
+++ b/internal/setup/handlers_mcp.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/fastclaw-ai/fastclaw/internal/buildinfo"
 	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/mcp"
 	"github.com/fastclaw-ai/fastclaw/internal/scope"
 	"github.com/fastclaw-ai/fastclaw/internal/store"
 )
@@ -142,6 +144,49 @@ func (s *Server) handleDeleteSystemMCPServer(w http.ResponseWriter, r *http.Requ
 	if s.mcpDelete(w, r, "", "", r.PathValue("name")) {
 		s.invalidateScope(scope.System, "")
 	}
+}
+
+func (s *Server) handleTestAgentMCPServer(w http.ResponseWriter, r *http.Request) {
+	agentID := r.PathValue("id")
+	if s.requireAgentOwner(w, r, agentID) == nil {
+		return
+	}
+	s.mcpTest(w, r, "", agentID)
+}
+
+func (s *Server) handleTestSystemMCPServer(w http.ResponseWriter, r *http.Request) {
+	if !s.authorizeScope(w, r, scope.System, "", scopeRead) {
+		return
+	}
+	s.mcpTest(w, r, "", "")
+}
+
+// mcpTest runs a one-shot connection check against the MCP config in the
+// request body. Masked secret values (****) fall back to the stored
+// secret of the same-name row when one exists, so the user can test an
+// edited config without re-pasting credentials. Only HTTP servers are
+// testable; stdio is rejected inside mcp.TestConnection.
+func (s *Server) mcpTest(w http.ResponseWriter, r *http.Request, userID, agentID string) {
+	var req writeAgentMCPServerRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	cfg, err := validateMCPServerConfig(req)
+	if err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	if req.Name != "" {
+		if rec, err := s.dataStore.GetConfigByName(r.Context(), store.KindMCP, userID, agentID, req.Name); err == nil && rec != nil {
+			if existing, err := mcpConfigFromRecord(*rec); err == nil {
+				cfg.Headers = mergeMaskedStringMap(existing.Headers, cfg.Headers)
+			}
+		}
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	jsonResponse(w, http.StatusOK, mcp.TestConnection(ctx, cfg))
 }
 
 // mcpList writes the masked server list for the given ownership.

--- a/internal/setup/handlers_mcp.go
+++ b/internal/setup/handlers_mcp.go
@@ -1,0 +1,482 @@
+package setup
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/fastclaw-ai/fastclaw/internal/buildinfo"
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/scope"
+	"github.com/fastclaw-ai/fastclaw/internal/store"
+)
+
+const maxMCPServersPerScope = 20
+
+var (
+	mcpServerNameRe = regexp.MustCompile(`^[A-Za-z0-9_]{1,64}$`)
+	mcpEnvKeyRe     = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+)
+
+type agentMCPServerOut struct {
+	Name      string            `json:"name"`
+	Type      string            `json:"type"`
+	Enabled   bool              `json:"enabled"`
+	URL       string            `json:"url,omitempty"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	UpdatedAt string            `json:"updatedAt,omitempty"`
+}
+
+type writeAgentMCPServerRequest struct {
+	Name    string            `json:"name"`
+	Type    string            `json:"type"`
+	Enabled *bool             `json:"enabled,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// MCP server config is stored in the configs table keyed by (kind="mcp",
+// user_id, agent_id). The handlers below come in two flavors — per-agent
+// (agent_id=Y, owner-gated) and system (agent_id="", super_admin-gated) —
+// but share one scope-parameterized core (mcpList/Create/Update/Delete)
+// that operates on a plain (userID, agentID) ownership pair. System scope
+// is (userID="", agentID="").
+
+func (s *Server) handleListAgentMCPServers(w http.ResponseWriter, r *http.Request) {
+	agentID := r.PathValue("id")
+	if s.requireAgentOwner(w, r, agentID) == nil {
+		return
+	}
+	s.mcpList(w, r, "", agentID)
+}
+
+func (s *Server) handleCreateAgentMCPServer(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWritable(w, r) {
+		return
+	}
+	agentID := r.PathValue("id")
+	if s.requireAgentOwner(w, r, agentID) == nil {
+		return
+	}
+	if s.mcpCreate(w, r, "", agentID) {
+		s.invalidateAgent(agentID)
+	}
+}
+
+func (s *Server) handleUpdateAgentMCPServer(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWritable(w, r) {
+		return
+	}
+	agentID := r.PathValue("id")
+	if s.requireAgentOwner(w, r, agentID) == nil {
+		return
+	}
+	if s.mcpUpdate(w, r, "", agentID, r.PathValue("name")) {
+		s.invalidateAgent(agentID)
+	}
+}
+
+func (s *Server) handleDeleteAgentMCPServer(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWritable(w, r) {
+		return
+	}
+	agentID := r.PathValue("id")
+	if s.requireAgentOwner(w, r, agentID) == nil {
+		return
+	}
+	if s.mcpDelete(w, r, "", agentID, r.PathValue("name")) {
+		s.invalidateAgent(agentID)
+	}
+}
+
+func (s *Server) handleListSystemMCPServers(w http.ResponseWriter, r *http.Request) {
+	if !s.authorizeScope(w, r, scope.System, "", scopeRead) {
+		return
+	}
+	s.mcpList(w, r, "", "")
+}
+
+func (s *Server) handleCreateSystemMCPServer(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWritable(w, r) {
+		return
+	}
+	if !s.authorizeScope(w, r, scope.System, "", scopeWrite) {
+		return
+	}
+	if s.mcpCreate(w, r, "", "") {
+		s.invalidateScope(scope.System, "")
+	}
+}
+
+func (s *Server) handleUpdateSystemMCPServer(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWritable(w, r) {
+		return
+	}
+	if !s.authorizeScope(w, r, scope.System, "", scopeWrite) {
+		return
+	}
+	if s.mcpUpdate(w, r, "", "", r.PathValue("name")) {
+		s.invalidateScope(scope.System, "")
+	}
+}
+
+func (s *Server) handleDeleteSystemMCPServer(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWritable(w, r) {
+		return
+	}
+	if !s.authorizeScope(w, r, scope.System, "", scopeWrite) {
+		return
+	}
+	if s.mcpDelete(w, r, "", "", r.PathValue("name")) {
+		s.invalidateScope(scope.System, "")
+	}
+}
+
+// mcpList writes the masked server list for the given ownership.
+func (s *Server) mcpList(w http.ResponseWriter, r *http.Request, userID, agentID string) {
+	rows, err := s.dataStore.ListConfigs(r.Context(), store.KindMCP, userID, agentID)
+	if err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return
+	}
+	out := make([]agentMCPServerOut, 0, len(rows))
+	for _, rec := range rows {
+		server, err := mcpServerOutFromRecord(rec)
+		if err != nil {
+			jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+			return
+		}
+		out = append(out, server)
+	}
+	jsonResponse(w, http.StatusOK, map[string]any{"servers": out})
+}
+
+// mcpCreate validates and persists a new MCP server at the given
+// ownership. Returns true when a row was saved (caller invalidates).
+func (s *Server) mcpCreate(w http.ResponseWriter, r *http.Request, userID, agentID string) bool {
+	var req writeAgentMCPServerRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return false
+	}
+	if err := validateMCPServerName(req.Name); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return false
+	}
+	cfg, err := validateMCPServerConfig(req)
+	if err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return false
+	}
+	if existing, err := s.dataStore.GetConfigByName(r.Context(), store.KindMCP, userID, agentID, req.Name); err == nil && existing != nil {
+		jsonResponse(w, http.StatusConflict, map[string]any{"error": "MCP server already exists"})
+		return false
+	} else if err != nil && !errors.Is(err, store.ErrNotFound) {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return false
+	}
+	rows, err := s.dataStore.ListConfigs(r.Context(), store.KindMCP, userID, agentID)
+	if err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return false
+	}
+	if len(rows) >= maxMCPServersPerScope {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": fmt.Sprintf("maximum %d MCP servers per scope", maxMCPServersPerScope)})
+		return false
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	rec := &store.ConfigRecord{
+		Kind:    store.KindMCP,
+		UserID:  userID,
+		AgentID: agentID,
+		Name:    req.Name,
+		Enabled: enabled,
+		Data:    mcpConfigToData(cfg),
+	}
+	if err := s.dataStore.SaveConfig(r.Context(), rec); err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return false
+	}
+	jsonResponse(w, http.StatusOK, map[string]any{"ok": true, "server": mcpServerOutFromConfig(req.Name, enabled, cfg, rec.UpdatedAt)})
+	return true
+}
+
+// mcpUpdate validates and persists changes to an existing MCP server.
+// Masked secret values are preserved from the stored config. Returns true
+// when a row was saved (caller invalidates).
+func (s *Server) mcpUpdate(w http.ResponseWriter, r *http.Request, userID, agentID, name string) bool {
+	if err := validateMCPServerName(name); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return false
+	}
+	rec, err := s.dataStore.GetConfigByName(r.Context(), store.KindMCP, userID, agentID, name)
+	if err != nil || rec == nil {
+		jsonResponse(w, http.StatusNotFound, map[string]any{"error": "not found"})
+		return false
+	}
+	existing, err := mcpConfigFromRecord(*rec)
+	if err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return false
+	}
+
+	var req writeAgentMCPServerRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return false
+	}
+	if req.Name != "" && req.Name != name {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "name cannot be changed"})
+		return false
+	}
+	cfg, err := validateMCPServerConfig(req)
+	if err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return false
+	}
+	cfg.Headers = mergeMaskedStringMap(existing.Headers, cfg.Headers)
+	cfg.Env = mergeMaskedStringMap(existing.Env, cfg.Env)
+	enabled := rec.Enabled
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	rec.Enabled = enabled
+	rec.Data = mcpConfigToData(cfg)
+	if err := s.dataStore.SaveConfig(r.Context(), rec); err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return false
+	}
+	jsonResponse(w, http.StatusOK, map[string]any{"ok": true, "server": mcpServerOutFromConfig(name, enabled, cfg, rec.UpdatedAt)})
+	return true
+}
+
+// mcpDelete removes an MCP server row. Returns true when a row was
+// deleted (caller invalidates).
+func (s *Server) mcpDelete(w http.ResponseWriter, r *http.Request, userID, agentID, name string) bool {
+	rec, err := s.dataStore.GetConfigByName(r.Context(), store.KindMCP, userID, agentID, name)
+	if err != nil || rec == nil {
+		jsonResponse(w, http.StatusNotFound, map[string]any{"error": "not found"})
+		return false
+	}
+	if err := s.dataStore.DeleteConfig(r.Context(), rec.ID); err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return false
+	}
+	jsonResponse(w, http.StatusOK, map[string]any{"ok": true})
+	return true
+}
+
+func validateMCPServerName(name string) error {
+	if name == "" {
+		return errors.New("name required")
+	}
+	if !mcpServerNameRe.MatchString(name) {
+		return errors.New("name must match ^[A-Za-z0-9_]{1,64}$")
+	}
+	return nil
+}
+
+func validateMCPServerConfig(req writeAgentMCPServerRequest) (config.MCPServerConfig, error) {
+	switch req.Type {
+	case "http":
+		if req.Command != "" || len(req.Args) > 0 || len(req.Env) > 0 {
+			return config.MCPServerConfig{}, errors.New("http MCP server cannot include command, args, or env")
+		}
+		if strings.TrimSpace(req.URL) == "" {
+			return config.MCPServerConfig{}, errors.New("url required")
+		}
+		u, err := url.Parse(req.URL)
+		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+			return config.MCPServerConfig{}, errors.New("url must be http or https with a host")
+		}
+		if buildinfo.IsHostedDeploy() && isBlockedHostedMCPHost(u.Hostname()) {
+			return config.MCPServerConfig{}, errors.New("hosted deployments cannot connect MCP servers to localhost, private, or link-local addresses")
+		}
+		if err := validateMCPStringMap("header", req.Headers, 50, 128, 4096, false); err != nil {
+			return config.MCPServerConfig{}, err
+		}
+		return config.MCPServerConfig{Type: "http", URL: req.URL, Headers: req.Headers}, nil
+	case "stdio":
+		if buildinfo.IsHostedDeploy() {
+			return config.MCPServerConfig{}, errors.New("stdio MCP servers are disabled on hosted deployments")
+		}
+		if req.URL != "" || len(req.Headers) > 0 {
+			return config.MCPServerConfig{}, errors.New("stdio MCP server cannot include url or headers")
+		}
+		cmd := strings.TrimSpace(req.Command)
+		if cmd == "" {
+			return config.MCPServerConfig{}, errors.New("command required")
+		}
+		if len(req.Args) > 100 {
+			return config.MCPServerConfig{}, errors.New("args cannot exceed 100 entries")
+		}
+		for _, arg := range req.Args {
+			if len(arg) > 4096 {
+				return config.MCPServerConfig{}, errors.New("arg cannot exceed 4096 characters")
+			}
+		}
+		if err := validateMCPStringMap("env", req.Env, 100, 128, 8192, true); err != nil {
+			return config.MCPServerConfig{}, err
+		}
+		return config.MCPServerConfig{Type: "stdio", Command: cmd, Args: req.Args, Env: req.Env}, nil
+	default:
+		return config.MCPServerConfig{}, errors.New("type must be http or stdio")
+	}
+}
+
+func validateMCPStringMap(label string, values map[string]string, maxEntries, maxKeyLen, maxValueLen int, envKeys bool) error {
+	if len(values) > maxEntries {
+		return fmt.Errorf("%s entries cannot exceed %d", label, maxEntries)
+	}
+	for k, v := range values {
+		if k == "" {
+			return fmt.Errorf("%s key required", label)
+		}
+		if len(k) > maxKeyLen {
+			return fmt.Errorf("%s key cannot exceed %d characters", label, maxKeyLen)
+		}
+		if strings.ContainsAny(k, "\r\n") || strings.ContainsAny(v, "\r\n") {
+			return fmt.Errorf("%s key/value cannot contain newlines", label)
+		}
+		if isEnvExpansionReference(v) {
+			return fmt.Errorf("%s value for %q cannot reference server environment variables", label, k)
+		}
+		if envKeys && !mcpEnvKeyRe.MatchString(k) {
+			return fmt.Errorf("env key %q is invalid", k)
+		}
+		if len(v) > maxValueLen {
+			return fmt.Errorf("%s value cannot exceed %d characters", label, maxValueLen)
+		}
+	}
+	return nil
+}
+
+func mcpConfigFromRecord(rec store.ConfigRecord) (config.MCPServerConfig, error) {
+	blob, err := json.Marshal(rec.Data)
+	if err != nil {
+		return config.MCPServerConfig{}, err
+	}
+	var cfg config.MCPServerConfig
+	if err := json.Unmarshal(blob, &cfg); err != nil {
+		return config.MCPServerConfig{}, err
+	}
+	return cfg, nil
+}
+
+func mcpConfigToData(cfg config.MCPServerConfig) map[string]interface{} {
+	blob, _ := json.Marshal(cfg)
+	var data map[string]interface{}
+	_ = json.Unmarshal(blob, &data)
+	return data
+}
+
+func mcpServerOutFromRecord(rec store.ConfigRecord) (agentMCPServerOut, error) {
+	cfg, err := mcpConfigFromRecord(rec)
+	if err != nil {
+		return agentMCPServerOut{}, err
+	}
+	return mcpServerOutFromConfig(rec.Name, rec.Enabled, cfg, rec.UpdatedAt), nil
+}
+
+func mcpServerOutFromConfig(name string, enabled bool, cfg config.MCPServerConfig, updatedAt time.Time) agentMCPServerOut {
+	masked := maskMCPConfig(cfg)
+	out := agentMCPServerOut{
+		Name:    name,
+		Type:    masked.Type,
+		Enabled: enabled,
+		URL:     masked.URL,
+		Headers: masked.Headers,
+		Command: masked.Command,
+		Args:    masked.Args,
+		Env:     masked.Env,
+	}
+	if !updatedAt.IsZero() {
+		out.UpdatedAt = updatedAt.Format(time.RFC3339)
+	}
+	return out
+}
+
+func maskMCPConfig(cfg config.MCPServerConfig) config.MCPServerConfig {
+	out := cfg
+	if len(cfg.Headers) > 0 {
+		out.Headers = make(map[string]string, len(cfg.Headers))
+		for k, v := range cfg.Headers {
+			if mcpKeyLooksSecret(k) {
+				out.Headers[k] = maskAPIKey(v)
+			} else {
+				out.Headers[k] = v
+			}
+		}
+	}
+	if len(cfg.Env) > 0 {
+		out.Env = make(map[string]string, len(cfg.Env))
+		for k, v := range cfg.Env {
+			if mcpKeyLooksSecret(k) {
+				out.Env[k] = maskAPIKey(v)
+			} else {
+				out.Env[k] = v
+			}
+		}
+	}
+	return out
+}
+
+func isEnvExpansionReference(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) < 2 || trimmed[0] != '$' {
+		return false
+	}
+	return mcpEnvKeyRe.MatchString(trimmed[1:])
+}
+
+func isBlockedHostedMCPHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" || host == "localhost" || strings.HasSuffix(host, ".localhost") || strings.HasSuffix(host, ".local") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
+}
+
+func mergeMaskedStringMap(existing, incoming map[string]string) map[string]string {
+	if incoming == nil {
+		return nil
+	}
+	out := make(map[string]string, len(incoming))
+	for k, v := range incoming {
+		if isMaskedSecret(v) {
+			if old, ok := existing[k]; ok {
+				out[k] = old
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func mcpKeyLooksSecret(name string) bool {
+	lower := strings.ToLower(name)
+	if strings.Contains(lower, "authorization") || strings.Contains(lower, "cookie") {
+		return true
+	}
+	return looksLikeSecret(name)
+}

--- a/internal/setup/handlers_mcp_test.go
+++ b/internal/setup/handlers_mcp_test.go
@@ -377,6 +377,95 @@ func TestSystemMCPServersNonAdminReadAllowedWriteForbidden(t *testing.T) {
 	}
 }
 
+func TestAgentMCPTestConnectionUsesStoredSecretForMaskedHeader(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, _, owner := newAuthTestServer(t, ctx)
+	s.SetUserResolver(&mcpTestResolver{})
+	agentID := createMCPTestAgent(t, ctx, s.dataStore, owner.ID)
+
+	gotAuth := make(chan string, 4)
+	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Method == "initialize" {
+			gotAuth <- r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"a"}]}}`))
+	}))
+	defer mcpServer.Close()
+
+	// Store a server with a real secret.
+	createBody := `{"name":"svc","type":"http","url":"` + mcpServer.URL + `","headers":{"Authorization":"Bearer real-secret"}}`
+	createReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp", owner.ID, createBody)
+	createReq.SetPathValue("id", agentID)
+	createRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleCreateAgentMCPServer)(createRR, createReq)
+	if createRR.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body=%s", createRR.Code, createRR.Body.String())
+	}
+
+	// Test with a masked Authorization value — the handler must substitute
+	// the stored secret before connecting.
+	testBody := `{"name":"svc","type":"http","url":"` + mcpServer.URL + `","headers":{"Authorization":"****"}}`
+	testReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp/test", owner.ID, testBody)
+	testReq.SetPathValue("id", agentID)
+	testRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleTestAgentMCPServer)(testRR, testReq)
+	if testRR.Code != http.StatusOK {
+		t.Fatalf("test status = %d, body=%s", testRR.Code, testRR.Body.String())
+	}
+	var res struct {
+		OK        bool   `json:"ok"`
+		ToolCount int    `json:"toolCount"`
+		Error     string `json:"error"`
+	}
+	if err := json.Unmarshal(testRR.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode test result: %v", err)
+	}
+	if !res.OK || res.ToolCount != 1 {
+		t.Fatalf("want ok with 1 tool, got %#v", res)
+	}
+
+	// The most recent initialize must have carried the stored secret, not
+	// the masked placeholder.
+	var lastAuth string
+	for len(gotAuth) > 0 {
+		lastAuth = <-gotAuth
+	}
+	if lastAuth != "Bearer real-secret" {
+		t.Fatalf("test should use stored secret, server saw %q", lastAuth)
+	}
+}
+
+func TestSystemMCPTestConnectionRejectsStdio(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, admin, _ := newAuthTestServer(t, ctx)
+	s.SetUserResolver(&mcpTestResolver{})
+
+	body := `{"name":"local","type":"stdio","command":"npx","args":["-y","x"]}`
+	req := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/admin/mcp/test", admin.ID, body)
+	rr := httptest.NewRecorder()
+	s.authMiddleware(s.handleTestSystemMCPServer)(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+	var res struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if res.OK || res.Error == "" {
+		t.Fatalf("stdio test should fail with a message, got %#v", res)
+	}
+}
+
 func createMCPTestAgent(t *testing.T, ctx context.Context, st store.Store, userID string) string {
 	t.Helper()
 	agentID := "agt_mcp_test"

--- a/internal/setup/handlers_mcp_test.go
+++ b/internal/setup/handlers_mcp_test.go
@@ -1,0 +1,420 @@
+package setup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/agent"
+	"github.com/fastclaw-ai/fastclaw/internal/api"
+	"github.com/fastclaw-ai/fastclaw/internal/store"
+	"github.com/fastclaw-ai/fastclaw/internal/users"
+)
+
+func TestAgentMCPServersCRUDMasksAndPreservesSecrets(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, _, owner := newAuthTestServer(t, ctx)
+	agentID := createMCPTestAgent(t, ctx, s.dataStore, owner.ID)
+	invalidator := &mcpTestResolver{}
+	s.SetUserResolver(invalidator)
+
+	createBody := `{"name":"github","type":"http","enabled":true,"url":"https://example.com/mcp","headers":{"Authorization":"Bearer secret","X-Trace":"visible"}}`
+	createReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp", owner.ID, createBody)
+	createReq.SetPathValue("id", agentID)
+	createRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleCreateAgentMCPServer)(createRR, createReq)
+	if createRR.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body=%s", createRR.Code, createRR.Body.String())
+	}
+	if len(invalidator.agents) != 1 || invalidator.agents[0] != agentID {
+		t.Fatalf("create should invalidate %s, got %#v", agentID, invalidator.agents)
+	}
+
+	listReq := mcpAuthRequest(t, ctx, resolver, http.MethodGet, "/api/agents/"+agentID+"/mcp", owner.ID, "")
+	listReq.SetPathValue("id", agentID)
+	listRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleListAgentMCPServers)(listRR, listReq)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body=%s", listRR.Code, listRR.Body.String())
+	}
+	var listResp struct {
+		Servers []agentMCPServerOut `json:"servers"`
+	}
+	if err := json.Unmarshal(listRR.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listResp.Servers) != 1 {
+		t.Fatalf("want 1 server, got %#v", listResp.Servers)
+	}
+	if got := listResp.Servers[0].Headers["Authorization"]; got == "Bearer secret" || got == "" {
+		t.Fatalf("Authorization header should be masked, got %q", got)
+	}
+	if got := listResp.Servers[0].Headers["X-Trace"]; got != "visible" {
+		t.Fatalf("non-secret header should remain visible, got %q", got)
+	}
+
+	updateBody := `{"name":"github","type":"http","enabled":false,"url":"https://example.com/mcp2","headers":{"Authorization":"****","X-Trace":"changed"}}`
+	updateReq := mcpAuthRequest(t, ctx, resolver, http.MethodPut, "/api/agents/"+agentID+"/mcp/github", owner.ID, updateBody)
+	updateReq.SetPathValue("id", agentID)
+	updateReq.SetPathValue("name", "github")
+	updateRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleUpdateAgentMCPServer)(updateRR, updateReq)
+	if updateRR.Code != http.StatusOK {
+		t.Fatalf("update status = %d, body=%s", updateRR.Code, updateRR.Body.String())
+	}
+	if len(invalidator.agents) != 2 || invalidator.agents[1] != agentID {
+		t.Fatalf("update should invalidate %s, got %#v", agentID, invalidator.agents)
+	}
+	rec, err := s.dataStore.GetConfigByName(ctx, store.KindMCP, "", agentID, "github")
+	if err != nil || rec == nil {
+		t.Fatalf("read MCP config: %v", err)
+	}
+	storedHeaders, _ := rec.Data["headers"].(map[string]any)
+	if got := storedHeaders["Authorization"]; got != "Bearer secret" {
+		t.Fatalf("masked update should preserve stored secret, got %#v", got)
+	}
+	if got := storedHeaders["X-Trace"]; got != "changed" {
+		t.Fatalf("plain header should update, got %#v", got)
+	}
+	if rec.Enabled {
+		t.Fatal("enabled should update to false")
+	}
+
+	deleteReq := mcpAuthRequest(t, ctx, resolver, http.MethodDelete, "/api/agents/"+agentID+"/mcp/github", owner.ID, "")
+	deleteReq.SetPathValue("id", agentID)
+	deleteReq.SetPathValue("name", "github")
+	deleteRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleDeleteAgentMCPServer)(deleteRR, deleteReq)
+	if deleteRR.Code != http.StatusOK {
+		t.Fatalf("delete status = %d, body=%s", deleteRR.Code, deleteRR.Body.String())
+	}
+	if len(invalidator.agents) != 3 || invalidator.agents[2] != agentID {
+		t.Fatalf("delete should invalidate %s, got %#v", agentID, invalidator.agents)
+	}
+	if rec, err := s.dataStore.GetConfigByName(ctx, store.KindMCP, "", agentID, "github"); err == nil && rec != nil {
+		t.Fatalf("MCP config should be deleted: %#v", rec)
+	}
+}
+
+func TestAgentMCPServersRejectDuplicateCreate(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, _, owner := newAuthTestServer(t, ctx)
+	agentID := createMCPTestAgent(t, ctx, s.dataStore, owner.ID)
+	body := `{"name":"github","type":"http","url":"https://example.com/mcp"}`
+
+	createReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp", owner.ID, body)
+	createReq.SetPathValue("id", agentID)
+	createRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleCreateAgentMCPServer)(createRR, createReq)
+	if createRR.Code != http.StatusOK {
+		t.Fatalf("initial create status = %d, body=%s", createRR.Code, createRR.Body.String())
+	}
+
+	dupReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp", owner.ID, body)
+	dupReq.SetPathValue("id", agentID)
+	dupRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleCreateAgentMCPServer)(dupRR, dupReq)
+	if dupRR.Code != http.StatusConflict {
+		t.Fatalf("duplicate create status = %d, want 409, body=%s", dupRR.Code, dupRR.Body.String())
+	}
+}
+
+func TestAgentMCPServersListMasksSecretStdioEnvOnly(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, _, owner := newAuthTestServer(t, ctx)
+	agentID := createMCPTestAgent(t, ctx, s.dataStore, owner.ID)
+	body := `{"name":"local","type":"stdio","command":"mcp-server","env":{"API_TOKEN":"super-secret-token","LOG_LEVEL":"debug"}}`
+
+	createReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp", owner.ID, body)
+	createReq.SetPathValue("id", agentID)
+	createRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleCreateAgentMCPServer)(createRR, createReq)
+	if createRR.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body=%s", createRR.Code, createRR.Body.String())
+	}
+
+	listReq := mcpAuthRequest(t, ctx, resolver, http.MethodGet, "/api/agents/"+agentID+"/mcp", owner.ID, "")
+	listReq.SetPathValue("id", agentID)
+	listRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleListAgentMCPServers)(listRR, listReq)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body=%s", listRR.Code, listRR.Body.String())
+	}
+	var listResp struct {
+		Servers []agentMCPServerOut `json:"servers"`
+	}
+	if err := json.Unmarshal(listRR.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listResp.Servers) != 1 {
+		t.Fatalf("want 1 server, got %#v", listResp.Servers)
+	}
+	if got := listResp.Servers[0].Env["API_TOKEN"]; got == "super-secret-token" || got == "" {
+		t.Fatalf("secret env should be masked, got %q", got)
+	}
+	if got := listResp.Servers[0].Env["LOG_LEVEL"]; got != "debug" {
+		t.Fatalf("non-secret env should remain visible, got %q", got)
+	}
+}
+
+func TestAgentMCPServersRejectInvalidCreate(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, _, owner := newAuthTestServer(t, ctx)
+	agentID := createMCPTestAgent(t, ctx, s.dataStore, owner.ID)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "bad name", body: `{"name":"bad-name","type":"http","url":"https://example.com/mcp"}`},
+		{name: "bad type", body: `{"name":"demo","type":"websocket","url":"https://example.com/mcp"}`},
+		{name: "http missing url", body: `{"name":"demo","type":"http"}`},
+		{name: "http bad scheme", body: `{"name":"demo","type":"http","url":"file:///tmp/mcp"}`},
+		{name: "http env expansion header", body: `{"name":"demo","type":"http","url":"https://example.com/mcp","headers":{"X-Leak":"$DATABASE_URL"}}`},
+		{name: "stdio missing command", body: `{"name":"demo","type":"stdio"}`},
+		{name: "stdio env expansion", body: `{"name":"demo","type":"stdio","command":"mcp-server","env":{"API_TOKEN":"$SECRET_TOKEN"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp", owner.ID, tc.body)
+			req.SetPathValue("id", agentID)
+			rr := httptest.NewRecorder()
+			s.authMiddleware(s.handleCreateAgentMCPServer)(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400, body=%s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestAgentMCPServersRejectHostedPrivateHTTPURL(t *testing.T) {
+	t.Setenv("FASTCLAW_DEPLOY", "hosted")
+	ctx := context.Background()
+	s, resolver, _, owner := newAuthTestServer(t, ctx)
+	agentID := createMCPTestAgent(t, ctx, s.dataStore, owner.ID)
+
+	for _, body := range []string{
+		`{"name":"loopback","type":"http","url":"http://127.0.0.1:8080/mcp"}`,
+		`{"name":"localhost","type":"http","url":"http://localhost:8080/mcp"}`,
+		`{"name":"private","type":"http","url":"http://10.0.0.1/mcp"}`,
+		`{"name":"metadata","type":"http","url":"http://169.254.169.254/latest/meta-data"}`,
+	} {
+		req := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp", owner.ID, body)
+		req.SetPathValue("id", agentID)
+		rr := httptest.NewRecorder()
+		s.authMiddleware(s.handleCreateAgentMCPServer)(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400, body=%s", rr.Code, rr.Body.String())
+		}
+	}
+}
+
+func TestAgentMCPServersNonOwnerForbidden(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, _, owner := newAuthTestServer(t, ctx)
+	accts, err := users.NewAccounts(s.dataStore)
+	if err != nil {
+		t.Fatalf("NewAccounts: %v", err)
+	}
+	other := createAuthTestUser(t, ctx, accts, "other", users.RoleUser)
+	agentID := createMCPTestAgent(t, ctx, s.dataStore, owner.ID)
+
+	ownerBody := `{"name":"github","type":"http","url":"https://example.com/mcp"}`
+	ownerReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/agents/"+agentID+"/mcp", owner.ID, ownerBody)
+	ownerReq.SetPathValue("id", agentID)
+	ownerRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleCreateAgentMCPServer)(ownerRR, ownerReq)
+	if ownerRR.Code != http.StatusOK {
+		t.Fatalf("owner create status = %d, body=%s", ownerRR.Code, ownerRR.Body.String())
+	}
+
+	cases := []struct {
+		name    string
+		method  string
+		path    string
+		mcpName string
+		body    string
+		handler http.HandlerFunc
+	}{
+		{name: "list", method: http.MethodGet, path: "/api/agents/" + agentID + "/mcp", handler: s.handleListAgentMCPServers},
+		{name: "create", method: http.MethodPost, path: "/api/agents/" + agentID + "/mcp", body: `{"name":"other","type":"http","url":"https://example.com/mcp"}`, handler: s.handleCreateAgentMCPServer},
+		{name: "update", method: http.MethodPut, path: "/api/agents/" + agentID + "/mcp/github", mcpName: "github", body: ownerBody, handler: s.handleUpdateAgentMCPServer},
+		{name: "delete", method: http.MethodDelete, path: "/api/agents/" + agentID + "/mcp/github", mcpName: "github", handler: s.handleDeleteAgentMCPServer},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpAuthRequest(t, ctx, resolver, tc.method, tc.path, other.ID, tc.body)
+			req.SetPathValue("id", agentID)
+			if tc.mcpName != "" {
+				req.SetPathValue("name", tc.mcpName)
+			}
+			rr := httptest.NewRecorder()
+			s.authMiddleware(tc.handler)(rr, req)
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403, body=%s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestSystemMCPServersCRUDBySuperAdmin(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, admin, _ := newAuthTestServer(t, ctx)
+	invalidator := &mcpTestResolver{}
+	s.SetUserResolver(invalidator)
+
+	createBody := `{"name":"shared","type":"http","enabled":true,"url":"https://sys.example/mcp","headers":{"Authorization":"Bearer secret","X-Trace":"visible"}}`
+	createReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/admin/mcp", admin.ID, createBody)
+	createRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleCreateSystemMCPServer)(createRR, createReq)
+	if createRR.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body=%s", createRR.Code, createRR.Body.String())
+	}
+	if invalidator.reloads != 1 {
+		t.Fatalf("create should trigger ReloadAgents once, got %d", invalidator.reloads)
+	}
+
+	listReq := mcpAuthRequest(t, ctx, resolver, http.MethodGet, "/api/admin/mcp", admin.ID, "")
+	listRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleListSystemMCPServers)(listRR, listReq)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body=%s", listRR.Code, listRR.Body.String())
+	}
+	var listResp struct {
+		Servers []agentMCPServerOut `json:"servers"`
+	}
+	if err := json.Unmarshal(listRR.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listResp.Servers) != 1 {
+		t.Fatalf("want 1 system server, got %#v", listResp.Servers)
+	}
+	if got := listResp.Servers[0].Headers["Authorization"]; got == "Bearer secret" || got == "" {
+		t.Fatalf("Authorization header should be masked, got %q", got)
+	}
+
+	updateBody := `{"name":"shared","type":"http","url":"https://sys.example/mcp2","headers":{"Authorization":"****","X-Trace":"changed"}}`
+	updateReq := mcpAuthRequest(t, ctx, resolver, http.MethodPut, "/api/admin/mcp/shared", admin.ID, updateBody)
+	updateReq.SetPathValue("name", "shared")
+	updateRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleUpdateSystemMCPServer)(updateRR, updateReq)
+	if updateRR.Code != http.StatusOK {
+		t.Fatalf("update status = %d, body=%s", updateRR.Code, updateRR.Body.String())
+	}
+	rec, err := s.dataStore.GetConfigByName(ctx, store.KindMCP, "", "", "shared")
+	if err != nil || rec == nil {
+		t.Fatalf("read system MCP config: %v", err)
+	}
+	storedHeaders, _ := rec.Data["headers"].(map[string]any)
+	if got := storedHeaders["Authorization"]; got != "Bearer secret" {
+		t.Fatalf("masked update should preserve stored secret, got %#v", got)
+	}
+	if got := storedHeaders["X-Trace"]; got != "changed" {
+		t.Fatalf("plain header should update, got %#v", got)
+	}
+
+	deleteReq := mcpAuthRequest(t, ctx, resolver, http.MethodDelete, "/api/admin/mcp/shared", admin.ID, "")
+	deleteReq.SetPathValue("name", "shared")
+	deleteRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleDeleteSystemMCPServer)(deleteRR, deleteReq)
+	if deleteRR.Code != http.StatusOK {
+		t.Fatalf("delete status = %d, body=%s", deleteRR.Code, deleteRR.Body.String())
+	}
+	if invalidator.reloads != 3 {
+		t.Fatalf("create+update+delete should trigger ReloadAgents 3 times, got %d", invalidator.reloads)
+	}
+}
+
+func TestSystemMCPServersNonAdminReadAllowedWriteForbidden(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, admin, regular := newAuthTestServer(t, ctx)
+	s.SetUserResolver(&mcpTestResolver{})
+
+	// Seed one row as super_admin so the read has something to return.
+	seedReq := mcpAuthRequest(t, ctx, resolver, http.MethodPost, "/api/admin/mcp", admin.ID, `{"name":"shared","type":"http","url":"https://sys.example/mcp"}`)
+	seedRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleCreateSystemMCPServer)(seedRR, seedReq)
+	if seedRR.Code != http.StatusOK {
+		t.Fatalf("seed status = %d, body=%s", seedRR.Code, seedRR.Body.String())
+	}
+
+	// Regular user can read system scope.
+	readReq := mcpAuthRequest(t, ctx, resolver, http.MethodGet, "/api/admin/mcp", regular.ID, "")
+	readRR := httptest.NewRecorder()
+	s.authMiddleware(s.handleListSystemMCPServers)(readRR, readReq)
+	if readRR.Code != http.StatusOK {
+		t.Fatalf("non-admin read status = %d, want 200, body=%s", readRR.Code, readRR.Body.String())
+	}
+
+	// Regular user cannot mutate system scope.
+	writeCases := []struct {
+		name    string
+		method  string
+		path    string
+		mcpName string
+		body    string
+		handler http.HandlerFunc
+	}{
+		{name: "create", method: http.MethodPost, path: "/api/admin/mcp", body: `{"name":"x","type":"http","url":"https://sys.example/mcp"}`, handler: s.handleCreateSystemMCPServer},
+		{name: "update", method: http.MethodPut, path: "/api/admin/mcp/shared", mcpName: "shared", body: `{"name":"shared","type":"http","url":"https://sys.example/mcp"}`, handler: s.handleUpdateSystemMCPServer},
+		{name: "delete", method: http.MethodDelete, path: "/api/admin/mcp/shared", mcpName: "shared", handler: s.handleDeleteSystemMCPServer},
+	}
+	for _, tc := range writeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpAuthRequest(t, ctx, resolver, tc.method, tc.path, regular.ID, tc.body)
+			if tc.mcpName != "" {
+				req.SetPathValue("name", tc.mcpName)
+			}
+			rr := httptest.NewRecorder()
+			s.authMiddleware(tc.handler)(rr, req)
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403, body=%s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func createMCPTestAgent(t *testing.T, ctx context.Context, st store.Store, userID string) string {
+	t.Helper()
+	agentID := "agt_mcp_test"
+	if err := st.SaveAgent(ctx, &store.AgentRecord{ID: agentID, UserID: userID, Name: "MCP Test"}); err != nil {
+		t.Fatalf("SaveAgent: %v", err)
+	}
+	return agentID
+}
+
+func mcpAuthRequest(t *testing.T, ctx context.Context, resolver interface {
+	IssueSession(context.Context, string) (*http.Cookie, error)
+}, method, path, userID, body string) *http.Request {
+	t.Helper()
+	reader := bytes.NewReader([]byte(body))
+	cookie, err := resolver.IssueSession(ctx, userID)
+	if err != nil {
+		t.Fatalf("IssueSession: %v", err)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.AddCookie(cookie)
+	return req
+}
+
+type mcpTestResolver struct {
+	agents  []string
+	reloads int
+}
+
+func (r *mcpTestResolver) UserSpaceFor(string) (*api.UserSpaceView, error) { return nil, nil }
+func (r *mcpTestResolver) LocalAgentManager() *agent.Manager               { return nil }
+func (r *mcpTestResolver) IsCloudMode() bool                               { return false }
+func (r *mcpTestResolver) InvalidateAgent(agentID string) {
+	r.agents = append(r.agents, agentID)
+}
+func (r *mcpTestResolver) ReloadAgents() error {
+	r.reloads++
+	return nil
+}

--- a/internal/setup/server.go
+++ b/internal/setup/server.go
@@ -309,6 +309,19 @@ func (s *Server) Run(ctx context.Context) error {
 	// running app) — lets the workspace tree show only this task's output.
 	mux.HandleFunc("GET /api/agents/{id}/changed-files", auth(s.handleChangedFiles))
 	mux.HandleFunc("GET /api/agents/{id}/projects/{pid}/runtime/logs", auth(s.handleRuntimeLogs))
+	// Per-agent MCP servers
+	mux.HandleFunc("GET /api/agents/{id}/mcp", auth(s.handleListAgentMCPServers))
+	mux.HandleFunc("POST /api/agents/{id}/mcp", auth(s.handleCreateAgentMCPServer))
+	mux.HandleFunc("PUT /api/agents/{id}/mcp/{name}", auth(s.handleUpdateAgentMCPServer))
+	mux.HandleFunc("DELETE /api/agents/{id}/mcp/{name}", auth(s.handleDeleteAgentMCPServer))
+
+	// System (global) MCP servers — inherited by every agent. Reads are
+	// open to any signed-in user (authorizeScope gates inside); writes are
+	// super_admin-only, enforced in the handler via authorizeScope.
+	mux.HandleFunc("GET /api/admin/mcp", auth(s.handleListSystemMCPServers))
+	mux.HandleFunc("POST /api/admin/mcp", auth(s.handleCreateSystemMCPServer))
+	mux.HandleFunc("PUT /api/admin/mcp/{name}", auth(s.handleUpdateSystemMCPServer))
+	mux.HandleFunc("DELETE /api/admin/mcp/{name}", auth(s.handleDeleteSystemMCPServer))
 
 	// Per-agent channels (IM bot bindings)
 	mux.HandleFunc("GET /api/agents/{id}/channels", auth(s.handleListAgentChannels))

--- a/internal/setup/server.go
+++ b/internal/setup/server.go
@@ -312,6 +312,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// Per-agent MCP servers
 	mux.HandleFunc("GET /api/agents/{id}/mcp", auth(s.handleListAgentMCPServers))
 	mux.HandleFunc("POST /api/agents/{id}/mcp", auth(s.handleCreateAgentMCPServer))
+	mux.HandleFunc("POST /api/agents/{id}/mcp/test", auth(s.handleTestAgentMCPServer))
 	mux.HandleFunc("PUT /api/agents/{id}/mcp/{name}", auth(s.handleUpdateAgentMCPServer))
 	mux.HandleFunc("DELETE /api/agents/{id}/mcp/{name}", auth(s.handleDeleteAgentMCPServer))
 
@@ -320,6 +321,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// super_admin-only, enforced in the handler via authorizeScope.
 	mux.HandleFunc("GET /api/admin/mcp", auth(s.handleListSystemMCPServers))
 	mux.HandleFunc("POST /api/admin/mcp", auth(s.handleCreateSystemMCPServer))
+	mux.HandleFunc("POST /api/admin/mcp/test", auth(s.handleTestSystemMCPServer))
 	mux.HandleFunc("PUT /api/admin/mcp/{name}", auth(s.handleUpdateSystemMCPServer))
 	mux.HandleFunc("DELETE /api/admin/mcp/{name}", auth(s.handleDeleteSystemMCPServer))
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -495,6 +495,7 @@ const (
 	KindProvider = "provider"
 	KindChannel  = "channel"
 	KindSetting  = "setting"
+	KindMCP      = "mcp"
 )
 
 // ConfigRecord is one row of the configs table — the unified

--- a/web/src/app/admin/mcp/page.tsx
+++ b/web/src/app/admin/mcp/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { MCPManager } from "@/components/mcp-manager";
+import {
+  createSystemMCPServer,
+  deleteSystemMCPServer,
+  listSystemMCPServers,
+  updateSystemMCPServer,
+} from "@/lib/api";
+
+export default function AdminMCPPage() {
+  return (
+    <MCPManager
+      scopeLabel="all agents (system-wide)"
+      scopeNote="System MCP servers are inherited by every agent. An agent can override one by configuring a server of the same name."
+      list={listSystemMCPServers}
+      create={createSystemMCPServer}
+      update={updateSystemMCPServer}
+      remove={deleteSystemMCPServer}
+    />
+  );
+}

--- a/web/src/app/admin/mcp/page.tsx
+++ b/web/src/app/admin/mcp/page.tsx
@@ -5,6 +5,7 @@ import {
   createSystemMCPServer,
   deleteSystemMCPServer,
   listSystemMCPServers,
+  testSystemMCPServer,
   updateSystemMCPServer,
 } from "@/lib/api";
 
@@ -17,6 +18,7 @@ export default function AdminMCPPage() {
       create={createSystemMCPServer}
       update={updateSystemMCPServer}
       remove={deleteSystemMCPServer}
+      test={testSystemMCPServer}
     />
   );
 }

--- a/web/src/app/agents/[id]/mcp/page.tsx
+++ b/web/src/app/agents/[id]/mcp/page.tsx
@@ -7,6 +7,7 @@ import {
   createAgentMCPServer,
   deleteAgentMCPServer,
   listAgentMCPServers,
+  testAgentMCPServer,
   updateAgentMCPServer,
   type MCPServerInput,
 } from "@/lib/api";
@@ -24,6 +25,7 @@ export default function AgentMCPPage() {
       create={(input: MCPServerInput) => createAgentMCPServer(agentId, input)}
       update={(name: string, input: MCPServerInput) => updateAgentMCPServer(agentId, name, input)}
       remove={(name: string) => deleteAgentMCPServer(agentId, name)}
+      test={(input: MCPServerInput) => testAgentMCPServer(agentId, input)}
     />
   );
 }

--- a/web/src/app/agents/[id]/mcp/page.tsx
+++ b/web/src/app/agents/[id]/mcp/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { MCPManager } from "@/components/mcp-manager";
+import { useAgentIdFromURL } from "@/hooks/use-agent-id";
+import { useAgentName } from "@/hooks/use-agent-name";
+import {
+  createAgentMCPServer,
+  deleteAgentMCPServer,
+  listAgentMCPServers,
+  updateAgentMCPServer,
+  type MCPServerInput,
+} from "@/lib/api";
+
+export default function AgentMCPPage() {
+  const agentId = useAgentIdFromURL();
+  const agentName = useAgentName(agentId);
+
+  if (!agentId) return null;
+
+  return (
+    <MCPManager
+      scopeLabel={agentName || "this agent"}
+      list={() => listAgentMCPServers(agentId)}
+      create={(input: MCPServerInput) => createAgentMCPServer(agentId, input)}
+      update={(name: string, input: MCPServerInput) => updateAgentMCPServer(agentId, name, input)}
+      remove={(name: string) => deleteAgentMCPServer(agentId, name)}
+    />
+  );
+}

--- a/web/src/components/agent-settings-dialog.tsx
+++ b/web/src/components/agent-settings-dialog.tsx
@@ -11,6 +11,7 @@ import {
   Palette,
   Plug,
   RadioIcon,
+  ServerIcon,
   SparklesIcon,
   UserCog,
   Wand2Icon,
@@ -25,6 +26,7 @@ import AgentModelsPage from "@/app/agents/[id]/models/page";
 import AgentContextPage from "@/app/agents/[id]/context/page";
 import AgentSkillsPage from "@/app/agents/[id]/skills/page";
 import AgentPluginsPage from "@/app/agents/[id]/plugins/page";
+import AgentMCPPage from "@/app/agents/[id]/mcp/page";
 import AgentChannelsPage from "@/app/agents/[id]/channels/page";
 import AgentSchedulerPage from "@/app/agents/[id]/scheduler/page";
 import AgentUsagePage from "@/app/agents/[id]/usage/page";
@@ -40,6 +42,7 @@ export type AgentSettingsTab =
   | "context"
   | "skills"
   | "plugins"
+  | "mcp"
   | "channels"
   | "scheduler"
   | "usage"
@@ -56,6 +59,7 @@ const AGENT_TABS: Array<{ id: AgentSettingsTab; label: string; icon: TabIcon }> 
   { id: "context", label: "Context", icon: LayersIcon },
   { id: "skills", label: "Skills", icon: SparklesIcon },
   { id: "plugins", label: "Plugins", icon: Plug },
+  { id: "mcp", label: "MCP", icon: ServerIcon },
   { id: "channels", label: "Channels", icon: RadioIcon },
   { id: "scheduler", label: "Scheduler", icon: ClockIcon },
   { id: "usage", label: "Token Usage", icon: CoinsIcon },
@@ -170,6 +174,7 @@ export function AgentSettingsDialog({
           {tab === "context" && <AgentContextPage />}
           {tab === "skills" && <AgentSkillsPage />}
           {tab === "plugins" && <AgentPluginsPage />}
+          {tab === "mcp" && <AgentMCPPage />}
           {tab === "channels" && <AgentChannelsPage />}
           {tab === "scheduler" && <AgentSchedulerPage />}
           {tab === "usage" && <AgentUsagePage />}

--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -26,6 +26,7 @@ import {
   LayoutDashboardIcon,
   MessagesSquareIcon,
   PlusIcon,
+  ServerIcon,
   SettingsIcon,
   SparklesIcon,
   UsersIcon,
@@ -51,7 +52,7 @@ import {
 // the sidebar showing the platform nav for /agents/<id>/project/...
 function extractAgentId(pathname: string): string | null {
   const match = pathname.match(
-    /^\/agents\/([^/]+)\/(chat|customize|skills|models|sessions|channels|chats|scheduler|project)/,
+    /^\/agents\/([^/]+)\/(chat|customize|skills|models|sessions|channels|mcp|chats|scheduler|project)/,
   );
   return match ? match[1] : null;
 }
@@ -94,6 +95,7 @@ const USER_USER_GROUP: NavItem[] = [
 const ADMIN_USER_GROUP: NavItem[] = [
   { title: "Users", url: "/admin/users/", icon: UsersIcon },
   { title: "Chats", url: "/admin/chats/", icon: MessagesSquareIcon },
+  { title: "MCP", url: "/admin/mcp/", icon: ServerIcon },
   { title: "Token Usage", url: "/admin/usage/", icon: CoinsIcon },
   { title: "API Keys", url: "/apikeys/", icon: KeyRoundIcon },
 ];

--- a/web/src/components/mcp-manager.tsx
+++ b/web/src/components/mcp-manager.tsx
@@ -35,7 +35,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import type { MCPServer, MCPServerInput, MCPServerType } from "@/lib/api";
+import type { MCPServer, MCPServerInput, MCPServerType, MCPTestResult } from "@/lib/api";
 
 type Pair = { key: string; value: string };
 
@@ -53,6 +53,7 @@ export interface MCPManagerProps {
   create: (input: MCPServerInput) => Promise<WriteResult>;
   update: (name: string, input: MCPServerInput) => Promise<WriteResult>;
   remove: (name: string) => Promise<WriteResult>;
+  test: (input: MCPServerInput) => Promise<MCPTestResult>;
 }
 
 export function MCPManager({
@@ -63,6 +64,7 @@ export function MCPManager({
   create,
   update,
   remove,
+  test,
 }: MCPManagerProps) {
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [loading, setLoading] = useState(true);
@@ -181,6 +183,7 @@ export function MCPManager({
         server={editing}
         create={create}
         update={update}
+        test={test}
         onSaved={refresh}
       />
 
@@ -268,6 +271,7 @@ function MCPServerDialog({
   server,
   create,
   update,
+  test,
   onSaved,
 }: {
   open: boolean;
@@ -275,6 +279,7 @@ function MCPServerDialog({
   server: MCPServer | null;
   create: (input: MCPServerInput) => Promise<WriteResult>;
   update: (name: string, input: MCPServerInput) => Promise<WriteResult>;
+  test: (input: MCPServerInput) => Promise<MCPTestResult>;
   onSaved: () => void;
 }) {
   const editing = !!server;
@@ -288,6 +293,8 @@ function MCPServerDialog({
   const [env, setEnv] = useState<Pair[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<MCPTestResult | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -301,6 +308,8 @@ function MCPServerDialog({
     setEnv(recordToPairs(server?.env));
     setSaving(false);
     setError("");
+    setTesting(false);
+    setTestResult(null);
   }, [open, server]);
 
   const canSubmit = useMemo(() => {
@@ -309,30 +318,32 @@ function MCPServerDialog({
     return !!command.trim();
   }, [command, name, type, url]);
 
+  const buildInput = (): MCPServerInput =>
+    type === "http"
+      ? {
+          name: name.trim(),
+          type,
+          enabled,
+          url: url.trim(),
+          headers: pairsToRecord(headers),
+        }
+      : {
+          name: name.trim(),
+          type,
+          enabled,
+          command: command.trim(),
+          args: argsText
+            .split("\n")
+            .map((arg) => arg.trim())
+            .filter(Boolean),
+          env: pairsToRecord(env),
+        };
+
   const submit = async () => {
     if (!canSubmit) return;
     setSaving(true);
     setError("");
-    const input: MCPServerInput =
-      type === "http"
-        ? {
-            name: name.trim(),
-            type,
-            enabled,
-            url: url.trim(),
-            headers: pairsToRecord(headers),
-          }
-        : {
-            name: name.trim(),
-            type,
-            enabled,
-            command: command.trim(),
-            args: argsText
-              .split("\n")
-              .map((arg) => arg.trim())
-              .filter(Boolean),
-            env: pairsToRecord(env),
-          };
+    const input = buildInput();
     try {
       const res = server ? await update(server.name, input) : await create(input);
       if (res.error) {
@@ -347,6 +358,22 @@ function MCPServerDialog({
       setSaving(false);
     }
   };
+
+  const runTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      setTestResult(await test(buildInput()));
+    } catch (err) {
+      setTestResult({ ok: false, error: err instanceof Error ? err.message : "Connection test failed" });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  // Connection test only exercises HTTP servers; stdio would spawn a local
+  // process, which the backend refuses for a dashboard dry-run.
+  const canTest = type === "http" && !!url.trim();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -457,13 +484,38 @@ function MCPServerDialog({
           )}
         </div>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
-            Cancel
+        {testResult && (
+          <div
+            className={
+              testResult.ok
+                ? "rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3 text-sm text-emerald-600 dark:text-emerald-400"
+                : "rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive"
+            }
+          >
+            {testResult.ok
+              ? `Connection OK — ${testResult.toolCount ?? 0} tool${testResult.toolCount === 1 ? "" : "s"} available.`
+              : `Connection failed: ${testResult.error || "unknown error"}`}
+          </div>
+        )}
+
+        <DialogFooter className="sm:justify-between">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={runTest}
+            disabled={!canTest || testing || saving}
+            title={type === "stdio" ? "Connection test is only available for HTTP servers" : undefined}
+          >
+            {testing ? "Testing..." : "Test connection"}
           </Button>
-          <Button onClick={submit} disabled={!canSubmit || saving}>
-            {saving ? "Saving..." : "Save"}
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button onClick={submit} disabled={!canSubmit || saving}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/web/src/components/mcp-manager.tsx
+++ b/web/src/components/mcp-manager.tsx
@@ -1,0 +1,547 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { PencilIcon, PlusIcon, ServerIcon, Trash2Icon } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import type { MCPServer, MCPServerInput, MCPServerType } from "@/lib/api";
+
+type Pair = { key: string; value: string };
+
+type WriteResult = { ok: boolean; error?: string };
+
+export interface MCPManagerProps {
+  // Short noun phrase describing who inherits these servers, e.g.
+  // "this agent" or "all agents (system-wide)".
+  scopeLabel: string;
+  // Optional extra note rendered under the intro paragraph.
+  scopeNote?: string;
+  // Whether the caller may mutate. When false, add/edit/delete are hidden.
+  readOnly?: boolean;
+  list: () => Promise<MCPServer[]>;
+  create: (input: MCPServerInput) => Promise<WriteResult>;
+  update: (name: string, input: MCPServerInput) => Promise<WriteResult>;
+  remove: (name: string) => Promise<WriteResult>;
+}
+
+export function MCPManager({
+  scopeLabel,
+  scopeNote,
+  readOnly = false,
+  list,
+  create,
+  update,
+  remove,
+}: MCPManagerProps) {
+  const [servers, setServers] = useState<MCPServer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<MCPServer | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<MCPServer | null>(null);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    setError("");
+    list()
+      .then((servers) => setServers(servers))
+      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load MCP servers"))
+      .finally(() => setLoading(false));
+  }, [list]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const openCreate = () => {
+    setEditing(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (server: MCPServer) => {
+    setEditing(server);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    const target = deleteTarget;
+    setDeleteTarget(null);
+    setError("");
+    try {
+      const res = await remove(target.name);
+      if (res.error) setError(res.error);
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete MCP server");
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <ServerIcon className="size-5 text-muted-foreground" />
+            <h2 className="text-2xl font-semibold tracking-tight">MCP Servers</h2>
+          </div>
+          <p className="text-sm text-muted-foreground mt-1">
+            Add MCP servers to expose external tools to <strong>{scopeLabel}</strong>. Tools appear
+            as <code className="rounded bg-muted px-1 py-0.5">mcp_&lt;server&gt;_&lt;tool&gt;</code>.
+          </p>
+          {scopeNote && <p className="text-sm text-muted-foreground mt-1">{scopeNote}</p>}
+        </div>
+        {!readOnly && (
+          <Button onClick={openCreate}>
+            <PlusIcon className="mr-2 size-4" />
+            Add MCP Server
+          </Button>
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+        HTTP MCP is the safest option for hosted services. stdio MCP starts a local process and is
+        only available on self-hosted deployments.
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <Skeleton className="h-40" />
+          <Skeleton className="h-40" />
+          <Skeleton className="h-40" />
+        </div>
+      ) : servers.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <ServerIcon className="mx-auto size-8 text-muted-foreground" />
+          <h3 className="mt-3 text-base font-medium">No MCP servers configured</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Add an MCP server to make external tools available.
+          </p>
+          {!readOnly && (
+            <Button className="mt-4" onClick={openCreate}>
+              <PlusIcon className="mr-2 size-4" />
+              Add MCP Server
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {servers.map((server) => (
+            <ServerCard
+              key={server.name}
+              server={server}
+              readOnly={readOnly}
+              onEdit={() => openEdit(server)}
+              onDelete={() => setDeleteTarget(server)}
+            />
+          ))}
+        </div>
+      )}
+
+      <MCPServerDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        server={editing}
+        create={create}
+        update={update}
+        onSaved={refresh}
+      />
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete MCP server?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes <strong>{deleteTarget?.name}</strong>. Existing chats will lose access to
+              tools provided by that server after the agent reloads.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDelete}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function ServerCard({
+  server,
+  readOnly,
+  onEdit,
+  onDelete,
+}: {
+  server: MCPServer;
+  readOnly: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const detail =
+    server.type === "http" ? server.url : [server.command, ...(server.args || [])].join(" ");
+
+  return (
+    <div className="rounded-lg border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate font-medium">{server.name}</h3>
+            <Badge variant="secondary">{server.type}</Badge>
+          </div>
+          <Badge className="mt-2" variant={server.enabled ? "default" : "outline"}>
+            {server.enabled ? "Enabled" : "Disabled"}
+          </Badge>
+        </div>
+        {!readOnly && (
+          <div className="flex gap-1">
+            <Button variant="ghost" size="icon" onClick={onEdit} aria-label={`Edit ${server.name}`}>
+              <PencilIcon className="size-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onDelete}
+              aria-label={`Delete ${server.name}`}
+            >
+              <Trash2Icon className="size-4 text-destructive" />
+            </Button>
+          </div>
+        )}
+      </div>
+      <p className="mt-4 line-clamp-2 break-all text-sm text-muted-foreground">
+        {detail || "No connection details"}
+      </p>
+      {server.updatedAt && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          Updated {new Date(server.updatedAt).toLocaleString()}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function MCPServerDialog({
+  open,
+  onOpenChange,
+  server,
+  create,
+  update,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  server: MCPServer | null;
+  create: (input: MCPServerInput) => Promise<WriteResult>;
+  update: (name: string, input: MCPServerInput) => Promise<WriteResult>;
+  onSaved: () => void;
+}) {
+  const editing = !!server;
+  const [name, setName] = useState("");
+  const [type, setType] = useState<MCPServerType>("http");
+  const [enabled, setEnabled] = useState(true);
+  const [url, setURL] = useState("");
+  const [command, setCommand] = useState("");
+  const [argsText, setArgsText] = useState("");
+  const [headers, setHeaders] = useState<Pair[]>([]);
+  const [env, setEnv] = useState<Pair[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setName(server?.name || "");
+    setType(server?.type || "http");
+    setEnabled(server?.enabled ?? true);
+    setURL(server?.url || "");
+    setCommand(server?.command || "");
+    setArgsText((server?.args || []).join("\n"));
+    setHeaders(recordToPairs(server?.headers));
+    setEnv(recordToPairs(server?.env));
+    setSaving(false);
+    setError("");
+  }, [open, server]);
+
+  const canSubmit = useMemo(() => {
+    if (!name.trim()) return false;
+    if (type === "http") return !!url.trim();
+    return !!command.trim();
+  }, [command, name, type, url]);
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setSaving(true);
+    setError("");
+    const input: MCPServerInput =
+      type === "http"
+        ? {
+            name: name.trim(),
+            type,
+            enabled,
+            url: url.trim(),
+            headers: pairsToRecord(headers),
+          }
+        : {
+            name: name.trim(),
+            type,
+            enabled,
+            command: command.trim(),
+            args: argsText
+              .split("\n")
+              .map((arg) => arg.trim())
+              .filter(Boolean),
+            env: pairsToRecord(env),
+          };
+    try {
+      const res = server ? await update(server.name, input) : await create(input);
+      if (res.error) {
+        setError(res.error);
+        return;
+      }
+      onOpenChange(false);
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save MCP server");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit MCP server" : "Add MCP server"}</DialogTitle>
+          <DialogDescription>
+            Configure an MCP server. Secret-looking values are masked when loaded and preserved if
+            saved unchanged.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {error && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="mcp-name">Name</Label>
+              <Input
+                id="mcp-name"
+                value={name}
+                disabled={editing}
+                placeholder="github"
+                onChange={(e) => setName(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Letters, numbers, and underscore only.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label>Type</Label>
+              <Select
+                value={type}
+                onValueChange={(value) => setType(value as MCPServerType)}
+                disabled={editing}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="http">HTTP</SelectItem>
+                  <SelectItem value="stdio">stdio</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border p-3">
+            <div>
+              <Label>Enabled</Label>
+              <p className="text-xs text-muted-foreground">
+                Disabled servers stay saved but are not loaded.
+              </p>
+            </div>
+            <Switch checked={enabled} onCheckedChange={setEnabled} />
+          </div>
+
+          {type === "http" ? (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="mcp-url">URL</Label>
+                <Input
+                  id="mcp-url"
+                  value={url}
+                  placeholder="https://example.com/mcp"
+                  onChange={(e) => setURL(e.target.value)}
+                />
+              </div>
+              <PairEditor
+                label="Headers"
+                pairs={headers}
+                onChange={setHeaders}
+                secretPlaceholder="Authorization"
+              />
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="mcp-command">Command</Label>
+                <Input
+                  id="mcp-command"
+                  value={command}
+                  placeholder="npx"
+                  onChange={(e) => setCommand(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="mcp-args">Args</Label>
+                <Textarea
+                  id="mcp-args"
+                  value={argsText}
+                  placeholder={"-y\n@modelcontextprotocol/server-filesystem\n/workspace"}
+                  onChange={(e) => setArgsText(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">One argument per line.</p>
+              </div>
+              <PairEditor
+                label="Environment"
+                pairs={env}
+                onChange={setEnv}
+                secretPlaceholder="API_TOKEN"
+              />
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={!canSubmit || saving}>
+            {saving ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PairEditor({
+  label,
+  pairs,
+  onChange,
+  secretPlaceholder,
+}: {
+  label: string;
+  pairs: Pair[];
+  onChange: (pairs: Pair[]) => void;
+  secretPlaceholder: string;
+}) {
+  const setPair = (index: number, patch: Partial<Pair>) => {
+    onChange(pairs.map((pair, i) => (i === index ? { ...pair, ...patch } : pair)));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label>{label}</Label>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => onChange([...pairs, { key: "", value: "" }])}
+        >
+          Add
+        </Button>
+      </div>
+      {pairs.length === 0 ? (
+        <p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+          No {label.toLowerCase()} configured.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {pairs.map((pair, index) => (
+            <div key={index} className="grid grid-cols-[1fr_1fr_auto] gap-2">
+              <Input
+                value={pair.key}
+                placeholder={secretPlaceholder}
+                onChange={(e) => setPair(index, { key: e.target.value })}
+              />
+              <Input
+                value={pair.value}
+                placeholder="value"
+                onChange={(e) => setPair(index, { value: e.target.value })}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => onChange(pairs.filter((_, i) => i !== index))}
+              >
+                <Trash2Icon className="size-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function recordToPairs(record?: Record<string, string>): Pair[] {
+  return Object.entries(record || {}).map(([key, value]) => ({ key, value }));
+}
+
+function pairsToRecord(pairs: Pair[]): Record<string, string> | undefined {
+  const out: Record<string, string> = {};
+  for (const pair of pairs) {
+    const key = pair.key.trim();
+    if (!key) continue;
+    out[key] = pair.value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1734,6 +1734,120 @@ export async function toggleAgentCronJob(
   return res.json();
 }
 
+export type MCPServerType = "http" | "stdio";
+
+export interface AgentMCPServer {
+  name: string;
+  type: MCPServerType;
+  enabled: boolean;
+  url?: string;
+  headers?: Record<string, string>;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  updatedAt?: string;
+}
+
+export interface AgentMCPServerInput {
+  name: string;
+  type: MCPServerType;
+  enabled?: boolean;
+  url?: string;
+  headers?: Record<string, string>;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export async function listAgentMCPServers(agentId: string): Promise<AgentMCPServer[]> {
+  const res = await apiFetch(`/api/agents/${encodeURIComponent(agentId)}/mcp`);
+  if (!res.ok) throw new Error(await readError(res, "load MCP servers failed"));
+  const data = await res.json();
+  return data.servers || [];
+}
+
+export async function createAgentMCPServer(
+  agentId: string,
+  input: AgentMCPServerInput,
+): Promise<{ ok: boolean; server?: AgentMCPServer; error?: string }> {
+  const res = await apiFetch(`/api/agents/${encodeURIComponent(agentId)}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return res.json();
+}
+
+export async function updateAgentMCPServer(
+  agentId: string,
+  name: string,
+  input: AgentMCPServerInput,
+): Promise<{ ok: boolean; server?: AgentMCPServer; error?: string }> {
+  const res = await apiFetch(
+    `/api/agents/${encodeURIComponent(agentId)}/mcp/${encodeURIComponent(name)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    },
+  );
+  return res.json();
+}
+
+export async function deleteAgentMCPServer(
+  agentId: string,
+  name: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const res = await apiFetch(
+    `/api/agents/${encodeURIComponent(agentId)}/mcp/${encodeURIComponent(name)}`,
+    { method: "DELETE" },
+  );
+  return res.json();
+}
+
+// Scope-neutral aliases shared by the per-agent and system MCP managers.
+export type MCPServer = AgentMCPServer;
+export type MCPServerInput = AgentMCPServerInput;
+
+export async function listSystemMCPServers(): Promise<MCPServer[]> {
+  const res = await apiFetch(`/api/admin/mcp`);
+  if (!res.ok) throw new Error(await readError(res, "load system MCP servers failed"));
+  const data = await res.json();
+  return data.servers || [];
+}
+
+export async function createSystemMCPServer(
+  input: MCPServerInput,
+): Promise<{ ok: boolean; server?: MCPServer; error?: string }> {
+  const res = await apiFetch(`/api/admin/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return res.json();
+}
+
+export async function updateSystemMCPServer(
+  name: string,
+  input: MCPServerInput,
+): Promise<{ ok: boolean; server?: MCPServer; error?: string }> {
+  const res = await apiFetch(`/api/admin/mcp/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return res.json();
+}
+
+export async function deleteSystemMCPServer(
+  name: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const res = await apiFetch(`/api/admin/mcp/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
+  return res.json();
+}
+
 export async function listAgentChannels(agentId: string): Promise<AgentChannel[]> {
   const res = await apiFetch(`/api/agents/${agentId}/channels`);
   if (!res.ok) return [];

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1805,6 +1805,24 @@ export async function deleteAgentMCPServer(
   return res.json();
 }
 
+export interface MCPTestResult {
+  ok: boolean;
+  toolCount?: number;
+  error?: string;
+}
+
+export async function testAgentMCPServer(
+  agentId: string,
+  input: AgentMCPServerInput,
+): Promise<MCPTestResult> {
+  const res = await apiFetch(`/api/agents/${encodeURIComponent(agentId)}/mcp/test`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return res.json();
+}
+
 // Scope-neutral aliases shared by the per-agent and system MCP managers.
 export type MCPServer = AgentMCPServer;
 export type MCPServerInput = AgentMCPServerInput;
@@ -1844,6 +1862,15 @@ export async function deleteSystemMCPServer(
 ): Promise<{ ok: boolean; error?: string }> {
   const res = await apiFetch(`/api/admin/mcp/${encodeURIComponent(name)}`, {
     method: "DELETE",
+  });
+  return res.json();
+}
+
+export async function testSystemMCPServer(input: MCPServerInput): Promise<MCPTestResult> {
+  const res = await apiFetch(`/api/admin/mcp/test`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
   });
   return res.json();
 }


### PR DESCRIPTION
- Add global and agent MCP configuration management pages
- Add support for connection testing during addition, while maintaining existing MCP override and activation rules.

Co-Authored-By: Claude Opus 4.6 (1M context) 