### PR TITLE
[codex] fix MiniMax Anthropic tool history replay

### DIFF
--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -52,9 +52,17 @@ type anthropicRequest struct {
 	Tools     []anthropicTool    `json:"tools,omitempty"`
 }
 
-// toAnthropicMessages converts provider Messages to Anthropic wire format.
-// Extracts the system message and returns the rest.
 func toAnthropicMessages(msgs []Message) (string, []anthropicMessage) {
+	return toAnthropicMessagesCompat(msgs, false)
+}
+
+// toAnthropicMessagesCompat converts provider Messages to Anthropic wire format.
+// Extracts the system message and returns the rest.
+func toAnthropicMessagesCompat(msgs []Message, flattenToolHistory bool) (string, []anthropicMessage) {
+	if flattenToolHistory {
+		msgs = flattenToolHistoryForText(msgs)
+	}
+
 	var system string
 	var out []anthropicMessage
 
@@ -246,6 +254,66 @@ func toAnthropicMessages(msgs []Message) (string, []anthropicMessage) {
 	return system, out
 }
 
+func flattenToolHistoryForText(msgs []Message) []Message {
+	out := make([]Message, 0, len(msgs))
+	appendMsg := func(m Message) {
+		if m.Role != "system" && m.Content != "" && len(m.ContentParts) == 0 && len(out) > 0 {
+			last := &out[len(out)-1]
+			if last.Role == m.Role && last.Content != "" && len(last.ContentParts) == 0 {
+				last.Content = strings.TrimSpace(last.Content) + "\n\n" + strings.TrimSpace(m.Content)
+				return
+			}
+		}
+		out = append(out, m)
+	}
+
+	for _, m := range msgs {
+		switch m.Role {
+		case "assistant":
+			if len(m.ToolCalls) > 0 {
+				appendMsg(Message{Role: "assistant", Content: flattenAssistantToolCallsText(m)})
+				continue
+			}
+		case "tool":
+			appendMsg(Message{Role: "assistant", Content: flattenToolResultText(m)})
+			continue
+		}
+		appendMsg(m)
+	}
+	return out
+}
+
+func flattenAssistantToolCallsText(m Message) string {
+	var b strings.Builder
+	if strings.TrimSpace(m.Content) != "" {
+		b.WriteString(strings.TrimSpace(m.Content))
+	}
+	for _, tc := range m.ToolCalls {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		fmt.Fprintf(&b, "Tool call: %s", tc.Function.Name)
+		if strings.TrimSpace(tc.Function.Arguments) != "" {
+			fmt.Fprintf(&b, "\nArguments: %s", strings.TrimSpace(tc.Function.Arguments))
+		}
+	}
+	return b.String()
+}
+
+func flattenToolResultText(m Message) string {
+	label := strings.TrimSpace(m.Name)
+	if label == "" {
+		label = strings.TrimSpace(m.ToolCallID)
+	}
+	if label == "" {
+		label = "tool"
+	}
+	if strings.TrimSpace(m.Content) == "" {
+		return "Tool result: " + label
+	}
+	return "Tool result: " + label + "\n" + strings.TrimSpace(m.Content)
+}
+
 // parseToolInput decodes a stored tool_use Arguments string into the
 // JSON object Anthropic's wire format requires. Anything that isn't
 // an object — empty string, null, JSON array, bare value — gets
@@ -303,7 +371,7 @@ func thinkingBlockFor(m Message) map[string]interface{} {
 }
 
 func (p *AnthropicProvider) buildRequest(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64, stream bool) (*http.Request, error) {
-	system, anthropicMsgs := toAnthropicMessages(messages)
+	system, anthropicMsgs := toAnthropicMessagesCompat(messages, p.flattenToolHistoryForCompat(model))
 
 	if maxTokens <= 0 {
 		maxTokens = 4096
@@ -348,6 +416,14 @@ func (p *AnthropicProvider) buildRequest(ctx context.Context, messages []Message
 	httpReq.Header.Set("x-api-key", p.apiKey)
 	httpReq.Header.Set("anthropic-version", "2023-06-01")
 	return httpReq, nil
+}
+
+func (p *AnthropicProvider) flattenToolHistoryForCompat(model string) bool {
+	base := strings.ToLower(p.apiBase)
+	mdl := strings.ToLower(model)
+	return strings.Contains(base, "minimax") ||
+		strings.Contains(base, "minimaxi") ||
+		strings.Contains(mdl, "minimax")
 }
 
 // Anthropic SSE event types

--- a/internal/provider/anthropic_orphan_test.go
+++ b/internal/provider/anthropic_orphan_test.go
@@ -153,6 +153,77 @@ func TestToAnthropicMessagesOrphanAssistantRawOnly(t *testing.T) {
 	}
 }
 
+func TestToAnthropicMessagesMiniMaxCompatFlattensToolHistory(t *testing.T) {
+	msgs := []Message{
+		{Role: "system", Content: "You are concise."},
+		{Role: "user", Content: "what os"},
+		{
+			Role:    "assistant",
+			Content: "I will check.",
+			ToolCalls: []ToolCall{{
+				ID:       "t1",
+				Type:     "function",
+				Function: FunctionCall{Name: "exec", Arguments: `{"command":"cat /etc/os-release"}`},
+			}},
+		},
+		{Role: "tool", ToolCallID: "t1", Content: "Debian 12"},
+		{Role: "assistant", Content: "It is Debian 12."},
+		{Role: "user", Content: "continue"},
+	}
+
+	_, out := toAnthropicMessagesCompat(msgs, true)
+
+	if len(out) != 3 {
+		t.Fatalf("expected flattened alternating history, got %d messages: %+v", len(out), out)
+	}
+	if out[0].Role != "user" || out[1].Role != "assistant" || out[2].Role != "user" {
+		t.Fatalf("unexpected role sequence: %s, %s, %s", out[0].Role, out[1].Role, out[2].Role)
+	}
+
+	for _, am := range out {
+		var blocks []any
+		if json.Unmarshal(am.Content, &blocks) == nil {
+			for _, b := range blocks {
+				mp, ok := b.(map[string]any)
+				if !ok {
+					continue
+				}
+				if bt, _ := mp["type"].(string); bt == "tool_use" || bt == "tool_result" {
+					t.Fatalf("MiniMax compat history must not replay %s blocks: %+v", bt, mp)
+				}
+			}
+		}
+	}
+
+	got := allText(out)
+	if !strings.Contains(got, "Tool call: exec") {
+		t.Errorf("flattened assistant missing tool call summary: %q", got)
+	}
+	if !strings.Contains(got, "Debian 12") {
+		t.Errorf("flattened assistant missing tool result/final content: %q", got)
+	}
+}
+
+func TestToAnthropicMessagesMiniMaxCompatCoalescesConsecutiveUsers(t *testing.T) {
+	msgs := []Message{
+		{Role: "user", Content: "first failed turn"},
+		{Role: "user", Content: "retry"},
+	}
+
+	_, out := toAnthropicMessagesCompat(msgs, true)
+
+	if len(out) != 1 {
+		t.Fatalf("expected one coalesced user message, got %d: %+v", len(out), out)
+	}
+	if out[0].Role != "user" {
+		t.Fatalf("expected user role, got %s", out[0].Role)
+	}
+	got := allText(out)
+	if !strings.Contains(got, "first failed turn") || !strings.Contains(got, "retry") {
+		t.Fatalf("coalesced user content missing pieces: %q", got)
+	}
+}
+
 func allText(out []anthropicMessage) string {
 	var sb strings.Builder
 	for _, am := range out {


### PR DESCRIPTION
## Summary

Fixes #71.

MiniMax's Anthropic-compatible endpoint returns HTTP 500 with `unknown error, 999 (1000)` when a request replays prior Anthropic-style tool history containing `tool_use` and `tool_result` blocks. The history is valid for Anthropic, but MiniMax's compatibility layer rejects it.

This PR adds a MiniMax-only compatibility path that flattens historical tool calls/results into assistant text before building the Anthropic request. Real Anthropic behavior remains unchanged.

## Why

A chat turn can successfully call a tool, but the next user message may fail because the previous tool call is replayed in native Anthropic block form. Flattening the historical tool exchange preserves the useful context while avoiding MiniMax's 999 error.

## Changes

- Add `toAnthropicMessagesCompat` with optional tool-history flattening.
- Enable flattening only when the Anthropic provider base/model indicates MiniMax.
- Add tests for MiniMax-compatible tool-history flattening and consecutive user coalescing.

## Validation

- `go test ./internal/provider ./internal/gateway ./internal/setup ./cmd/fastclaw`
- `go build -o bin/fastclaw ./cmd/fastclaw`
- Manual local Web stream verification: turn 1 called `exec`; turn 2 sent `继续` and no longer returned MiniMax `999 (1000)`.