### PR TITLE
fix(agent): avoid false-positive tool loop detection

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2012,13 +2011,8 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 
 	toolDefs := a.registry.DefinitionsForMode(builtinAllowForMode(a.promptMode))
 
-	// Loop detection: track consecutive identical tool calls
-	type toolCallSig struct {
-		name string
-		hash [32]byte
-	}
-	var lastSig toolCallSig
-	consecutiveCount := 0
+	// Loop detection: track consecutive identical tool calls and results.
+	var loopDetector toolLoopDetector
 	totalToolCalls := 0
 	// allFailedRounds is the count of CONSECUTIVE rounds where every
 	// tool result came back as a 4xx/5xx HTTP error or an executor
@@ -2161,35 +2155,6 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 		sess.Append(assistantMsg)
 		messages = append(messages, assistantMsg)
 
-		// Loop detection: check before executing
-		loopDetected := false
-		for _, tc := range resp.ToolCalls {
-			sig := toolCallSig{
-				name: tc.Function.Name,
-				hash: sha256.Sum256([]byte(tc.Function.Arguments)),
-			}
-			if sig.name == lastSig.name && sig.hash == lastSig.hash {
-				consecutiveCount++
-			} else {
-				consecutiveCount = 1
-				lastSig = sig
-			}
-			if consecutiveCount >= 3 {
-				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
-				warnMsg := provider.Message{
-					Role:    "system",
-					Content: "Loop detected: you called the same tool with the same arguments 3 times. Please try a different approach.",
-				}
-				sess.Append(warnMsg)
-				messages = append(messages, warnMsg)
-				loopDetected = true
-				break
-			}
-		}
-		if loopDetected {
-			break
-		}
-
 		// Fire BeforeToolCall hooks
 		for _, tc := range resp.ToolCalls {
 			a.hooks.Run(ctx, &HookContext{
@@ -2273,6 +2238,7 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 			results = padded
 		}
 
+		loopDetected := false
 		// Round-level failure detection: did EVERY result come back
 		// as a 4xx/5xx HTTP error or executor error? Tracked here so
 		// the next iteration can decide whether to drop tools.
@@ -2353,6 +2319,16 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 				evt["metadata"] = meta
 			}
 			emitEvent(ctx, ChatEvent{Type: "tool_result", Data: evt})
+
+			if loopDetector.Observe(tc, resultContent) && !loopDetected {
+				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
+				loopDetected = true
+			}
+		}
+		if loopDetected {
+			warnMsg := repeatedToolCallWarning("Loop detected: you called the same tool with the same arguments and received the same result 3 times. Please try a different approach.")
+			sess.Append(warnMsg)
+			messages = append(messages, warnMsg)
 		}
 		// Update consecutive-failed-rounds tally now that the whole
 		// round's results have been processed. A single non-failure
@@ -2362,6 +2338,9 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 			allFailedRounds++
 		} else {
 			allFailedRounds = 0
+		}
+		if loopDetected {
+			break
 		}
 
 		// Steering: messages that arrived while this tool round ran are
@@ -2726,12 +2705,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 
 	toolDefs := a.registry.DefinitionsForMode(builtinAllowForMode(a.promptMode))
 
-	type toolCallSig struct {
-		name string
-		hash [32]byte
-	}
-	var lastSig toolCallSig
-	consecutiveCount := 0
+	var loopDetector toolLoopDetector
 	totalToolCalls := 0
 
 	// ReAct loop - use Chat for tool iterations
@@ -2850,35 +2824,6 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 		sess.Append(assistantMsg)
 		messages = append(messages, assistantMsg)
 
-		// Loop detection
-		loopDetected := false
-		for _, tc := range resp.ToolCalls {
-			sig := toolCallSig{
-				name: tc.Function.Name,
-				hash: sha256.Sum256([]byte(tc.Function.Arguments)),
-			}
-			if sig.name == lastSig.name && sig.hash == lastSig.hash {
-				consecutiveCount++
-			} else {
-				consecutiveCount = 1
-				lastSig = sig
-			}
-			if consecutiveCount >= 3 {
-				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
-				warnMsg := provider.Message{
-					Role:    "system",
-					Content: "Loop detected: you called the same tool with the same arguments 3 times. Please try a different approach.",
-				}
-				sess.Append(warnMsg)
-				messages = append(messages, warnMsg)
-				loopDetected = true
-				break
-			}
-		}
-		if loopDetected {
-			break
-		}
-
 		// Fire BeforeToolCall hooks
 		for _, tc := range resp.ToolCalls {
 			a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: BeforeToolCall, ToolName: tc.Function.Name, ToolArgs: tc.Function.Arguments, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID})
