### PR TITLE
fix: support newer OpenAI chat parameters

### DIFF
--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -52,13 +52,14 @@ type apiMessage struct {
 }
 
 type chatRequest struct {
-	Model         string            `json:"model"`
-	Messages      []json.RawMessage `json:"messages"`
-	Tools         []Tool            `json:"tools,omitempty"`
-	MaxTokens     int               `json:"max_tokens,omitempty"`
-	Temperature   float64           `json:"temperature,omitempty"`
-	Stream        bool              `json:"stream"`
-	StreamOptions *streamOptions    `json:"stream_options,omitempty"`
+	Model               string            `json:"model"`
+	Messages            []json.RawMessage `json:"messages"`
+	Tools               []Tool            `json:"tools,omitempty"`
+	MaxTokens           int               `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int               `json:"max_completion_tokens,omitempty"`
+	Temperature         *float64          `json:"temperature,omitempty"`
+	Stream              bool              `json:"stream"`
+	StreamOptions       *streamOptions    `json:"stream_options,omitempty"`
 }
 
 // streamOptions.include_usage tells OpenAI-compat APIs to emit one final
@@ -241,13 +242,24 @@ type sseResponse struct {
 	Usage   *sseUsage   `json:"usage,omitempty"` // present only on the final chunk when include_usage=true
 }
 
-func (p *OpenAIProvider) buildRequest(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64, stream bool) (*http.Request, error) {
+type openAIRequestMode struct {
+	maxCompletionTokens bool
+	omitTemperature     bool
+}
+
+func (p *OpenAIProvider) buildRequest(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64, stream bool, mode openAIRequestMode) (*http.Request, error) {
 	req := chatRequest{
-		Model:       StripProviderPrefix(model),
-		Messages:    toAPIMessages(messages),
-		MaxTokens:   maxTokens,
-		Temperature: temperature,
-		Stream:      stream,
+		Model:    StripProviderPrefix(model),
+		Messages: toAPIMessages(messages),
+		Stream:   stream,
+	}
+	if !mode.omitTemperature {
+		req.Temperature = &temperature
+	}
+	if mode.maxCompletionTokens {
+		req.MaxCompletionTokens = maxTokens
+	} else {
+		req.MaxTokens = maxTokens
 	}
 	if stream {
 		// include_usage adds a terminal chunk carrying the call's token
@@ -277,41 +289,20 @@ func (p *OpenAIProvider) buildRequest(ctx context.Context, messages []Message, t
 }
 
 func (p *OpenAIProvider) Chat(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64) (*Response, error) {
-	httpReq, err := p.buildRequest(ctx, messages, tools, model, maxTokens, temperature, true)
+	resp, err := p.doChatRequest(ctx, messages, tools, model, maxTokens, temperature, true)
 	if err != nil {
 		return nil, err
 	}
-
-	resp, err := p.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("send request: %w", err)
-	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
-	}
 
 	return p.parseSSE(resp.Body)
 }
 
 // ChatStream returns a StreamReader that yields chunks as they arrive from the LLM.
 func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64) (*StreamReader, error) {
-	httpReq, err := p.buildRequest(ctx, messages, tools, model, maxTokens, temperature, true)
+	resp, err := p.doChatRequest(ctx, messages, tools, model, maxTokens, temperature, true)
 	if err != nil {
 		return nil, err
-	}
-
-	resp, err := p.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("send request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	ch := make(chan StreamChunk, 64)
@@ -444,6 +435,58 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, too
 	}()
 
 	return reader, nil
+}
+
+func (p *OpenAIProvider) doChatRequest(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64, stream bool) (*http.Response, error) {
+	mode := openAIRequestMode{}
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		httpReq, err := p.buildRequest(ctx, messages, tools, model, maxTokens, temperature, stream, mode)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := p.client.Do(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("send request: %w", err)
+		}
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		body := string(respBody)
+		lastErr = fmt.Errorf("API error %d: %s", resp.StatusCode, body)
+
+		if !mode.maxCompletionTokens && shouldRetryWithMaxCompletionTokens(resp.StatusCode, body) {
+			mode.maxCompletionTokens = true
+			continue
+		}
+		if !mode.omitTemperature && shouldRetryWithoutTemperature(resp.StatusCode, body) {
+			mode.omitTemperature = true
+			continue
+		}
+
+		return nil, lastErr
+	}
+	return nil, lastErr
+}
+
+func shouldRetryWithMaxCompletionTokens(status int, body string) bool {
+	if status < 400 || status >= 500 {
+		return false
+	}
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "max_tokens") && strings.Contains(lower, "max_completion_tokens")
+}
+
+func shouldRetryWithoutTemperature(status int, body string) bool {
+	if status < 400 || status >= 500 {
+		return false
+	}
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "temperature") && strings.Contains(lower, "only the default")
 }
 
 func (p *OpenAIProvider) parseSSE(reader io.Reader) (*Response, error) {

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -247,6 +247,18 @@ type openAIRequestMode struct {
 	omitTemperature     bool
 }
 
+func initialOpenAIRequestMode(model string) openAIRequestMode {
+	model = strings.ToLower(StripProviderPrefix(model))
+	switch {
+	case strings.HasPrefix(model, "gpt-5"):
+		return openAIRequestMode{maxCompletionTokens: true, omitTemperature: true}
+	case strings.HasPrefix(model, "o1"), strings.HasPrefix(model, "o3"), strings.HasPrefix(model, "o4"):
+		return openAIRequestMode{maxCompletionTokens: true, omitTemperature: true}
+	default:
+		return openAIRequestMode{}
+	}
+}
+
 func (p *OpenAIProvider) buildRequest(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64, stream bool, mode openAIRequestMode) (*http.Request, error) {
 	req := chatRequest{
 		Model:    StripProviderPrefix(model),
@@ -438,7 +450,7 @@ func (p *OpenAIProvider) ChatStream(ctx context.Context, messages []Message, too
 }
 
 func (p *OpenAIProvider) doChatRequest(ctx context.Context, messages []Message, tools []Tool, model string, maxTokens int, temperature float64, stream bool) (*http.Response, error) {
-	mode := openAIRequestMode{}
+	mode := initialOpenAIRequestMode(model)
 	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {
 		httpReq, err := p.buildRequest(ctx, messages, tools, model, maxTokens, temperature, stream, mode)

--- a/internal/provider/openai_request_retry_test.go
+++ b/internal/provider/openai_request_retry_test.go
@@ -86,3 +86,75 @@ func TestOpenAIRetriesWithoutTemperature(t *testing.T) {
 		t.Fatalf("calls = %d, want 2", calls)
 	}
 }
+
+func TestOpenAIUsesNewerModelChatParametersWithoutRetry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if _, ok := body["max_completion_tokens"]; !ok {
+			t.Fatalf("request missing max_completion_tokens: %#v", body)
+		}
+		if _, ok := body["max_tokens"]; ok {
+			t.Fatalf("request sent legacy max_tokens: %#v", body)
+		}
+		if _, ok := body["temperature"]; ok {
+			t.Fatalf("request sent unsupported temperature: %#v", body)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test-key", srv.URL)
+	resp, err := p.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}}, nil, "openai/gpt-5.5", 123, 0.7)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("content = %q, want ok", resp.Content)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+}
+
+func TestOpenAIKeepsLegacyChatParametersForUnknownModels(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if _, ok := body["max_tokens"]; !ok {
+			t.Fatalf("request missing legacy max_tokens: %#v", body)
+		}
+		if _, ok := body["max_completion_tokens"]; ok {
+			t.Fatalf("request sent max_completion_tokens for unknown model: %#v", body)
+		}
+		if _, ok := body["temperature"]; !ok {
+			t.Fatalf("request missing temperature for unknown model: %#v", body)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test-key", srv.URL)
+	resp, err := p.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}}, nil, "compatible-model", 123, 0.7)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("content = %q, want ok", resp.Content)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+}

--- a/internal/provider/openai_request_retry_test.go
+++ b/internal/provider/openai_request_retry_test.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestOpenAIRetriesWithMaxCompletionTokens(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if call == 1 {
+			if _, ok := body["max_tokens"]; !ok {
+				t.Fatalf("first request missing max_tokens: %#v", body)
+			}
+			http.Error(w, `{"error":{"message":"Unsupported parameter: 'max_tokens'. Use 'max_completion_tokens' instead."}}`, http.StatusBadRequest)
+			return
+		}
+		if _, ok := body["max_completion_tokens"]; !ok {
+			t.Fatalf("retry missing max_completion_tokens: %#v", body)
+		}
+		if _, ok := body["max_tokens"]; ok {
+			t.Fatalf("retry still sent max_tokens: %#v", body)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test-key", srv.URL)
+	resp, err := p.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}}, nil, "test-model", 123, 0)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("content = %q, want ok", resp.Content)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}
+
+func TestOpenAIRetriesWithoutTemperature(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if call == 1 {
+			if _, ok := body["temperature"]; !ok {
+				t.Fatalf("first request missing temperature: %#v", body)
+			}
+			http.Error(w, `{"error":{"message":"Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.","param":"temperature","code":"unsupported_value"}}`, http.StatusBadRequest)
+			return
+		}
+		if _, ok := body["temperature"]; ok {
+			t.Fatalf("retry still sent temperature: %#v", body)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test-key", srv.URL)
+	resp, err := p.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}}, nil, "test-model", 123, 0.7)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("content = %q, want ok", resp.Content)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}

--- a/internal/setup/handlers.go
+++ b/internal/setup/handlers.go
@@ -737,27 +737,60 @@ func (s *Server) handleTestStoredProvider(w http.ResponseWriter, r *http.Request
 func runProviderTest(ctx context.Context, req testProviderRequest) map[string]any {
 	base := provider.NormalizeAPIBase(req.APIBase, req.APIType)
 	var testURL string
-	var body io.Reader
+	var payload string
 	if req.APIType == "anthropic-messages" {
 		testURL = base + "/v1/messages"
 		model := req.Model
 		if model == "" {
 			model = "claude-sonnet-4-20250514"
 		}
-		payload := fmt.Sprintf(`{"model":"%s","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`, model)
-		body = strings.NewReader(payload)
+		payload = fmt.Sprintf(`{"model":"%s","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`, model)
 	} else {
 		testURL = base + "/chat/completions"
 		model := req.Model
 		if model == "" {
 			model = "gpt-4o-mini"
 		}
-		payload := fmt.Sprintf(`{"model":"%s","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`, model)
-		body = strings.NewReader(payload)
+		payload = openAIProviderTestPayload(model, false)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", testURL, body)
+	respBody, statusCode, err := sendProviderTestRequest(ctx, req, testURL, payload)
 	if err != nil {
 		return map[string]any{"ok": false, "error": err.Error()}
+	}
+	if req.APIType != "anthropic-messages" && statusCode >= 400 && shouldRetryProviderTestWithMaxCompletionTokens(respBody) {
+		model := req.Model
+		if model == "" {
+			model = "gpt-4o-mini"
+		}
+		respBody, statusCode, err = sendProviderTestRequest(ctx, req, testURL, openAIProviderTestPayload(model, true))
+		if err != nil {
+			return map[string]any{"ok": false, "error": err.Error()}
+		}
+	}
+
+	if statusCode < 200 || statusCode >= 300 {
+		return map[string]any{
+			"ok":    false,
+			"error": fmt.Sprintf("HTTP %d: %s", statusCode, truncate(strings.TrimSpace(string(respBody)), 240)),
+		}
+	}
+	if err := validateProviderTestBody(req.APIType, respBody); err != nil {
+		return map[string]any{"ok": false, "error": err.Error()}
+	}
+	return map[string]any{"ok": true}
+}
+
+func openAIProviderTestPayload(model string, maxCompletionTokens bool) string {
+	if maxCompletionTokens {
+		return fmt.Sprintf(`{"model":"%s","max_completion_tokens":16,"messages":[{"role":"user","content":"hi"}]}`, model)
+	}
+	return fmt.Sprintf(`{"model":"%s","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`, model)
+}
+
+func sendProviderTestRequest(ctx context.Context, req testProviderRequest, testURL, payload string) ([]byte, int, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", testURL, strings.NewReader(payload))
+	if err != nil {
+		return nil, 0, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	if req.APIType == "anthropic-messages" {
@@ -771,20 +804,16 @@ func runProviderTest(ctx context.Context, req testProviderRequest) map[string]an
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		return map[string]any{"ok": false, "error": err.Error()}
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return map[string]any{
-			"ok":    false,
-			"error": fmt.Sprintf("HTTP %d: %s", resp.StatusCode, truncate(strings.TrimSpace(string(respBody)), 240)),
-		}
-	}
-	if err := validateProviderTestBody(req.APIType, respBody); err != nil {
-		return map[string]any{"ok": false, "error": err.Error()}
-	}
-	return map[string]any{"ok": true}
+	return respBody, resp.StatusCode, nil
+}
+
+func shouldRetryProviderTestWithMaxCompletionTokens(body []byte) bool {
+	lower := strings.ToLower(string(body))
+	return strings.Contains(lower, "max_tokens") && strings.Contains(lower, "max_completion_tokens")
 }
 
 // validateProviderTestBody confirms the 2xx body is a real Messages /

--- a/internal/setup/provider_test.go
+++ b/internal/setup/provider_test.go
@@ -1,0 +1,51 @@
+package setup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunProviderTestRetriesMaxCompletionTokens(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if call == 1 {
+			if _, ok := body["max_tokens"]; !ok {
+				t.Fatalf("first request missing max_tokens: %#v", body)
+			}
+			http.Error(w, `{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}}`, http.StatusBadRequest)
+			return
+		}
+		if _, ok := body["max_completion_tokens"]; !ok {
+			t.Fatalf("retry missing max_completion_tokens: %#v", body)
+		}
+		if _, ok := body["max_tokens"]; ok {
+			t.Fatalf("retry still sent max_tokens: %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"chatcmpl-test","choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+	}))
+	defer srv.Close()
+
+	got := runProviderTest(context.Background(), testProviderRequest{
+		APIBase: srv.URL,
+		APIKey:  "test-key",
+		Model:   "gpt-5.5",
+		APIType: "openai-chat",
+	})
+	if ok, _ := got["ok"].(bool); !ok {
+		t.Fatalf("runProviderTest ok = false, got %#v", got)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}


### PR DESCRIPTION
Support OpenAI chat models that require `max_completion_tokens` or default-only temperature settings.

Test plan:
- [x] `go test ./internal/provider ./internal/setup ./internal/agent`
- [x] `go test ./...`
