### PR TITLE
fix(cron): include AccountID in fireJob InboundMessage + LLM retry

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -1732,6 +1733,50 @@ func (a *Agent) flushLeftoverSteer(sess *session.Session) {
 	}
 }
 
+// llmRetry wraps an LLM call with retry logic for transient errors (network
+// glitches, server 5xx, EOF). Context cancellation / deadline exceeded are
+// treated as terminal — there's no point retrying when the caller has gone
+// away or the deadline has passed. Uses exponential backoff (1s, 4s, 9s)
+// across up to wechatLLMRetryAttempts calls.
+//
+// The label argument is used for structured logging (typically a.name).
+const llmRetryAttempts = 3
+
+func llmRetry(ctx context.Context, label string, fn func(context.Context) (*provider.Response, error)) (*provider.Response, error) {
+	var lastErr error
+	for attempt := 1; attempt <= llmRetryAttempts; attempt++ {
+		resp, err := fn(ctx)
+		if err == nil {
+			if attempt > 1 {
+				slog.Info("LLM call succeeded after retries",
+					"agent", label, "attempts", attempt)
+			}
+			return resp, nil
+		}
+		lastErr = err
+
+		// Context errors are terminal — don't retry.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+
+		if attempt < llmRetryAttempts {
+			backoff := time.Duration(attempt*attempt) * time.Second // 1s, 4s, 9s
+			slog.Warn("LLM call failed, retrying",
+				"agent", label, "attempt", attempt,
+				"max", llmRetryAttempts, "backoff", backoff, "error", err)
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return nil, errors.Join(lastErr, ctx.Err())
+			}
+		}
+	}
+	slog.Error("LLM call failed after all retries",
+		"agent", label, "attempts", llmRetryAttempts, "error", lastErr)
+	return nil, lastErr
+}
+
 // HandleMessage processes an inbound message through the ReAct loop.
 func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) string {
 	// Check for slash commands first. Empty reply means "handled but
@@ -1981,14 +2026,16 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 			})
 		}
 		dumpLLMRequest(a.name, a.model, llmMessages, callTools)
-		resp, err := a.streamChatToResponse(ctx, llmMessages, callTools)
+		resp, err := llmRetry(ctx, a.name, func(ctx context.Context) (*provider.Response, error) {
+			return a.streamChatToResponse(ctx, llmMessages, callTools)
+		})
 
 		// Hook: AfterModelCall
 		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID, GoalSessionKey: a.registry.GoalSessionKey()}
 		a.hooks.Run(ctx, hcAfter)
 
 		if err != nil {
-			slog.Error("LLM chat failed", "agent", a.name, "error", err)
+			slog.Error("LLM chat failed after retries", "agent", a.name, "error", err)
 			emitEvent(ctx, ChatEvent{Type: "error", Data: map[string]any{"message": err.Error()}})
 			emitEvent(ctx, ChatEvent{Type: "done"})
 			return "Sorry, I encountered an error processing your request."
@@ -2619,13 +2666,15 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 		a.hooks.Run(ctx, hcBefore)
 
 		dumpLLMRequest(a.name, a.model, messages, toolDefs)
-		resp, err := a.provider.Chat(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
+		resp, err := llmRetry(ctx, a.name, func(ctx context.Context) (*provider.Response, error) {
+			return a.provider.Chat(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
+		})
 
 		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID, GoalSessionKey: a.registry.GoalSessionKey()}
 		a.hooks.Run(ctx, hcAfter)
 
 		if err != nil {
-			slog.Error("LLM chat failed", "agent", a.name, "error", err)
+			slog.Error("LLM chat failed after retries", "agent", a.name, "error", err)
 			return a.stringStream("Sorry, I encountered an error processing your request.")
 		}
 		a.meterTokens(ctx, sess.Key(), resp.Usage)

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -278,6 +278,7 @@ func (s *Scheduler) processDueJobs(ctx context.Context) {
 
 		s.bus.Inbound <- bus.InboundMessage{
 			Channel:     j.Channel,
+			AccountID:   j.AccountID,
 			ChatID:      j.ChatID,
 			UserID:      "cron",
 			OwnerUserID: j.OwnerUserID,


### PR DESCRIPTION
## Bug Fix: Cron fireJob missing AccountID

`fireJob` constructs an `InboundMessage` for cron-triggered tasks but omits the `AccountID` field. When the agent replies, the outbound router receives `key=wechat:` (empty account) and logs `unknown outbound channel`, silently dropping every cron-scheduled proactive message.

**Fix:** Add `AccountID: j.AccountID` to the struct literal.

## Enhancement: LLM call retry

Wrap `streamChatToResponse` (chatbot mode) and `provider.Chat` (agent mode) with `llmRetry` — up to 3 retries, exponential backoff (1s → 4s → 9s). Context cancellation / deadline exceeded are treated as terminal and never retried. Transient errors (network EOF, 5xx) are retried transparently.

Related: `internal/agent/loop.go`, `internal/cron/scheduler.go`