@@ -2887,6 +2832,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 		// Execute tools concurrently via SDK engine
 		results := a.engine.executeToolsConcurrently(ctx, a.registry, resp.ToolCalls, a.workspacePath)
 		totalToolCalls += len(results)
+		loopDetected := false
 
 		for idx, r := range results {
 			tc := resp.ToolCalls[idx]
@@ -2904,6 +2850,19 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 			toolMsg := provider.Message{Role: "tool", Content: resultContent, ToolCallID: tc.ID, Name: r.toolName, Metadata: meta}
 			sess.Append(toolMsg)
 			messages = append(messages, toolMsg)
+
+			if loopDetector.Observe(tc, resultContent) && !loopDetected {
+				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
+				loopDetected = true
+			}
+		}
+		if loopDetected {
+			warnMsg := repeatedToolCallWarning("Loop detected: you called the same tool with the same arguments and received the same result 3 times. Please try a different approach.")
+			sess.Append(warnMsg)
+			messages = append(messages, warnMsg)
+		}
+		if loopDetected {
+			break
 		}
 	}
 

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -98,12 +97,7 @@ func (a *Agent) runSubagentLoop(ctx context.Context, task string, maxIterations 
 		toolDefs = append(toolDefs, t)
 	}
 
-	type sig struct {
-		name string
-		hash [32]byte
-	}
-	var lastSig sig
-	consecutiveCount := 0
+	var loopDetector toolLoopDetector
 	allFailedRounds := 0
 	const failedRoundsLimit = 3
 
@@ -167,30 +161,6 @@ func (a *Agent) runSubagentLoop(ctx context.Context, task string, maxIterations 
 			RawAssistant: resp.RawAssistant,
 		})
 
-		// Loop detection: same shape as HandleMessage but on private state.
-		loopDetected := false
-		for _, tc := range resp.ToolCalls {
-			s := sig{name: tc.Function.Name, hash: sha256.Sum256([]byte(tc.Function.Arguments))}
-			if s.name == lastSig.name && s.hash == lastSig.hash {
-				consecutiveCount++
-			} else {
-				consecutiveCount = 1
-				lastSig = s
-			}
-			if consecutiveCount >= 3 {
-				slog.Warn("subagent tool-loop detected", "agent", a.name, "tool", tc.Function.Name)
-				messages = append(messages, provider.Message{
-					Role:    "system",
-					Content: "Loop detected: same tool with same arguments 3 times. Stop and produce the deliverable from what you have.",
-				})
-				loopDetected = true
-				break
-			}
-		}
-		if loopDetected {
-			break
-		}
-
 		// Second heartbeat: tools are about to run. Surface their names
 		// so the UI can show "running web_search" / "running exec
 		// (camoufox-cli open …)" instead of just a spinner.
@@ -207,6 +177,7 @@ func (a *Agent) runSubagentLoop(ctx context.Context, task string, maxIterations 
 
 		results := a.engine.executeToolsConcurrently(ctx, a.registry, resp.ToolCalls, a.workspacePath)
 		roundAllFailed := true
+		loopDetected := false
 		for idx, r := range results {
 			tc := resp.ToolCalls[idx]
 			resultContent, _ := extractToolMeta(r.result)
@@ -219,11 +190,21 @@ func (a *Agent) runSubagentLoop(ctx context.Context, task string, maxIterations 
 				ToolCallID: tc.ID,
 				Name:       r.toolName,
 			})
+			if loopDetector.Observe(tc, resultContent) && !loopDetected {
+				slog.Warn("subagent tool loop detected", "agent", a.name, "tool", tc.Function.Name)
+				loopDetected = true
+			}
+		}
+		if loopDetected {
+			messages = append(messages, repeatedToolCallWarning("Loop detected: same tool with same arguments and same result 3 times. Stop and produce the deliverable from what you have."))
 		}
 		if roundAllFailed {
 			allFailedRounds++
 		} else {
 			allFailedRounds = 0
+		}
+		if loopDetected {
+			break
 		}
 	}
 

--- a/internal/agent/tool_loop_detector.go
+++ b/internal/agent/tool_loop_detector.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"strings"
+
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+)
+
+const toolLoopDetectionThreshold = 3
+
+type toolLoopDetector struct {
+	last        toolLoopSignature
+	consecutive int
+}
+
+type toolLoopSignature struct {
+	name       string
+	inputHash  [32]byte
+	resultHash [32]byte
+}
+
+func (d *toolLoopDetector) Observe(tc provider.ToolCall, result string) bool {
+	sig := toolLoopSignature{
+		name:       tc.Function.Name,
+		inputHash:  sha256.Sum256([]byte(tc.Function.Arguments)),
+		resultHash: sha256.Sum256([]byte(strings.TrimSpace(result))),
+	}
+	if sig.name == d.last.name && sig.inputHash == d.last.inputHash && sig.resultHash == d.last.resultHash {
+		d.consecutive++
+	} else {
+		d.consecutive = 1
+		d.last = sig
+	}
+	return d.consecutive >= toolLoopDetectionThreshold
+}
+
+func repeatedToolCallWarning(content string) provider.Message {
+	return provider.Message{Role: "system", Content: content}
+}

