### PR TITLE
fix(store): repair user/agent-delete configs queries after configs refactor

### DIFF
--- a/internal/store/database.go
+++ b/internal/store/database.go
@@ -2002,7 +2002,8 @@ func (d *DBStore) DeleteUser(ctx context.Context, id string) error {
 			return err
 		}
 		if _, err := tx.ExecContext(ctx,
-			fmt.Sprintf("DELETE FROM configs WHERE agent_id = %s", d.ph(1)), aid); err != nil {
+			fmt.Sprintf(`DELETE FROM configs WHERE (scope = 'agent' AND scope_id = %s) OR (scope = 'user-agent' AND scope_id LIKE %s)`,
+				d.ph(1), d.ph(2)), aid, "%/"+aid); err != nil {
 			return err
 		}
 	}
@@ -2017,11 +2018,14 @@ func (d *DBStore) DeleteUser(ctx context.Context, id string) error {
 			return err
 		}
 	}
-	// Drop every config row owned by this user — both their own
-	// ('user_id=X, agent_id="') and any per-agent overrides they
-	// authored on someone else's agent ('user_id=X, agent_id=Y').
+	// Drop every config row owned by this user. After the configs
+	// refactor user identity lives in scope_id, not a dedicated
+	// user_id column: a user's own rows are (scope='user', scope_id=X);
+	// per-agent overrides they authored are (scope='user-agent',
+	// scope_id='X/<agent>'). Match both.
 	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf("DELETE FROM configs WHERE user_id = %s", d.ph(1)), id); err != nil {
+		fmt.Sprintf(`DELETE FROM configs WHERE (scope = 'user' AND scope_id = %s) OR (scope = 'user-agent' AND scope_id LIKE %s)`,
+			d.ph(1), d.ph(2)), id, id+"/%"); err != nil {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx,
@@ -2282,12 +2286,14 @@ func (d *DBStore) DeleteAgent(ctx context.Context, agentID string) error {
 		fmt.Sprintf(`DELETE FROM apikey_agents WHERE agent_id = %s`, d.ph(1)), agentID); err != nil {
 		return err
 	}
-	// Drop every config row pointing at this agent — owner's official
-	// rows (user_id='', agent_id=X), agent owner's per-agent overrides
-	// (user_id=owner, agent_id=X), and any non-owner per-agent
-	// overrides (user_id=other, agent_id=X).
+	// Drop every config row pointing at this agent. After the configs
+	// refactor agent identity lives in scope_id, not a dedicated
+	// agent_id column: official agent rows are (scope='agent',
+	// scope_id=X); per-user overrides are (scope='user-agent',
+	// scope_id='<user>/X'). Match both.
 	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`DELETE FROM configs WHERE agent_id = %s`, d.ph(1)), agentID); err != nil {
+		fmt.Sprintf(`DELETE FROM configs WHERE (scope = 'agent' AND scope_id = %s) OR (scope = 'user-agent' AND scope_id LIKE %s)`,
+			d.ph(1), d.ph(2)), agentID, "%/"+agentID); err != nil {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx,

--- a/internal/store/delete_configs_test.go
+++ b/internal/store/delete_configs_test.go
@@ -1,0 +1,117 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+// TestDeleteAgentRemovesScopedConfigs and TestDeleteUserRemovesScopedConfigs
+// guard the delete paths against the configs refactor that replaced the
+// (user_id, agent_id) columns with (scope, scope_id). Before the fix the
+// DELETE statements still referenced the dropped columns and failed at
+// runtime with "no such column" on any migrated database. These tests
+// reproduce that failure (DeleteAgent/DeleteUser returning an error) and
+// assert the scoped config rows are actually removed.
+
+func TestDeleteAgentRemovesScopedConfigs(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	const ownerID = "u-owner"
+	const otherID = "u-other"
+	const agentID = "agt-x"
+
+	for _, u := range []string{ownerID, otherID} {
+		if err := db.CreateUser(ctx, &UserRecord{ID: u, Username: u, Email: u + "@test.local", Role: "user"}); err != nil {
+			t.Fatalf("seed user %s: %v", u, err)
+		}
+	}
+	if err := db.SaveAgent(ctx, &AgentRecord{ID: agentID, UserID: ownerID, Name: "x"}); err != nil {
+		t.Fatalf("save agent: %v", err)
+	}
+
+	// Official agent row (scope='agent') + a per-user overlay authored by
+	// a different user (scope='user-agent', scope_id='u-other/agt-x').
+	mustSaveConfig(t, db, &ConfigRecord{Kind: "setting", AgentID: agentID, Name: "model", Enabled: true})
+	mustSaveConfig(t, db, &ConfigRecord{Kind: "setting", UserID: otherID, AgentID: agentID, Name: "model", Enabled: true})
+	// An unrelated user-scoped row that must survive.
+	mustSaveConfig(t, db, &ConfigRecord{Kind: "setting", UserID: otherID, Name: "theme", Enabled: true})
+
+	if err := db.DeleteAgent(ctx, agentID); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+
+	assertNoConfig(t, db, "setting", "", agentID, "model")      // official agent row gone
+	assertNoConfig(t, db, "setting", otherID, agentID, "model") // overlay gone
+	assertConfig(t, db, "setting", otherID, "", "theme")        // unrelated row survives
+}
+
+func TestDeleteUserRemovesScopedConfigs(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	const userID = "u-self"
+	const keepID = "u-keep"
+	const otherAgent = "agt-other"
+
+	for _, u := range []string{userID, keepID} {
+		if err := db.CreateUser(ctx, &UserRecord{ID: u, Username: u, Email: u + "@test.local", Role: "user"}); err != nil {
+			t.Fatalf("seed user %s: %v", u, err)
+		}
+	}
+	if err := db.SaveAgent(ctx, &AgentRecord{ID: otherAgent, UserID: keepID, Name: "o"}); err != nil {
+		t.Fatalf("save agent: %v", err)
+	}
+
+	// The user's own row (scope='user') + an overlay they authored on
+	// someone else's agent (scope='user-agent', scope_id='u-self/agt-other').
+	mustSaveConfig(t, db, &ConfigRecord{Kind: "setting", UserID: userID, Name: "theme", Enabled: true})
+	mustSaveConfig(t, db, &ConfigRecord{Kind: "setting", UserID: userID, AgentID: otherAgent, Name: "model", Enabled: true})
+	// Another user's row that must survive.
+	mustSaveConfig(t, db, &ConfigRecord{Kind: "setting", UserID: keepID, Name: "theme", Enabled: true})
+
+	if err := db.DeleteUser(ctx, userID); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+
+	assertNoConfig(t, db, "setting", userID, "", "theme")         // own row gone
+	assertNoConfig(t, db, "setting", userID, otherAgent, "model") // overlay gone
+	assertConfig(t, db, "setting", keepID, "", "theme")           // other user survives
+}
+
+func mustSaveConfig(t *testing.T, db *DBStore, c *ConfigRecord) {
+	t.Helper()
+	if err := db.SaveConfig(context.Background(), c); err != nil {
+		t.Fatalf("SaveConfig %+v: %v", c, err)
+	}
+}
+
+func assertConfig(t *testing.T, db *DBStore, kind, userID, agentID, name string) {
+	t.Helper()
+	if got := getConfigByName(t, db, kind, userID, agentID, name); got == nil {
+		t.Fatalf("expected config (kind=%s user=%s agent=%s name=%s) to exist", kind, userID, agentID, name)
+	}
+}
+
+func assertNoConfig(t *testing.T, db *DBStore, kind, userID, agentID, name string) {
+	t.Helper()
+	if got := getConfigByName(t, db, kind, userID, agentID, name); got != nil {
+		t.Fatalf("expected config (kind=%s user=%s agent=%s name=%s) to be deleted, still present", kind, userID, agentID, name)
+	}
+}
+
+func getConfigByName(t *testing.T, db *DBStore, kind, userID, agentID, name string) *ConfigRecord {
+	t.Helper()
+	recs, err := db.ListConfigs(context.Background(), kind, userID, agentID)
+	if err != nil {
+		t.Fatalf("ListConfigs: %v", err)
+	}
+	for i := range recs {
+		if recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}

--- a/internal/store/sessions_channel_test.go
+++ b/internal/store/sessions_channel_test.go
@@ -18,6 +18,15 @@ func TestSessionChannelTriple(t *testing.T) {
 	const userID = "u-test"
 	const agentID = "agt-test"
 
+	// ListSessions now scopes results to rows whose user_id exists in
+	// the users table (the query joins sessions → users to surface a
+	// caller's own + their app_users' threads). Seed the owner so the
+	// sessions saved below are visible. (Upstream's version of this test
+	// omitted this and fails the final ListSessions assertion.)
+	if err := db.CreateUser(ctx, &UserRecord{ID: userID, Username: userID, Email: userID + "@test.local", Role: "user"}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
 	// Two sessions sharing the same wechat (account, openid) triple —
 	// the older "v1" thread plus a newer "v2" minted after a /new.
 	older := &SessionRecord{


### PR DESCRIPTION
## Problem

The configs refactor (`fb7d32c`) collapsed the `(user_id, agent_id)`
columns into a single `(scope, scope_id)` key, and a later migration
(`migrateConfigsDropLegacyColumns`) drops the old `user_id` / `agent_id`
columns outright. Three `DELETE` statements in the delete paths were left
referencing the now-dropped columns, so they fail at runtime on any
migrated database with `SQL logic error: no such column`:

- `DeleteUser` — `DELETE FROM configs WHERE agent_id = ?` (owned-agents loop)
- `DeleteUser` — `DELETE FROM configs WHERE user_id = ?` (the user's own rows)
- `DeleteAgent` — `DELETE FROM configs WHERE agent_id = ?`

This breaks user deletion and agent deletion entirely on existing installs.

## Fix

Rewrite all three to the new scope/scope_id keying, matching the scope
values the migration itself assigns (`scope='agent'`, `scope='user'`,
`scope='user-agent'` with `scope_id` encoded as `"<user>/<agent>"`):

- agent rows: `scope='agent' AND scope_id = <agentID>`
- user rows: `scope='user' AND scope_id = <userID>`
- per-user overlays: `scope='user-agent' AND scope_id LIKE '<id>/%'` (or `'%/<agentID>'`)

## Tests

- New `delete_configs_test.go` covers both delete paths, asserting that
  scoped rows are removed while unrelated rows survive. On unpatched code
  these reproduce the failure (`no such column: agent_id` /
  `no such column: user_id`); they pass with the fix.
- Also seeds the owner user row in `TestSessionChannelTriple`: `ListSessions`
  now restricts results to `user_id`s present in the `users` table, so the
  test's sessions were invisible without a matching users row (the test
  fails on a pristine `dev` otherwise).

`go build`, `go vet`, and `go test ./internal/store/...` all pass.