--- a/internal/agent/tool_loop_detector_test.go
+++ b/internal/agent/tool_loop_detector_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+)
+
+func testToolCall(name, args string) provider.ToolCall {
+	return provider.ToolCall{Function: provider.FunctionCall{Name: name, Arguments: args}}
+}
+
+func TestToolLoopDetectorAllowsProgressingPolling(t *testing.T) {
+	var detector toolLoopDetector
+	tc := testToolCall("check_status", `{"id":"abc"}`)
+
+	for _, result := range []string{"pending", "processing", "completed"} {
+		if detector.Observe(tc, result) {
+			t.Fatalf("progressing polling result %q was classified as a loop", result)
+		}
+	}
+}
+
+type argOnlyLoopDetector struct {
+	last        argOnlyLoopSignature
+	consecutive int
+}
+
+type argOnlyLoopSignature struct {
+	name      string
+	inputHash [32]byte
+}
+
+func (d *argOnlyLoopDetector) Observe(tc provider.ToolCall) bool {
+	sig := argOnlyLoopSignature{
+		name:      tc.Function.Name,
+		inputHash: sha256.Sum256([]byte(tc.Function.Arguments)),
+	}
+	if sig.name == d.last.name && sig.inputHash == d.last.inputHash {
+		d.consecutive++
+	} else {
+		d.consecutive = 1
+		d.last = sig
+	}
+	return d.consecutive >= toolLoopDetectionThreshold
+}
+
+func TestToolLoopDetectorAllowsThirdProgressingPollThatArgOnlyDetectorWouldBlock(t *testing.T) {
+	tc := testToolCall("check_status", "{\"id\":\"abc\"}")
+	results := []string{"pending: queued", "pending: running", "pending: finalizing"}
+
+	var oldDetector argOnlyLoopDetector
+	for i := range results {
+		got := oldDetector.Observe(tc)
+		if i < toolLoopDetectionThreshold-1 && got {
+			t.Fatalf("arg-only detector looped before the threshold on poll %d", i+1)
+		}
+		if i == toolLoopDetectionThreshold-1 && !got {
+			t.Fatalf("arg-only detector should block the third identical tool call")
+		}
+	}
+
+	var detector toolLoopDetector
+	for _, result := range results {
+		if detector.Observe(tc, result) {
+			t.Fatalf("result-aware detector should allow progressing poll result %q", result)
+		}
+	}
+}
+
+func TestToolLoopDetectorDetectsIdenticalInputAndResult(t *testing.T) {
+	var detector toolLoopDetector
+	tc := testToolCall("check_status", `{"id":"abc"}`)
+
+	for i := 1; i <= toolLoopDetectionThreshold; i++ {
+		got := detector.Observe(tc, "pending")
+		if i < toolLoopDetectionThreshold && got {
+			t.Fatalf("Observe call %d detected a loop before the threshold", i)
+		}
+		if i == toolLoopDetectionThreshold && !got {
+			t.Fatalf("Observe call %d did not detect repeated identical results", i)
+		}
+	}
+}
+
+func TestToolLoopDetectorResetsOnDifferentArguments(t *testing.T) {
+	var detector toolLoopDetector
+	first := testToolCall("check_status", `{"id":"abc"}`)
+	second := testToolCall("check_status", `{"id":"def"}`)
+
+	if detector.Observe(first, "pending") {
+		t.Fatal("first observation should not detect a loop")
+	}
+	if detector.Observe(first, "pending") {
+		t.Fatal("second observation should not detect a loop")
+	}
+	if detector.Observe(second, "pending") {
+		t.Fatal("different arguments should reset loop detection")
+	}
+}


### PR DESCRIPTION
## Summary

Fix false-positive tool loop detection by moving repeated-tool detection from pre-execution argument matching to post-execution result-aware matching.

Repeated tool calls are now only treated as loops when the tool name, arguments, and returned result are identical. This allows normal polling workflows where the same tool is called with the same arguments but returns progressing results.

## Tests

- `go test ./internal/agent -run TestToolLoopDetector -count=1`
- `go test ./internal/agent -count=1`
- `git diff --check`