### PR TITLE
fix(skills): resolve {baseDir} to in-container path so skill scripts run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+Notable changes to FastClaw. Items marked **BREAKING** require operator
+action on upgrade — read those notes before deploying.
+
+## [Unreleased]
+
+### Fixed
+
+- **Cron jobs fired ~hours late on Postgres when the server ran in a
+  non-UTC timezone.** The `cron_jobs` time columns were declared
+  `TIMESTAMP WITHOUT TIME ZONE`. A Go `time.Time` carrying a non-UTC
+  offset (e.g. `Asia/Shanghai`) was written with its offset silently
+  dropped, so a Beijing "09:00" job was stored as `09:00` and read back
+  as `09:00 UTC` = `17:00 Beijing` — firing 8h late (or, in the opposite
+  direction, never matching `next_run <= now()` at all). SQLite was
+  unaffected. The columns are now `TIMESTAMPTZ`, which preserves the
+  instant across write/read regardless of offset or session `TimeZone`.
+
+### BREAKING — cron schedule state is reset on upgrade (Postgres only)
+
+When a Postgres deployment runs the schema migration for the first time,
+**every existing row in `cron_jobs` is deleted.** This is deliberate:
+the stored `next_run` wall-clocks already carry the wrong timezone, so
+converting them would freeze the bug into the new column type. A clean
+reschedule is the correct recovery.
+
+- **What is lost:** pending scheduled jobs (recurring `cron`, `interval`,
+  and not-yet-fired `once` reminders).
+- **What is NOT lost:** chat history (`sessions`, `session_messages`),
+  agent identity files, provider/channel config — none of these are
+  touched.
+- **Operator action required:** after upgrading, any recurring schedule
+  a user relies on (e.g. "every day at 9am") must be recreated by asking
+  the agent again, or via the dashboard's Scheduler tab. The original
+  `create_cron_job` tool calls are still visible in chat history and can
+  serve as a reference for what to rebuild.
+- **Visibility:** the gateway logs a single
+  `level=WARN msg="resetting cron schedule state for timestamptz migration …"`
+  line with the row count before wiping, so operators can tell from the
+  upgrade log whether any jobs were affected.
+- **SQLite deployments:** unaffected — the migration is skipped entirely.
+- **Idempotent:** re-running the migration (e.g. on every daemon boot)
+  is a no-op once the columns are already `timestamptz`.

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -311,7 +311,7 @@ func NewAgentWithSkillsCfg(rc config.ResolvedAgent, prov provider.Provider, mb *
 	// executor-pool failure would silently fall through to /bin/sh on the
 	// host, defeating the security boundary the user asked for.
 	skillDirs := loader.AllSkillDirs()
-	tools.RegisterLoadSkill(registry, skillDirs)
+	tools.RegisterLoadSkill(registry, skillDirs, loader.UserSkillsDir())
 	var sbCfg *tools.SandboxConfig
 	if rc.Sandbox.Enabled {
 		sbCfg = &tools.SandboxConfig{Enabled: true}
@@ -3322,7 +3322,7 @@ func (a *Agent) refreshSkillsFromStore(userID string) {
 	skills := loader.LoadSkills()
 	summary := loader.BuildSkillsSummary(skills)
 	a.ctxBuilder.SetSkillsSummary(summary)
-	tools.RegisterLoadSkill(a.registry, loader.AllSkillDirs())
+	tools.RegisterLoadSkill(a.registry, loader.AllSkillDirs(), loader.UserSkillsDir())
 	// Per-turn fingerprint of the skill set the system prompt will
 	// ship. Lets us diff IM vs web for the same (agent, chatter) and
 	// confirm — or rule out — that agent-scope skills are reaching
@@ -3356,7 +3356,7 @@ func (a *Agent) ReloadWorkspaceFiles() {
 	}
 	skills := loader.LoadSkills()
 	skillsSummary := loader.BuildSkillsSummary(skills)
-	tools.RegisterLoadSkill(a.registry, loader.AllSkillDirs())
+	tools.RegisterLoadSkill(a.registry, loader.AllSkillDirs(), loader.UserSkillsDir())
 	a.ctxBuilder = NewContextBuilder(a.homePath, a.memory, skillsSummary)
 	a.ctxBuilder.SetWorkspace(a.workspacePath)
 	a.ctxBuilder.SetPromptMode(a.promptMode)

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -164,53 +164,59 @@ func (a *Agent) SetSandboxPool(p sandbox.ExecutorPool) {
 	}
 }
 
-// bindSession wires per-turn session state into the tool registry: the
-// session-scoped sandbox executor (when a pool is configured), the
-// sessionID workspace.Store calls use to namespace artifacts, and the
-// (channel, accountID, chatID) bus address so deferred-work tools (create_cron_job)
-// can stamp it onto persisted rows for later replay. Called at the top
-// of HandleMessage / HandleMessageStream before any tool runs.
+// bindSession computes the per-turn scoping values (session/project ids,
+// coding-root/subdir) and binds a session-scoped sandbox executor when a
+// pool is configured. It returns a partially-populated TurnContext that
+// the caller enriches with chatter/admin/goalKey and attaches to ctx via
+// tools.WithTurnContext.
 //
-// Mutating the shared registry across concurrent chats would race, but
-// the current invariant is one chat-in-flight per agent — the gateway
-// serializes per-agent turns. Documenting it here in case that changes.
-func (a *Agent) bindSession(ctx context.Context, channel, accountID, sessionID, projectID string) {
-	a.registry.SetSessionID(sessionID)
-	a.registry.SetProjectID(projectID)
-	// Coding agents (those with a project runtime wired) treat a project
-	// as ONE shared app tree: file tools address the project root so the
-	// agent's edits land where the dev server serves. Only when actually
-	// inside a project; loose chats and non-coding agents are unaffected.
-	a.registry.SetCodingRootScope(a.projectRuntime != nil && projectID != "")
+// Per-turn state is NO LONGER written to shared Registry fields — that
+// was the race surface when two turns overlapped on one agent (public
+// agents, cron + live chat, …). The sandbox executor bind still goes
+// through SetExecutor because it re-registers the sandboxed tool closures
+// with the session's container; those closures read their per-turn
+// scoping from ctx at call time, so the bind itself is safe to keep on
+// the registry.
+func (a *Agent) bindSession(ctx context.Context, channel, accountID, sessionID, projectID string) *tools.TurnContext {
+	tc := &tools.TurnContext{
+		SessionID: sessionID,
+		ProjectID: projectID,
+		// Coding agents (those with a project runtime wired) treat a
+		// project as ONE shared app tree: file tools address the project
+		// root so the agent's edits land where the dev server serves.
+		// Only when actually inside a project; loose chats and non-coding
+		// agents are unaffected.
+		CodingRootScope: a.projectRuntime != nil && projectID != "",
+		Channel:         channel,
+		AccountID:       accountID,
+		ChatID:          sessionID,
+	}
 	// If this scope already has a running app (a runtime record exists),
 	// redirect file tools into its app subfolder so edits keep landing
 	// where the dev server serves — across turns, not just the turn that
-	// called start_app_preview. EffectiveUserID is the owner here
-	// (chatter is bound later), which is correct for the web-direct case.
-	a.registry.SetCodingSubdir("")
-	if a.projectRuntime != nil {
-		if uid := a.registry.EffectiveUserID(); uid != "" {
-			if _, err := a.projectRuntime.Get(ctx, uid, a.name, projectID, sessionID); err == nil {
-				a.registry.SetCodingSubdir(coderuntime.AppSubdir)
-			}
+	// called start_app_preview. The owner id (a.ownerUserID) is the right
+	// scope key here; chatter is bound later but the project runtime is
+	// owned by the agent owner regardless of who's chatting.
+	if a.projectRuntime != nil && a.ownerUserID != "" {
+		if _, err := a.projectRuntime.Get(ctx, a.ownerUserID, a.name, projectID, sessionID); err == nil {
+			tc.CodingSubdir = coderuntime.AppSubdir
 		}
 	}
-	a.registry.SetMessageContext(channel, accountID, sessionID)
-	if a.sandboxPool == nil {
-		return
+	if a.sandboxPool != nil {
+		ex, err := a.sandboxPool.Get(ctx, a.name, projectID, sessionID)
+		if err != nil {
+			// Error level (not warn) — when sandbox is required and we
+			// can't bind, the next exec call will refuse with the
+			// "sandboxRequired but no executor" message; log here so the
+			// upstream cause (docker daemon down, image pull failed, …) is
+			// captured next to the user-facing error.
+			slog.Error("sandbox executor unavailable; exec will refuse host fallback",
+				"agent", a.name, "session", sessionID, "error", err)
+		} else {
+			a.registry.SetExecutor(ex)
+		}
 	}
-	ex, err := a.sandboxPool.Get(ctx, a.name, projectID, sessionID)
-	if err != nil {
-		// Error level (not warn) — when sandbox is required and we
-		// can't bind, the next exec call will refuse with the
-		// "sandboxRequired but no executor" message; log here so the
-		// upstream cause (docker daemon down, image pull failed, …) is
-		// captured next to the user-facing error.
-		slog.Error("sandbox executor unavailable; exec will refuse host fallback",
-			"agent", a.name, "session", sessionID, "error", err)
-		return
-	}
-	a.registry.SetExecutor(ex)
+	return tc
 }
 
 // NewAgent creates a new Agent from a resolved config.
@@ -1914,21 +1920,26 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 	// + writes get session-scoped paths and (when a sandbox pool is
 	// wired) the executor used by exec/read_file/list_dir is tied to a
 	// session-private container.
-	a.bindSession(ctx, msg.Channel, msg.AccountID, msg.ChatID, msg.ProjectID)
-	// Flag whether this turn's chatter is the agent owner / channel
-	// admin. File tools use this to refuse identity-file reads from
-	// regular chatters (SOUL/IDENTITY/BOOTSTRAP/... leak as verbatim
-	// chat replies otherwise).
-	a.registry.SetCallerIsAdmin(a.isAdminChatter(msg))
-	// Plumb the persistent session_key for goal-scoped tools.
-	// SetSessionID above uses msg.ChatID (the channel-level chat
-	// identifier); goal tools need the durable session.Session.SessionKey
-	// to address rows in agent_goals.
-	a.registry.SetGoalSessionKey(sess.SessionKey())
+	// Build the per-turn TurnContext and attach it to ctx. All per-turn
+	// tool state (session/project scoping, message address for cron
+	// replay, chatter for per-user files, admin flag for identity-file
+	// gates, goal session key) now flows through ctx instead of mutating
+	// shared Registry fields — so two concurrent turns on the same agent
+	// (public agents, cron + live chat, …) cannot race on that state.
+	// Named `turn` (not `tc`) to avoid shadowing the loop-local `tc`
+	// iteration variable used for provider.ToolCall throughout the ReAct
+	// loop below.
+	turn := a.bindSession(ctx, msg.Channel, msg.AccountID, msg.ChatID, msg.ProjectID)
+	turn.CallerIsAdmin = a.isAdminChatter(msg)
+	// Goal tools need the durable session.Session.SessionKey (distinct
+	// from msg.ChatID, the channel-level chat identifier) to address rows
+	// in agent_goals.
+	turn.GoalSessionKey = sess.SessionKey()
 	// Per-user file writes (USER.md / MEMORY.md) need to land in the
 	// per-turn chatter's row, not the UserSpace owner — see
 	// Registry.systemFileUserID for the routing rule.
-	a.registry.SetChatterUserID(chatterUID)
+	turn.ChatterUserID = chatterUID
+	ctx = tools.WithTurnContext(ctx, turn)
 
 	// Steering: mark a turn in-flight so messages arriving mid-run are
 	// buffered onto the session (drained between tool iterations below)
@@ -2089,7 +2100,7 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 		})
 
 		// Hook: AfterModelCall
-		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID, GoalSessionKey: a.registry.GoalSessionKey()}
+		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID, GoalSessionKey: turn.GoalSessionKey}
 		a.hooks.Run(ctx, hcAfter)
 
 		if err != nil {
@@ -2294,7 +2305,7 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 				AccountID:      msg.AccountID,
 				ChatID:         msg.ChatID,
 				UserID:         a.ownerUserID,
-				GoalSessionKey: a.registry.GoalSessionKey(),
+				GoalSessionKey: turn.GoalSessionKey,
 				IsPlanMode:     isPlanMode(msg.Params),
 				Source:         msg.Source,
 			})
@@ -2568,7 +2579,7 @@ func (a *Agent) runPostTurn(ctx context.Context, msg bus.InboundMessage, message
 		AccountID:      msg.AccountID,
 		ChatID:         msg.ChatID,
 		Source:         msg.Source,
-		GoalSessionKey: a.registry.GoalSessionKey(),
+		GoalSessionKey: a.registry.GoalSessionKeyFromCtx(ctx),
 		IsPlanMode:     isPlanMode(msg.Params),
 	})
 
@@ -2668,13 +2679,16 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 		prov, mdl := provider.SplitProviderModel(a.model)
 		sess.SetProviderModel(prov, mdl)
 	}
-	a.bindSession(ctx, msg.Channel, msg.AccountID, msg.ChatID, msg.ProjectID)
-	a.registry.SetCallerIsAdmin(a.isAdminChatter(msg))
-	a.registry.SetGoalSessionKey(sess.SessionKey())
-	// Per-user file writes (USER.md / MEMORY.md) need to land in the
-	// per-turn chatter's row, not the UserSpace owner — see
-	// Registry.systemFileUserID for the routing rule.
-	a.registry.SetChatterUserID(chatterUID)
+	// Build the per-turn TurnContext and attach it to ctx (mirrors
+	// HandleMessage): per-turn tool state flows through ctx, not shared
+	// Registry fields, so concurrent turns on the same agent can't race.
+	// Named `turn` (not `tc`) to avoid shadowing the loop-local `tc`
+	// iteration variable used for provider.ToolCall in the streaming loop.
+	turn := a.bindSession(ctx, msg.Channel, msg.AccountID, msg.ChatID, msg.ProjectID)
+	turn.CallerIsAdmin = a.isAdminChatter(msg)
+	turn.GoalSessionKey = sess.SessionKey()
+	turn.ChatterUserID = chatterUID
+	ctx = tools.WithTurnContext(ctx, turn)
 
 	// Same orphan-tool_use safety net as HandleMessage. The streaming path
 	// previously lacked this, so loop detection (which appends an assistant
@@ -2744,7 +2758,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 			return a.provider.Chat(ctx, messages, toolDefs, a.model, a.maxTokens, a.temperature)
 		})
 
-		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID, GoalSessionKey: a.registry.GoalSessionKey()}
+		hcAfter := &HookContext{AgentName: a.name, Point: AfterModelCall, Messages: messages, Response: resp, Error: err, StartTime: hcBefore.StartTime, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID, GoalSessionKey: turn.GoalSessionKey}
 		a.hooks.Run(ctx, hcAfter)
 
 		if err != nil {
@@ -2891,7 +2905,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 		for idx, r := range results {
 			tc := resp.ToolCalls[idx]
 			resultContent, meta := extractToolMeta(r.result)
-			a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: AfterToolCall, ToolName: r.toolName, ToolResult: resultContent, Error: r.err, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID, GoalSessionKey: a.registry.GoalSessionKey(), IsPlanMode: isPlanMode(msg.Params), Source: msg.Source})
+			a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: AfterToolCall, ToolName: r.toolName, ToolResult: resultContent, Error: r.err, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID, GoalSessionKey: turn.GoalSessionKey, IsPlanMode: isPlanMode(msg.Params), Source: msg.Source})
 
 			if r.err != nil {
 				slog.Warn("tool execution error", "agent", a.name, "name", r.toolName, "error", r.err)

--- a/internal/agent/prompt_modules.go
+++ b/internal/agent/prompt_modules.go
@@ -498,6 +498,13 @@ You have access to a sandbox environment for executing code. Key rules:
                                     so the next sandbox start picks it up). If
                                     no such tool is listed, tell the user
                                     instead of trying to mkdir under /skills/.
+- /root/.agents/skills/<name>/    ← your PER-USER skills live here. When a skill
+                                    was created by you mid-chat (or installed via
+                                    ` + "`npx skills add -g -y`" + `), its scripts are mounted HERE,
+                                    read-write — NOT under /skills/. So if you
+                                    cannot find a skill's scripts under /skills/<name>/,
+                                    look under /root/.agents/skills/<name>/ before
+                                    concluding they are missing.
 - Host paths (anything starting with /Users/, /home/, /var/, etc.) DO NOT EXIST in the sandbox. Never reference them.
 
 ## Shell quirks

--- a/internal/agent/runtime_tools.go
+++ b/internal/agent/runtime_tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/fastclaw-ai/fastclaw/internal/agent/tools"
 	coderuntime "github.com/fastclaw-ai/fastclaw/internal/runtime"
 )
 
@@ -57,15 +58,15 @@ func (a *Agent) registerProjectRuntimeTools() {
 			if a.projectRuntime == nil {
 				return "App preview is not enabled on this deployment.", nil
 			}
-			userID := reg.EffectiveUserID()
+			userID := reg.EffectiveUserIDFromCtx(ctx)
 			if userID == "" {
 				return "", fmt.Errorf("start_app_preview: no user resolved for this turn")
 			}
 			// Home the app in the project when there is one, else in this
 			// chat's own session workspace — so a preview works without a
 			// pre-created project.
-			projectID := reg.ProjectID()
-			sessionID := reg.SessionID()
+			projectID := reg.ProjectIDFromCtx(ctx)
+			sessionID := reg.SessionIDFromCtx(ctx)
 			if projectID == "" && sessionID == "" {
 				return "", fmt.Errorf("start_app_preview: no project or chat session to home the app in")
 			}
@@ -83,8 +84,12 @@ func (a *Agent) registerProjectRuntimeTools() {
 			}
 			// Redirect this turn's file tools into the app subfolder so the
 			// agent's edits land where the dev server serves (subsequent
-			// turns get this from bindSession).
-			reg.SetCodingSubdir(coderuntime.AppSubdir)
+			// turns get this from bindSession). Done by re-attaching an
+			// updated TurnContext to ctx — mutating a shared registry field
+			// here would race with concurrent turns on the same agent.
+			if tc := tools.FromContext(ctx); tc != nil {
+				tc.CodingSubdir = coderuntime.AppSubdir
+			}
 			return fmt.Sprintf(
 				"Preview is live: %s (status: %s, template: %s).\n"+
 					"The app lives in the `%s/` folder of the workspace. Your file tools are already "+
@@ -113,9 +118,9 @@ func (a *Agent) registerProjectRuntimeTools() {
 			if a.projectRuntime == nil {
 				return "App preview is not enabled on this deployment.", nil
 			}
-			userID := reg.EffectiveUserID()
-			projectID := reg.ProjectID()
-			sessionID := reg.SessionID()
+			userID := reg.EffectiveUserIDFromCtx(ctx)
+			projectID := reg.ProjectIDFromCtx(ctx)
+			sessionID := reg.SessionIDFromCtx(ctx)
 			if projectID == "" && sessionID == "" {
 				return "No project or chat session, so there's no preview to read logs from.", nil
 			}

--- a/internal/agent/skills.go
+++ b/internal/agent/skills.go
@@ -478,6 +478,15 @@ func (sl *SkillsLoader) allSkillDirs() []string {
 	return dirs
 }
 
+// UserSkillsDir returns the chatter's per-user skills host directory
+// (~/.fastclaw/users/<uid>/skills), or "" when there is no per-user layer.
+// Exported so load_skill can map a per-user skill's {baseDir} placeholder to
+// its in-container mount path /root/.agents/skills/<name> instead of the
+// default /skills/<name> used by per-agent / managed skills.
+func (sl *SkillsLoader) UserSkillsDir() string {
+	return sl.userSkillsDir()
+}
+
 // userSkillsDir returns ~/.fastclaw/users/<uid>/skills (FASTCLAW_HOME-aware).
 // Empty when no userID is set so the loader skips the layer entirely on
 // single-user installs / legacy paths.

--- a/internal/agent/tools/apply_patch.go
+++ b/internal/agent/tools/apply_patch.go
@@ -490,11 +490,11 @@ type applyPatchArgs struct {
 // -----------------------------------------------------------------------------
 
 func (r *Registry) readForPatch(ctx context.Context, path string) (string, error) {
-	if r.identityFileBlocked(path) {
+	if r.identityFileBlocked(ctx, path) {
 		return "", fmt.Errorf("%s", IdentityFileRefusal)
 	}
 	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
-		rc, err := r.workspaceStore.Get(ctx, r.agentID, r.projectID, r.sessionID, path)
+		rc, err := r.workspaceStore.Get(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), path)
 		if err != nil {
 			return "", fmt.Errorf("workspace get: %w", err)
 		}
@@ -507,7 +507,7 @@ func (r *Registry) readForPatch(ctx context.Context, path string) (string, error
 	}
 	if r.systemFileStore != nil && r.agentID != "" && basenameIsSystemFile(path) {
 		name := filepath.Base(filepath.Clean(path))
-		if data, err := r.readSystemFileForUser(ctx, r.systemFileUserID(name), name); err == nil {
+		if data, err := r.readSystemFileForUser(ctx, r.systemFileUserID(ctx, name), name); err == nil {
 			return string(data), nil
 		}
 		if r.systemRoot != "" {
@@ -533,16 +533,16 @@ func (r *Registry) readForPatch(ctx context.Context, path string) (string, error
 }
 
 func (r *Registry) writeForPatch(ctx context.Context, path, content string) error {
-	if r.identityFileBlocked(path) {
+	if r.identityFileBlocked(ctx, path) {
 		return fmt.Errorf("%s", IdentityFileRefusal)
 	}
 	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
-		return r.workspaceStore.Put(ctx, r.agentID, r.projectID, r.sessionID, path,
+		return r.workspaceStore.Put(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), path,
 			strings.NewReader(content), int64(len(content)), "")
 	}
 	if r.systemFileStore != nil && r.agentID != "" && isSingleSegmentSystemFile(path) {
 		name := filepath.Clean(path)
-		if err := r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(name), name, []byte(content)); err != nil {
+		if err := r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(ctx, name), name, []byte(content)); err != nil {
 			return err
 		}
 		// Mirror to disk so this pod's in-process readers (context builder,
@@ -578,7 +578,7 @@ func (r *Registry) deleteForPatch(ctx context.Context, path string) error {
 		return fmt.Errorf("apply_patch: refusing to delete identity file %q (use Update File with empty content instead)", path)
 	}
 	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
-		return r.workspaceStore.Delete(ctx, r.agentID, r.projectID, r.sessionID, path)
+		return r.workspaceStore.Delete(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), path)
 	}
 	root := r.rootForPath(path)
 	full, err := resolvePathSandboxed(root, r.effectiveSandboxRoot(root), path)
@@ -598,13 +598,13 @@ func (r *Registry) deleteForPatch(ctx context.Context, path string) error {
 func (r *Registry) readForPatchSandbox(ctx context.Context, ex sandbox.Executor, path string) (string, error) {
 	if r.systemFileStore != nil && r.agentID != "" && basenameIsSystemFile(path) {
 		name := filepath.Base(filepath.Clean(path))
-		if data, err := r.readSystemFileForUser(ctx, r.systemFileUserID(name), name); err == nil {
+		if data, err := r.readSystemFileForUser(ctx, r.systemFileUserID(ctx, name), name); err == nil {
 			return string(data), nil
 		}
 		return "", nil
 	}
 	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
-		rc, err := r.workspaceStore.Get(ctx, r.agentID, r.projectID, r.sessionID, path)
+		rc, err := r.workspaceStore.Get(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), path)
 		if err == nil {
 			defer rc.Close()
 			data, readErr := io.ReadAll(rc)
@@ -620,10 +620,10 @@ func (r *Registry) readForPatchSandbox(ctx context.Context, ex sandbox.Executor,
 func (r *Registry) writeForPatchSandbox(ctx context.Context, ex sandbox.Executor, path, content string) error {
 	if r.systemFileStore != nil && r.agentID != "" && isSingleSegmentSystemFile(path) {
 		name := filepath.Clean(path)
-		return r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(name), name, []byte(content))
+		return r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(ctx, name), name, []byte(content))
 	}
 	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
-		return r.workspaceStore.Put(ctx, r.agentID, r.projectID, r.sessionID, path,
+		return r.workspaceStore.Put(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), path,
 			strings.NewReader(content), int64(len(content)), "")
 	}
 	_, err := ex.WriteFile(ctx, path, content)
@@ -635,7 +635,7 @@ func (r *Registry) deleteForPatchSandbox(ctx context.Context, ex sandbox.Executo
 		return fmt.Errorf("apply_patch: refusing to delete identity file %q (use Update File with empty content instead)", path)
 	}
 	if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(path) {
-		return r.workspaceStore.Delete(ctx, r.agentID, r.projectID, r.sessionID, path)
+		return r.workspaceStore.Delete(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), path)
 	}
 	// Sandbox executor exposes no Delete API; fall back to `rm`. Single-quote
 	// the path and escape embedded single quotes so a pathological filename

--- a/internal/agent/tools/bash_session.go
+++ b/internal/agent/tools/bash_session.go
@@ -12,6 +12,15 @@ package tools
 //   - tail-only observation; no send-keys / paste / interactive control
 //     (those use cases route through tmux invoked from regular `exec`)
 //   - sessions are agent-private and live until killed or Registry.Close
+//
+// Multi-tenant isolation: every session is stamped with the ownerKey passed
+// to Start (a deterministic fold of agentID + chatterUserID + sessionKey —
+// the same identity tuple workspace.Store namespaces by). Get then refuses
+// cross-owner reads/writes, so a chatter who guesses another's bash_id
+// (the ids are a monotonic sequence bash_1, bash_2, …) cannot read that
+// session's stdout/stderr or kill its process. An empty ownerKey means
+// "no tenancy boundary enforced" — used by boot/admin paths that run
+// outside any chat (no chatter to isolate against) and by legacy tests.
 
 import (
 	"context"
@@ -89,6 +98,7 @@ func (b *outputBuffer) readSince(since int) (out []byte, dropped bool, newSince 
 // needed to observe and terminate it.
 type bashSession struct {
 	id        string
+	owner     string // ownerKey stamped at Start; Get refuses mismatched callers
 	command   string
 	startedAt time.Time
 
@@ -167,7 +177,14 @@ func newShellManager() *shellManager {
 // session lives until kill or natural exit; the caller's ctx does NOT
 // propagate to the child — that ctx dies at turn end and would take
 // every backgrounded process with it.
-func (m *shellManager) Start(command string, env []string) (*bashSession, error) {
+//
+// ownerKey is stamped onto the session so Get can refuse cross-owner
+// access (multi-tenant isolation). Pass "" only when there is no chat-
+// level chatter to isolate against — boot/admin paths and tests that
+// don't model tenancy. Every chat-driven exec call must pass a real key
+// derived from (agentID, chatterUserID, sessionKey); see OwnerKeyFor in
+// turnctx.go for the canonical constructor.
+func (m *shellManager) Start(command string, env []string, ownerKey string) (*bashSession, error) {
 	if command == "" {
 		return nil, errors.New("command is required")
 	}
@@ -231,6 +248,7 @@ func (m *shellManager) Start(command string, env []string) (*bashSession, error)
 	id := fmt.Sprintf("bash_%d", m.counter)
 	s := &bashSession{
 		id:        id,
+		owner:     ownerKey,
 		command:   command,
 		startedAt: time.Now(),
 		cmd:       cmd,
@@ -266,11 +284,22 @@ func (m *shellManager) Start(command string, env []string) (*bashSession, error)
 	return s, nil
 }
 
-// Get fetches a session by bash_id, or nil if not found.
-func (m *shellManager) Get(id string) *bashSession {
+// Get fetches a session by bash_id. It returns nil — indistinguishable
+// from "no such id" — when ownerKey is non-empty and does not match the
+// session's owner, so a caller cannot probe whether a guessed bash_id
+// exists for someone else. An empty ownerKey skips the check (boot/admin
+// paths and legacy tests that run outside any chat tenancy).
+func (m *shellManager) Get(id, ownerKey string) *bashSession {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.shells[id]
+	s := m.shells[id]
+	if s == nil {
+		return nil
+	}
+	if ownerKey != "" && s.owner != ownerKey {
+		return nil
+	}
+	return s
 }
 
 // Close kills every live session, clears the registry, and refuses any

--- a/internal/agent/tools/bash_session_owner_test.go
+++ b/internal/agent/tools/bash_session_owner_test.go
@@ -1,0 +1,159 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestShellManager_OwnerIsolation guards the cross-tenant leak fixed by
+// stamping an ownerKey on every background shell: a Get with a different
+// ownerKey must return nil, indistinguishable from "no such id", so a
+// chatter who guesses another's bash_id cannot read its output or kill
+// its process.
+func TestShellManager_OwnerIsolation(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+
+	ownerA := OwnerKeyFor("ag_1", "u_alice", "s-aaa")
+	ownerB := OwnerKeyFor("ag_1", "u_bob", "s-bbb")
+
+	// Alice starts a shell printing a secret.
+	sA, err := m.Start("printf 'alice-secret\\n'", nil, ownerA)
+	if err != nil {
+		t.Fatalf("alice start: %v", err)
+	}
+	waitDone(t, sA, 2*time.Second)
+
+	// Bob starts an unrelated shell.
+	sB, err := m.Start("printf 'bob-secret\\n'", nil, ownerB)
+	if err != nil {
+		t.Fatalf("bob start: %v", err)
+	}
+	waitDone(t, sB, 2*time.Second)
+
+	// Same owner can read its own shell.
+	if got := m.Get(sA.id, ownerA); got == nil {
+		t.Fatalf("alice cannot read her own shell %s", sA.id)
+	} else {
+		out, _ := got.readNew()
+		if !strings.Contains(string(out), "alice-secret") {
+			t.Errorf("alice got wrong output: %q", out)
+		}
+	}
+
+	// Cross-owner read must be refused — nil, like "no such id".
+	if got := m.Get(sA.id, ownerB); got != nil {
+		t.Errorf("SECURITY: bob read alice's shell %s — owner isolation broken", sA.id)
+	}
+	if got := m.Get(sB.id, ownerA); got != nil {
+		t.Errorf("SECURITY: alice read bob's shell %s — owner isolation broken", sB.id)
+	}
+
+	// A guessed id that doesn't exist also returns nil (parity — caller
+	// can't tell "exists but not yours" from "doesn't exist").
+	if got := m.Get("bash_999", ownerA); got != nil {
+		t.Errorf("nonexistent id returned non-nil: %v", got)
+	}
+}
+
+// TestShellManager_OwnerIsolation_Kill confirms a cross-owner kill_shell
+// is also refused (not just reads). Mirrors the Get gate the kill tool
+// relies on.
+func TestShellManager_OwnerIsolation_Kill(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+
+	ownerA := OwnerKeyFor("ag_1", "u_alice", "s-aaa")
+	ownerB := OwnerKeyFor("ag_1", "u_bob", "s-bbb")
+
+	// Alice starts a long-running shell.
+	sA, err := m.Start("sleep 30", nil, ownerA)
+	if err != nil {
+		t.Fatalf("alice start: %v", err)
+	}
+	defer sA.kill()
+
+	// Bob must not be able to resolve (and thus kill) Alice's shell.
+	if got := m.Get(sA.id, ownerB); got != nil {
+		t.Errorf("SECURITY: bob resolved alice's shell for kill — isolation broken")
+	}
+	// Alice can.
+	if got := m.Get(sA.id, ownerA); got == nil {
+		t.Errorf("alice cannot resolve her own shell for kill")
+	}
+}
+
+// TestShellManager_EmptyOwnerKeySkipsGate documents the opt-out: an empty
+// ownerKey means "no chat tenancy" (boot/admin paths, legacy tests) and
+// must NOT block access. Without this, boot-driven exec would be locked
+// out of shells it legitimately owns.
+func TestShellManager_EmptyOwnerKeySkipsGate(t *testing.T) {
+	m := newShellManager()
+	defer m.Close()
+
+	s, err := m.Start("printf 'boot\\n'", nil, "some-owner")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitDone(t, s, 2*time.Second)
+
+	// Empty ownerKey bypasses the check even though the shell was
+	// started with a real owner — this is the boot/admin escape hatch.
+	if got := m.Get(s.id, ""); got == nil {
+		t.Errorf("empty ownerKey should bypass isolation but got nil")
+	}
+}
+
+// TestBashOutput_CrossTenantRefused exercises the full tool path
+// (registerBashOutput → shellManager.Get) to confirm the ownerKey is
+// plumbed from TurnContext through to the gate, closing the real
+// attack: a chatter reading another's shell via the bash_output tool.
+func TestBashOutput_CrossTenantRefused(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+	defer r.Close()
+	r.agentID = "ag_1"
+
+	// Alice starts a shell in her turn context.
+	ctxAlice := WithTurnContext(context.Background(), &TurnContext{
+		ChatterUserID: "u_alice",
+		SessionID:     "s-aaa",
+	})
+	// Drive Start through the exec tool so the ownerKey wiring is the
+	// real production path (not a direct shellMgr.Start call).
+	execArgs := `{"command":"printf 'alice-secret\\n'","run_in_background":true}`
+	if _, err := r.Execute(ctxAlice, "exec", execArgs); err != nil {
+		t.Fatalf("alice exec: %v", err)
+	}
+	// The only shell belongs to alice → bash_1.
+	sA := r.shellMgr.Get("bash_1", OwnerKeyFor("ag_1", "u_alice", "s-aaa"))
+	if sA == nil {
+		t.Fatalf("alice's shell not found as bash_1")
+	}
+	waitDone(t, sA, 2*time.Second)
+
+	// Bob tries to read it from his own turn context — must be refused.
+	ctxBob := WithTurnContext(context.Background(), &TurnContext{
+		ChatterUserID: "u_bob",
+		SessionID:     "s-bbb",
+	})
+	args := `{"bash_id":"bash_1"}`
+	got, err := r.Execute(ctxBob, "bash_output", args)
+	if err == nil {
+		t.Errorf("SECURITY: bob read alice's shell without error: %q", got)
+	}
+	if err != nil && !strings.Contains(err.Error(), "no such bash_id") {
+		t.Errorf("expected 'no such bash_id' refusal, got err: %q", err.Error())
+	}
+	if strings.Contains(got, "alice-secret") || (err != nil && strings.Contains(err.Error(), "alice-secret")) {
+		t.Errorf("SECURITY: alice's output leaked to bob: result=%q err=%q", got, err)
+	}
+
+	// Alice can still read her own shell through the tool.
+	if got, err := r.Execute(ctxAlice, "bash_output", args); err != nil {
+		t.Errorf("alice failed to read her own shell: %v", err)
+	} else if !strings.Contains(got, "alice-secret") {
+		t.Errorf("alice didn't get her own output: %q", got)
+	}
+}

--- a/internal/agent/tools/bash_session_test.go
+++ b/internal/agent/tools/bash_session_test.go
@@ -118,7 +118,7 @@ func TestShellManager_EchoExitsZero(t *testing.T) {
 	m := newShellManager()
 	defer m.Close()
 
-	s, err := m.Start("echo hello", nil)
+	s, err := m.Start("echo hello", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestShellManager_EchoExitsZero(t *testing.T) {
 func TestShellManager_NonZeroExitCodePreserved(t *testing.T) {
 	m := newShellManager()
 	defer m.Close()
-	s, err := m.Start("exit 42", nil)
+	s, err := m.Start("exit 42", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestShellManager_NonZeroExitCodePreserved(t *testing.T) {
 func TestShellManager_KillTerminatesRunning(t *testing.T) {
 	m := newShellManager()
 	defer m.Close()
-	s, err := m.Start("sleep 10", nil)
+	s, err := m.Start("sleep 10", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestShellManager_KillReachesGrandchildren(t *testing.T) {
 	// `sh -c "sleep 30 & wait"` — the shell forks `sleep`, then waits
 	// on it. Without group kill, killing the shell leaves `sleep`
 	// behind. With group kill, both go.
-	s, err := m.Start("sleep 30 & echo started; wait", nil)
+	s, err := m.Start("sleep 30 & echo started; wait", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestShellManager_KillReachesGrandchildren(t *testing.T) {
 func TestShellManager_KillIsIdempotentOnExited(t *testing.T) {
 	m := newShellManager()
 	defer m.Close()
-	s, err := m.Start("true", nil)
+	s, err := m.Start("true", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestShellManager_IncrementalReadAdvancesCursor(t *testing.T) {
 	m := newShellManager()
 	defer m.Close()
 	// Two outputs separated by a sleep so we can read between them.
-	s, err := m.Start("echo first; sleep 0.15; echo second", nil)
+	s, err := m.Start("echo first; sleep 0.15; echo second", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -281,7 +281,7 @@ func TestShellManager_CloseKillsAllSessions(t *testing.T) {
 	// and pass the assertion regardless of whether kills actually fired.
 	captured := make([]*bashSession, 0, 3)
 	for i := 0; i < 3; i++ {
-		s, err := m.Start("sleep 30", nil)
+		s, err := m.Start("sleep 30", nil, "")
 		if err != nil {
 			t.Fatalf("start: %v", err)
 		}
@@ -315,7 +315,7 @@ func TestShellManager_CloseKillsAllSessions(t *testing.T) {
 func TestShellManager_StartAfterCloseRefuses(t *testing.T) {
 	m := newShellManager()
 	m.Close()
-	s, err := m.Start("echo nope", nil)
+	s, err := m.Start("echo nope", nil, "")
 	if err == nil {
 		t.Errorf("Start after Close should error, got session %v", s)
 	}
@@ -334,7 +334,7 @@ func TestBashOutputTool_DrainsTailOnExit(t *testing.T) {
 	// Print a sentinel just before exit so we can detect the loss case
 	// directly: a successful drain MUST yield the sentinel together
 	// with the "exited" status line.
-	s, err := r.shellMgr.Start("printf 'tail-sentinel\\n'", nil)
+	s, err := r.shellMgr.Start("printf 'tail-sentinel\\n'", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestBashOutputTool_FilterRegex(t *testing.T) {
 	r := NewRegistry(t.TempDir(), t.TempDir())
 	defer r.Close()
 
-	s, err := r.shellMgr.Start("printf 'INFO: ok\\nERROR: boom\\nINFO: done\\n'", nil)
+	s, err := r.shellMgr.Start("printf 'INFO: ok\\nERROR: boom\\nINFO: done\\n'", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestBashOutputTool_UnknownIDErrors(t *testing.T) {
 func TestKillShellTool_AlreadyExited(t *testing.T) {
 	r := NewRegistry(t.TempDir(), t.TempDir())
 	defer r.Close()
-	s, err := r.shellMgr.Start("true", nil)
+	s, err := r.shellMgr.Start("true", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -415,7 +415,7 @@ func TestKillShellTool_AlreadyExited(t *testing.T) {
 func TestKillShellTool_TerminatesRunning(t *testing.T) {
 	r := NewRegistry(t.TempDir(), t.TempDir())
 	defer r.Close()
-	s, err := r.shellMgr.Start("sleep 30", nil)
+	s, err := r.shellMgr.Start("sleep 30", nil, "")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}

--- a/internal/agent/tools/bash_tools.go
+++ b/internal/agent/tools/bash_tools.go
@@ -61,7 +61,14 @@ func registerBashOutput(r *Registry) {
 		if r.shellMgr == nil {
 			return "", fmt.Errorf("bash_output: shell manager not initialised")
 		}
-		s := r.shellMgr.Get(args.BashID)
+		// Enforce the same chat-tenancy boundary Start stamped: a shell
+		// started by one chatter is invisible to another. No TurnContext
+		// (boot/admin) → ownerKey "" skips the check, matching legacy.
+		ownerKey := ""
+		if tc := FromContext(ctx); tc != nil {
+			ownerKey = OwnerKeyFor(r.agentID, tc.ChatterUserID, tc.SessionID)
+		}
+		s := r.shellMgr.Get(args.BashID, ownerKey)
 		if s == nil {
 			return "", fmt.Errorf("bash_output: no such bash_id %q (call exec(run_in_background=true) first; ids are valid only within the same agent process)", args.BashID)
 		}
@@ -140,7 +147,13 @@ func registerKillShell(r *Registry) {
 		if r.shellMgr == nil {
 			return "", fmt.Errorf("kill_shell: shell manager not initialised")
 		}
-		s := r.shellMgr.Get(args.BashID)
+		// Same tenancy gate as bash_output — a chatter can only kill
+		// shells their own chat started. No TurnContext → no gate.
+		ownerKey := ""
+		if tc := FromContext(ctx); tc != nil {
+			ownerKey = OwnerKeyFor(r.agentID, tc.ChatterUserID, tc.SessionID)
+		}
+		s := r.shellMgr.Get(args.BashID, ownerKey)
 		if s == nil {
 			return "", fmt.Errorf("kill_shell: no such bash_id %q", args.BashID)
 		}

--- a/internal/agent/tools/billing.go
+++ b/internal/agent/tools/billing.go
@@ -29,15 +29,19 @@ func RegisterBillingTools(r *Registry, meter usage.Meter, quotaStore usage.Quota
 
 func makeGetBillingUsage(meter usage.Meter, quotaStore usage.QuotaStore, r *Registry) ToolFunc {
 	return func(ctx context.Context, _ json.RawMessage) (string, error) {
+		// Billing is charged to the account owner (boot-stable r.userID);
+		// the per-turn chatter (resolved from ctx) is reported for
+		// attribution. On IM channels with per-sender app_users these two
+		// differ, which is exactly why billing must NOT race on a shared
+		// per-turn field — each turn resolves its own chatter from ctx.
 		billingUserID := r.OwnerUserID()
+		chatterUserID := r.chatterFromCtx(ctx)
 		if billingUserID == "" {
-			billingUserID = r.EffectiveUserID()
+			billingUserID = chatterUserID
 		}
 		if billingUserID == "" {
 			return "", fmt.Errorf("billing user is not available in this chat context")
 		}
-
-		chatterUserID := r.ChatterUserID()
 		out := map[string]any{
 			"billingUserId": billingUserID,
 			"chatterUserId": chatterUserID,

--- a/internal/agent/tools/billing_test.go
+++ b/internal/agent/tools/billing_test.go
@@ -26,8 +26,11 @@ func TestGetBillingUsageWithQuota(t *testing.T) {
 
 	r := NewRegistry("", "")
 	r.SetOwnerUserID("owner-1")
-	r.SetChatterUserID("chatter-1")
 	RegisterBillingTools(r, meter, quota)
+
+	// Per-turn chatter now flows through TurnContext on ctx (the same
+	// path the agent loop uses), not a shared registry field.
+	ctx = WithTurnContext(ctx, &TurnContext{ChatterUserID: "chatter-1"})
 
 	got, err := r.Execute(ctx, "get_billing_usage", `{}`)
 	if err != nil {

--- a/internal/agent/tools/coding_scope_test.go
+++ b/internal/agent/tools/coding_scope_test.go
@@ -1,25 +1,42 @@
 package tools
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // codingRootScope must collapse the session segment so file tools address
 // the project root the dev server serves; off, it preserves per-chat
 // isolation. This is the invariant the coding-agent preview relies on.
+//
+// Per-turn scoping now flows through TurnContext on ctx (not shared
+// registry fields), so these tests attach a TurnContext to a background
+// ctx — the same path the agent loop uses — instead of mutating fields.
 func TestScopeSessionIDCodingRoot(t *testing.T) {
 	r := NewRegistry(t.TempDir(), t.TempDir())
-	r.SetSessionID("sess-123")
 
-	if got := r.scopeSessionID(); got != "sess-123" {
+	// Default mode: session segment preserved.
+	ctx := WithTurnContext(context.Background(), &TurnContext{
+		SessionID: "sess-123",
+	})
+	if got := r.scopeSessionID(ctx); got != "sess-123" {
 		t.Fatalf("default mode: want session segment preserved, got %q", got)
 	}
 
-	r.SetCodingRootScope(true)
-	if got := r.scopeSessionID(); got != "" {
+	// coding-root mode: session segment collapses to "".
+	ctx = WithTurnContext(context.Background(), &TurnContext{
+		SessionID:      "sess-123",
+		CodingRootScope: true,
+	})
+	if got := r.scopeSessionID(ctx); got != "" {
 		t.Fatalf("coding-root mode: want empty session segment, got %q", got)
 	}
 
-	r.SetCodingRootScope(false)
-	if got := r.scopeSessionID(); got != "sess-123" {
+	// Back to default: restored.
+	ctx = WithTurnContext(context.Background(), &TurnContext{
+		SessionID: "sess-123",
+	})
+	if got := r.scopeSessionID(ctx); got != "sess-123" {
 		t.Fatalf("after disabling: want session segment restored, got %q", got)
 	}
 }
@@ -28,11 +45,12 @@ func TestWsPathSubdirRedirect(t *testing.T) {
 	r := NewRegistry(t.TempDir(), t.TempDir())
 
 	// No subdir → passthrough.
-	if got := r.wsPath("src/x.tsx"); got != "src/x.tsx" {
+	ctx := context.Background()
+	if got := r.wsPath(ctx, "src/x.tsx"); got != "src/x.tsx" {
 		t.Fatalf("no subdir: want passthrough, got %q", got)
 	}
 
-	r.SetCodingSubdir("app")
+	ctxApp := WithTurnContext(context.Background(), &TurnContext{CodingSubdir: "app"})
 	cases := map[string]string{
 		"src/x.tsx":     "app/src/x.tsx", // bare path gets prefixed
 		"app/src/x.tsx": "app/src/x.tsx", // already-prefixed is idempotent
@@ -41,25 +59,30 @@ func TestWsPathSubdirRedirect(t *testing.T) {
 		"package.json":  "app/package.json",
 	}
 	for in, want := range cases {
-		if got := r.wsPath(in); got != want {
+		if got := r.wsPath(ctxApp, in); got != want {
 			t.Fatalf("wsPath(%q): want %q, got %q", in, want, got)
 		}
 	}
 
-	r.SetCodingSubdir("")
-	if got := r.wsPath("src/x.tsx"); got != "src/x.tsx" {
+	// Empty subdir → passthrough again.
+	if got := r.wsPath(ctx, "src/x.tsx"); got != "src/x.tsx" {
 		t.Fatalf("after disabling: want passthrough, got %q", got)
 	}
 }
 
+// EffectiveUserID now resolves the per-turn chatter from ctx, falling back
+// to the boot-time owner when no TurnContext is attached.
 func TestEffectiveUserIDFallback(t *testing.T) {
 	r := NewRegistry(t.TempDir(), t.TempDir())
 	r.SetOwnerUserID("owner-1")
-	if got := r.EffectiveUserID(); got != "owner-1" {
+
+	// No TurnContext → boot owner.
+	if got := r.EffectiveUserIDFromCtx(context.Background()); got != "owner-1" {
 		t.Fatalf("no chatter: want owner fallback, got %q", got)
 	}
-	r.SetChatterUserID("chatter-9")
-	if got := r.EffectiveUserID(); got != "chatter-9" {
+	// TurnContext with a chatter → chatter wins.
+	ctx := WithTurnContext(context.Background(), &TurnContext{ChatterUserID: "chatter-9"})
+	if got := r.EffectiveUserIDFromCtx(ctx); got != "chatter-9" {
 		t.Fatalf("with chatter: want chatter, got %q", got)
 	}
 }

--- a/internal/agent/tools/cron.go
+++ b/internal/agent/tools/cron.go
@@ -99,12 +99,13 @@ func makeCreateCronJob(st store.Store, r *Registry, userID, agentID string) Tool
 			jobType = "cron"
 		}
 
-		// Read the originating bus address at execute time — bindSession
-		// stamps it on every turn, so this captures the channel/chatID
-		// the user was on when they asked for the reminder.
-		channel := r.MessageChannel()
-		accountID := r.MessageAccountID()
-		chatID := r.MessageChatID()
+		// Read the originating bus address at execute time — the loop
+		// stamps it on every turn's TurnContext, so this captures the
+		// channel/chatID the user was on when they asked for the reminder.
+		tc := turnOrZero(ctx)
+		channel := tc.Channel
+		accountID := tc.AccountID
+		chatID := tc.ChatID
 
 		// The chatter's effective timezone governs how the schedule is
 		// read: zone-less 'once' datetimes and cron wall-clock fields
@@ -112,7 +113,7 @@ func makeCreateCronJob(st store.Store, r *Registry, userID, agentID string) Tool
 		// prompt's date line is rendered in), not the server's. The
 		// resolved name is frozen onto the row so the scheduler keeps
 		// evaluating recurrences in it even if the chatter later moves.
-		tzName := scope.Timezone(ctx, st, r.ChatterUserID(), agentID)
+		tzName := scope.Timezone(ctx, st, r.chatterFromCtx(ctx), agentID)
 		loc := scope.LoadLocationOrLocal(tzName)
 
 		id := generateUUID()

--- a/internal/agent/tools/cron_test.go
+++ b/internal/agent/tools/cron_test.go
@@ -21,9 +21,17 @@ func TestCreateCronJobPersistsMessageAccountID(t *testing.T) {
 
 	r := NewRegistry(t.TempDir(), t.TempDir())
 	r.SetOwnerUserID("user-1")
-	r.SetChatterUserID("user-1")
-	r.SetMessageContext("telegram", "dclaw_official_bot", "8169894742")
 	RegisterCronTools(r, db, "user-1", "agent-1")
+
+	// Per-turn message context (channel/account/chatID) + chatter now
+	// flow through TurnContext on ctx — the same path the agent loop
+	// uses — instead of shared registry fields.
+	ctx := WithTurnContext(context.Background(), &TurnContext{
+		Channel:       "telegram",
+		AccountID:     "dclaw_official_bot",
+		ChatID:        "8169894742",
+		ChatterUserID: "user-1",
+	})
 
 	args, err := json.Marshal(createCronJobArgs{
 		Name:     "telegram reminder",
@@ -35,7 +43,7 @@ func TestCreateCronJobPersistsMessageAccountID(t *testing.T) {
 		t.Fatalf("marshal args: %v", err)
 	}
 
-	if _, err := r.Execute(context.Background(), "create_cron_job", string(args)); err != nil {
+	if _, err := r.Execute(ctx, "create_cron_job", string(args)); err != nil {
 		t.Fatalf("create cron job: %v", err)
 	}
 

--- a/internal/agent/tools/exec.go
+++ b/internal/agent/tools/exec.go
@@ -169,7 +169,16 @@ func makeExecToolFull(r *Registry, sbCfg *SandboxConfig, envProvider SkillEnvPro
 				skillEnv = resolveSkillEnv(args.Command, envProvider, skillDirs)
 			}
 			sessEnv := buildSubprocessEnv(skillEnv)
-			s, err := r.shellMgr.Start(command, sessEnv)
+			// Stamp the shell with the calling chat's identity so
+			// bash_output / kill_shell from a different chat can't
+			// read or kill it (cross-tenant isolation). Falls back to
+			// "" (no isolation) when no TurnContext is attached — i.e.
+			// boot/admin paths with no chatter in flight.
+			ownerKey := ""
+			if tc := FromContext(ctx); tc != nil {
+				ownerKey = OwnerKeyFor(r.agentID, tc.ChatterUserID, tc.SessionID)
+			}
+			s, err := r.shellMgr.Start(command, sessEnv, ownerKey)
 			if err != nil {
 				return "", err
 			}

--- a/internal/agent/tools/file.go
+++ b/internal/agent/tools/file.go
@@ -485,19 +485,20 @@ func makeReadFile(r *Registry) ToolFunc {
 
 		// Identity-file confidentiality gate. A chatter who asks "show me
 		// your SOUL.md" must not get the verbatim persona spec back.
-		if r.identityFileBlocked(args.Path) {
+		if r.identityFileBlocked(ctx, args.Path) {
 			return IdentityFileRefusal, nil
 		}
 		// Skill-manifest gate. Same rationale for a bundled SKILL.md —
 		// the agent's IP, not for a chatter to pull verbatim.
-		if r.skillManifestBlocked(args.Path) {
+		if r.skillManifestBlocked(ctx, args.Path) {
 			return SkillManifestRefusal, nil
 		}
 
 		// Mirror makeWriteFile's routing: userRoot-destined paths go to the
 		// workspace store when one is configured.
 		if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(args.Path) {
-			rc, err := r.workspaceStore.Get(ctx, r.agentID, r.projectID, r.scopeSessionID(), r.wsPath(args.Path))
+			tc := turnOrZero(ctx)
+			rc, err := r.workspaceStore.Get(ctx, r.agentID, tc.ProjectID, r.scopeSessionID(ctx), r.wsPath(ctx, args.Path))
 			if err != nil {
 				return "", fmt.Errorf("workspace get: %w", err)
 			}
@@ -521,7 +522,7 @@ func makeReadFile(r *Registry) ToolFunc {
 		// reading from a workspace dir where identity files don't live.
 		if r.systemFileStore != nil && r.agentID != "" && basenameIsSystemFile(args.Path) {
 			name := filepath.Base(filepath.Clean(args.Path))
-			if data, err := r.readSystemFileForUser(ctx, r.systemFileUserID(name), name); err == nil {
+			if data, err := r.readSystemFileForUser(ctx, r.systemFileUserID(ctx, name), name); err == nil {
 				return string(data), nil
 			}
 			// Store miss: try the agent's systemRoot on disk directly,
@@ -581,7 +582,7 @@ func makeWriteFile(r *Registry) ToolFunc {
 
 		// Identity-file confidentiality gate — also blocks a chatter
 		// from REWRITING the agent's persona via prompt injection.
-		if r.identityFileBlocked(args.Path) {
+		if r.identityFileBlocked(ctx, args.Path) {
 			return IdentityFileRefusal, nil
 		}
 
@@ -590,7 +591,7 @@ func makeWriteFile(r *Registry) ToolFunc {
 		// filesystem because the memory store already covers their
 		// durability via a separate path.
 		if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(args.Path) {
-			if err := r.workspaceStore.Put(ctx, r.agentID, r.projectID, r.scopeSessionID(), r.wsPath(args.Path),
+			if err := r.workspaceStore.Put(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), r.wsPath(ctx, args.Path),
 				strings.NewReader(args.Content), int64(len(args.Content)), ""); err != nil {
 				if friendly := asIsDirToolError("write_file", args.Path, err); friendly != nil {
 					return "", friendly
@@ -607,7 +608,7 @@ func makeWriteFile(r *Registry) ToolFunc {
 		// systemFileStore when available.
 		if r.systemFileStore != nil && r.agentID != "" && isSingleSegmentSystemFile(args.Path) {
 			name := filepath.Clean(args.Path)
-			if err := r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(name), name, []byte(args.Content)); err != nil {
+			if err := r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(ctx, name), name, []byte(args.Content)); err != nil {
 				return "", fmt.Errorf("system file save: %w", err)
 			}
 			// Keep a filesystem mirror so the agent runtime (context
@@ -669,13 +670,13 @@ func makeEditFile(r *Registry) ToolFunc {
 		}
 
 		// Identity-file confidentiality gate.
-		if r.identityFileBlocked(args.Path) {
+		if r.identityFileBlocked(ctx, args.Path) {
 			return IdentityFileRefusal, nil
 		}
 		// Skill-manifest gate — block edits to a bundled SKILL.md for
 		// non-admin chatters (editing returns surrounding content + lets
 		// them tamper with the agent's IP). Owner edits skills via the UI.
-		if r.skillManifestBlocked(args.Path) {
+		if r.skillManifestBlocked(ctx, args.Path) {
 			return SkillManifestRefusal, nil
 		}
 
@@ -685,7 +686,7 @@ func makeEditFile(r *Registry) ToolFunc {
 		// the same backend or an edit could silently land in a different
 		// store than the one the agent later reads from.
 		if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(args.Path) {
-			rc, err := r.workspaceStore.Get(ctx, r.agentID, r.projectID, r.scopeSessionID(), r.wsPath(args.Path))
+			rc, err := r.workspaceStore.Get(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), r.wsPath(ctx, args.Path))
 			if err != nil {
 				return "", fmt.Errorf("workspace get: %w", err)
 			}
@@ -701,7 +702,7 @@ func makeEditFile(r *Registry) ToolFunc {
 			if err != nil {
 				return "", err
 			}
-			if err := r.workspaceStore.Put(ctx, r.agentID, r.projectID, r.scopeSessionID(), r.wsPath(args.Path),
+			if err := r.workspaceStore.Put(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), r.wsPath(ctx, args.Path),
 				strings.NewReader(updated), int64(len(updated)), ""); err != nil {
 				if friendly := asIsDirToolError("edit_file", args.Path, err); friendly != nil {
 					return "", friendly
@@ -713,7 +714,7 @@ func makeEditFile(r *Registry) ToolFunc {
 
 		if r.systemFileStore != nil && r.agentID != "" && isSingleSegmentSystemFile(args.Path) {
 			name := filepath.Clean(args.Path)
-			uid := r.systemFileUserID(name)
+			uid := r.systemFileUserID(ctx, name)
 			data, err := r.readSystemFileForUser(ctx, uid, name)
 			if err != nil {
 				return "", fmt.Errorf("system file get: %w", err)
@@ -803,7 +804,7 @@ func makeListDir(r *Registry) ToolFunc {
 		// listing" by filtering List output to entries whose agent-relative
 		// path sits under args.Path's prefix.
 		if r.workspaceStore != nil && r.agentID != "" && r.isWorkspacePath(args.Path) {
-			objs, err := r.workspaceStore.List(ctx, r.agentID, r.projectID, r.scopeSessionID())
+			objs, err := r.workspaceStore.List(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx))
 			if err != nil {
 				return "", fmt.Errorf("workspace list: %w", err)
 			}
@@ -885,7 +886,7 @@ func makeListDir(r *Registry) ToolFunc {
 // dev server serves the sandbox /workspace root and envd resolves a bare
 // path against $HOME, not /workspace.
 func (r *Registry) mirrorCodingWriteToSandbox(ctx context.Context, path, content string) {
-	if r.codingSubdir == "" || r.executor == nil {
+	if turnOrZero(ctx).CodingSubdir == "" || r.executor == nil {
 		return
 	}
 	if _, ok := r.executor.(sandbox.RemoteWorkspace); !ok {
@@ -915,12 +916,12 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 		// Identity-file confidentiality gate — same as the host path.
 		// Runs BEFORE the systemFileStore lookup so a chatter never
 		// reaches the DB row at all.
-		if r.identityFileBlocked(args.Path) {
+		if r.identityFileBlocked(ctx, args.Path) {
 			return IdentityFileRefusal, nil
 		}
 		// Skill-manifest gate — refuse before any routing so a chatter
 		// can't read a bundled `/skills/<name>/SKILL.md` off the mount.
-		if r.skillManifestBlocked(args.Path) {
+		if r.skillManifestBlocked(ctx, args.Path) {
 			return SkillManifestRefusal, nil
 		}
 		// Identity files (SOUL.md, IDENTITY.md, …) are routed by basename
@@ -930,14 +931,14 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 		// /data/.fastclaw/workspaces/<id>/IDENTITY.md still hits the DB.
 		if r.systemFileStore != nil && r.agentID != "" && basenameIsSystemFile(args.Path) {
 			name := filepath.Base(filepath.Clean(args.Path))
-			if data, err := r.readSystemFileForUser(ctx, r.systemFileUserID(name), name); err == nil {
+			if data, err := r.readSystemFileForUser(ctx, r.systemFileUserID(ctx, name), name); err == nil {
 				return string(data), nil
 			}
 			return "", nil // miss → treat as unset (fresh agent)
 		}
 		switch r.routeFor(args.Path, OpRead) {
 		case RouteWorkspaceStore:
-			rc, err := r.workspaceStore.Get(ctx, r.agentID, r.projectID, r.scopeSessionID(), r.wsPath(args.Path))
+			rc, err := r.workspaceStore.Get(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), r.wsPath(ctx, args.Path))
 			if err == nil {
 				defer rc.Close()
 				data, readErr := io.ReadAll(rc)
@@ -1016,18 +1017,18 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 		if err := validateFileTargetPath(args.Path); err != nil {
 			return "", fmt.Errorf("write_file: %w", err)
 		}
-		if r.identityFileBlocked(args.Path) {
+		if r.identityFileBlocked(ctx, args.Path) {
 			return IdentityFileRefusal, nil
 		}
 		switch r.routeFor(args.Path, OpWrite) {
 		case RouteSystemStore:
 			name := filepath.Clean(args.Path)
-			if err := r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(name), name, []byte(args.Content)); err != nil {
+			if err := r.systemFileStore.SaveWorkspaceFile(ctx, r.agentID, r.systemFileUserID(ctx, name), name, []byte(args.Content)); err != nil {
 				return "", fmt.Errorf("system file save: %w", err)
 			}
 			return fmt.Sprintf("Written %d bytes to %s", len(args.Content), name), nil
 		case RouteWorkspaceStore:
-			if err := r.workspaceStore.Put(ctx, r.agentID, r.projectID, r.scopeSessionID(), r.wsPath(args.Path),
+			if err := r.workspaceStore.Put(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), r.wsPath(ctx, args.Path),
 				strings.NewReader(args.Content), int64(len(args.Content)), ""); err != nil {
 				if friendly := asIsDirToolError("write_file", args.Path, err); friendly != nil {
 					return "", friendly
@@ -1081,7 +1082,7 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 		}
 		switch r.routeFor(args.Path, OpList) {
 		case RouteWorkspaceStore:
-			objs, err := r.workspaceStore.List(ctx, r.agentID, r.projectID, r.scopeSessionID())
+			objs, err := r.workspaceStore.List(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx))
 			if err == nil {
 				prefix := strings.Trim(filepath.ToSlash(filepath.Clean(args.Path)), "/")
 				if prefix == "." {
@@ -1154,10 +1155,10 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 		if err := validateFileTargetPath(args.Path); err != nil {
 			return "", fmt.Errorf("edit_file: %w", err)
 		}
-		if r.identityFileBlocked(args.Path) {
+		if r.identityFileBlocked(ctx, args.Path) {
 			return IdentityFileRefusal, nil
 		}
-		if r.skillManifestBlocked(args.Path) {
+		if r.skillManifestBlocked(ctx, args.Path) {
 			return SkillManifestRefusal, nil
 		}
 
@@ -1185,7 +1186,7 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 		switch r.routeFor(args.Path, OpWrite) {
 		case RouteSystemStore:
 			name := filepath.Clean(args.Path)
-			uid := r.systemFileUserID(name)
+			uid := r.systemFileUserID(ctx, name)
 			data, err := r.readSystemFileForUser(ctx, uid, name)
 			if err != nil {
 				return "", fmt.Errorf("system file get: %w", err)
@@ -1199,7 +1200,7 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 			}
 			return fmt.Sprintf("Edited %s (%d replacement(s))", name, count), nil
 		case RouteWorkspaceStore:
-			rc, err := r.workspaceStore.Get(ctx, r.agentID, r.projectID, r.scopeSessionID(), r.wsPath(args.Path))
+			rc, err := r.workspaceStore.Get(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), r.wsPath(ctx, args.Path))
 			if err == nil {
 				data, readErr := io.ReadAll(rc)
 				rc.Close()
@@ -1211,7 +1212,7 @@ func registerSandboxedFile(r *Registry, ex sandbox.Executor) {
 					if err != nil {
 						return "", err
 					}
-					if err := r.workspaceStore.Put(ctx, r.agentID, r.projectID, r.scopeSessionID(), r.wsPath(args.Path),
+					if err := r.workspaceStore.Put(ctx, r.agentID, turnOrZero(ctx).ProjectID, r.scopeSessionID(ctx), r.wsPath(ctx, args.Path),
 						strings.NewReader(updated), int64(len(updated)), ""); err != nil {
 						if friendly := asIsDirToolError("edit_file", args.Path, err); friendly != nil {
 							return "", friendly

--- a/internal/agent/tools/goal.go
+++ b/internal/agent/tools/goal.go
@@ -61,7 +61,10 @@ func makeUpdateGoal(st goal.Store, r *Registry, agentID string) ToolFunc {
 				"update_goal: status must be \"complete\"; pause / resume / budget_limited are user- or runtime-controlled, not model-controlled")
 		}
 
-		sessionKey := r.GoalSessionKey()
+		// The durable session key is per-turn (resolved from the inbound
+		// message's session triple); read it from ctx so concurrent turns
+		// on the same agent each address their own goal row.
+		sessionKey := turnOrZero(ctx).GoalSessionKey
 		if sessionKey == "" {
 			return "", errors.New("update_goal: no active session context")
 		}

--- a/internal/agent/tools/goal_test.go
+++ b/internal/agent/tools/goal_test.go
@@ -64,21 +64,28 @@ func (m *memGoalStore) DeleteGoal(context.Context, string) error { return nil }
 func fixture(t *testing.T) (*Registry, *memGoalStore) {
 	t.Helper()
 	r := NewRegistry("", "")
-	r.SetGoalSessionKey("s-fixture-1")
 	st := newMemGoalStore()
 	RegisterGoalTools(r, st, "agent-A")
 	return r, st
 }
 
+// goalFixtureSessionKey is the per-turn goal session key attached to ctx
+// in tests — the same value the old r.SetGoalSessionKey wired. Kept as a
+// constant so seedGoal and callTool agree on it.
+const goalFixtureSessionKey = "s-fixture-1"
+
 // callTool runs the named tool with the given args JSON and returns
-// (result, err).
+// (result, err). It attaches a TurnContext carrying the fixture session
+// key so update_goal can resolve its goal row — mirroring how the agent
+// loop threads per-turn state through ctx instead of registry fields.
 func callTool(t *testing.T, r *Registry, name, argsJSON string) (string, error) {
 	t.Helper()
 	fn := r.GetFunc(name)
 	if fn == nil {
 		t.Fatalf("tool %q not registered", name)
 	}
-	return fn(context.Background(), json.RawMessage(argsJSON))
+	ctx := WithTurnContext(context.Background(), &TurnContext{GoalSessionKey: goalFixtureSessionKey})
+	return fn(ctx, json.RawMessage(argsJSON))
 }
 
 // seedGoal directly inserts an Active goal into the store, bypassing
@@ -169,16 +176,20 @@ func TestUpdateGoalRegistered(t *testing.T) {
 }
 
 // TestUpdateGoalNoSessionContext: when the tool fires outside a chat
-// turn (registry never got SetGoalSessionKey), it must surface a
-// recoverable error instead of dereferencing a nil session. This is
-// the boot-time / out-of-context path.
+// turn (no TurnContext attached to ctx), it must surface a recoverable
+// error instead of dereferencing a nil session. This is the boot-time /
+// out-of-context path.
 func TestUpdateGoalNoSessionContext(t *testing.T) {
 	r := NewRegistry("", "")
-	// Deliberately skip SetGoalSessionKey.
+	// Deliberately use a bare background ctx — no TurnContext attached.
 	st := newMemGoalStore()
 	RegisterGoalTools(r, st, "agent-A")
 
-	_, err := callTool(t, r, "update_goal", `{"status":"complete"}`)
+	fn := r.GetFunc("update_goal")
+	if fn == nil {
+		t.Fatalf("update_goal not registered")
+	}
+	_, err := fn(context.Background(), json.RawMessage(`{"status":"complete"}`))
 	if err == nil || !strings.Contains(err.Error(), "no active session") {
 		t.Fatalf("expected no-session error, got %v", err)
 	}

--- a/internal/agent/tools/identity_gate_test.go
+++ b/internal/agent/tools/identity_gate_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -39,8 +40,12 @@ func TestIdentityFileBlockedRespectsCallerFlag(t *testing.T) {
 		{"", false, false},
 	}
 	for _, c := range cases {
-		r := &Registry{callerIsAdmin: c.admin}
-		got := r.identityFileBlocked(c.path)
+		// callerIsAdmin now lives on TurnContext (per-turn), not the
+		// shared registry field — mirror the production path by attaching
+		// it to ctx.
+		ctx := WithTurnContext(context.Background(), &TurnContext{CallerIsAdmin: c.admin})
+		r := &Registry{}
+		got := r.identityFileBlocked(ctx, c.path)
 		if got != c.want {
 			t.Errorf("identityFileBlocked(%q) admin=%v = %v, want %v",
 				c.path, c.admin, got, c.want)
@@ -67,8 +72,9 @@ func TestNestedIdentityNameIsNotBlocked(t *testing.T) {
 	// "notes/SOUL.md" is a workspace artifact named like an identity
 	// file — it's the chatter's own note, not the agent's persona. The
 	// gate must not block it.
-	r := &Registry{callerIsAdmin: false}
-	if r.identityFileBlocked("notes/SOUL.md") {
+	ctx := WithTurnContext(context.Background(), &TurnContext{CallerIsAdmin: false})
+	r := &Registry{}
+	if r.identityFileBlocked(ctx, "notes/SOUL.md") {
 		t.Errorf("nested SOUL.md must not be gated as the agent's identity")
 	}
 }

--- a/internal/agent/tools/load_skill.go
+++ b/internal/agent/tools/load_skill.go
@@ -16,7 +16,16 @@ type loadSkillArgs struct {
 }
 
 // RegisterLoadSkill registers the load_skill tool that reads full SKILL.md content.
-func RegisterLoadSkill(r *Registry, skillDirs []string) {
+//
+// userSkillsHostDir is the chatter's per-user skills host directory
+// (~/.fastclaw/users/<uid>/skills), or "" when there is no per-user layer.
+// It lets makeLoadSkill map a per-user skill's {baseDir} placeholder to its
+// in-container path /root/.agents/skills/<name> (the read-write mount used by
+// `npx skills add -g -y`), instead of the default /skills/<name> used by the
+// per-agent / managed layers. Without this, a skill referenced via {baseDir}
+// resolves to a host path that does not exist inside the sandbox and the
+// script can't be found.
+func RegisterLoadSkill(r *Registry, skillDirs []string, userSkillsHostDir string) {
 	r.Register("load_skill", "Load the full content of a skill by name. Use this when you need detailed instructions for a specific skill.", map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
@@ -26,10 +35,10 @@ func RegisterLoadSkill(r *Registry, skillDirs []string) {
 			},
 		},
 		"required": []string{"name"},
-	}, makeLoadSkill(skillDirs))
+	}, makeLoadSkill(skillDirs, userSkillsHostDir))
 }
 
-func makeLoadSkill(skillDirs []string) ToolFunc {
+func makeLoadSkill(skillDirs []string, userSkillsHostDir string) ToolFunc {
 	return func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 		var args loadSkillArgs
 		if err := json.Unmarshal(rawArgs, &args); err != nil {
@@ -48,8 +57,16 @@ func makeLoadSkill(skillDirs []string) ToolFunc {
 			skillPath := filepath.Join(dir, args.Name, "SKILL.md")
 			data, err := os.ReadFile(skillPath)
 			if err == nil {
-				skillDir, _ := filepath.Abs(filepath.Join(dir, args.Name))
-				content := strings.ReplaceAll(string(data), "{baseDir}", skillDir)
+				// {baseDir} must resolve to the script's IN-CONTAINER path, not the
+				// host path. The sandbox bind-mounts each skill folder:
+				//   per-agent / managed layers → /skills/<name>/          (read-only)
+				//   per-user layer             → /root/.agents/skills/<name>/  (read-write)
+				// Replacing {baseDir} with the host path (the old behavior) produced
+				// "/home/<user>/.fastclaw/.../scripts/render.py" — a path that does
+				// NOT exist inside the container, so every skill that referenced its
+				// scripts via {baseDir} failed at exec time.
+				containerBase := containerBaseDir(dir, userSkillsHostDir, args.Name)
+				content := strings.ReplaceAll(string(data), "{baseDir}", containerBase)
 				if reason := unavailableReason(data); reason != "" {
 					content = "[SKILL CURRENTLY UNAVAILABLE: " + reason +
 						". Explain this to the user and ask an administrator to configure the missing requirement before using authenticated operations.]\n\n" +
@@ -61,6 +78,24 @@ func makeLoadSkill(skillDirs []string) ToolFunc {
 
 		return "", fmt.Errorf("skill %q not found", args.Name)
 	}
+}
+
+// containerBaseDir maps a skill's host layer directory to the path where its
+// scripts are visible INSIDE the sandbox container. The match against
+// userSkillsHostDir is exact: the per-user mount is a single whole-directory
+// bind (<base>/users/<uid>/skills → /root/.agents/skills), so only the layer
+// dir itself maps to that container path — every other layer (per-agent,
+// managed, team, extra) is enumerated and mounted under /skills/<name>.
+//
+// Team / extra dirs are not currently mounted into the container at all
+// (skillDirsForAgent only returns per-agent + managed), but we still return
+// /skills/<name> for them: it matches the documented convention and avoids
+// fabricating a host path that is definitely wrong.
+func containerBaseDir(hostSkillLayerDir, userSkillsHostDir, skillName string) string {
+	if userSkillsHostDir != "" && hostSkillLayerDir == userSkillsHostDir {
+		return "/root/.agents/skills/" + skillName
+	}
+	return "/skills/" + skillName
 }
 
 // wrapSkillContentInternal prefixes SKILL.md content with an explicit

--- a/internal/agent/tools/load_skill_test.go
+++ b/internal/agent/tools/load_skill_test.go
@@ -26,7 +26,7 @@ Run {baseDir}/scripts/render.py with JSON input.`
 	}
 
 	r := NewRegistry(t.TempDir(), t.TempDir())
-	RegisterLoadSkill(r, []string{filepath.Join(home, "skills")})
+	RegisterLoadSkill(r, []string{filepath.Join(home, "skills")}, "")
 
 	fn := r.GetFunc("load_skill")
 	if fn == nil {
@@ -41,8 +41,14 @@ Run {baseDir}/scripts/render.py with JSON input.`
 		t.Fatal(err)
 	}
 
-	if !strings.Contains(got, "Run "+skillDir+"/scripts/render.py") {
-		t.Fatalf("load_skill did not return full content with baseDir replaced:\n%s", got)
+	// {baseDir} must resolve to the IN-CONTAINER path, not the host path.
+	// The sandbox mounts per-agent/managed skills at /skills/<name>, so the
+	// placeholder should become /skills/chart-maker — never the host dir.
+	if !strings.Contains(got, "Run /skills/chart-maker/scripts/render.py") {
+		t.Fatalf("load_skill did not return full content with baseDir replaced by container path:\n%s", got)
+	}
+	if strings.Contains(got, skillDir+"/scripts/render.py") {
+		t.Fatalf("load_skill leaked the HOST skill path into output:\n%s", got)
 	}
 	if !strings.Contains(got, "INTERNAL CONTEXT") {
 		t.Fatalf("load_skill output missing internal wrapper:\n%s", got)
@@ -65,7 +71,7 @@ func TestLoadSkillUsesDirectoryPrecedence(t *testing.T) {
 	}
 
 	r := NewRegistry(t.TempDir(), t.TempDir())
-	RegisterLoadSkill(r, []string{agentSkills, userSkills})
+	RegisterLoadSkill(r, []string{agentSkills, userSkills}, "")
 	rawArgs, err := json.Marshal(map[string]string{"name": "shared"})
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +110,7 @@ Authenticated instructions.`
 	}
 
 	r := NewRegistry(t.TempDir(), t.TempDir())
-	RegisterLoadSkill(r, []string{filepath.Join(home, "skills")})
+	RegisterLoadSkill(r, []string{filepath.Join(home, "skills")}, "")
 	rawArgs, err := json.Marshal(map[string]string{"name": "deepcoin-trade"})
 	if err != nil {
 		t.Fatal(err)
@@ -119,5 +125,67 @@ Authenticated instructions.`
 	}
 	if !strings.Contains(got, "DC_API_KEY, DC_SECRET_KEY") {
 		t.Fatalf("load_skill output missing env names:\n%s", got)
+	}
+}
+
+// TestLoadSkillPerUserLayerMapsBaseDirToAgentSkills verifies that a skill
+// installed at the per-user layer resolves {baseDir} to the per-user in-container
+// mount path /root/.agents/skills/<name>, not the default /skills/<name> used by
+// per-agent/managed skills. The per-user layer is bind-mounted RW as a whole
+// directory at /root/.agents/skills (the location `npx skills add -g` writes to),
+// so its scripts are NOT under /skills/.
+func TestLoadSkillPerUserLayerMapsBaseDirToAgentSkills(t *testing.T) {
+	home := t.TempDir()
+	// managed layer dir (for contrast — should still map to /skills/<name>)
+	managedSkills := filepath.Join(home, "skills")
+	// per-user layer dir — mimics ~/.fastclaw/users/<uid>/skills
+	userSkills := filepath.Join(home, "users", "u_test", "skills")
+
+	for _, tc := range []struct {
+		name        string
+		skillLayer  string // host dir holding the skill folder
+		skillName   string
+		wantSubstr string // expected in-container path the placeholder resolves to
+	}{
+		{
+			name:        "managed layer maps to /skills/<name>",
+			skillLayer:  managedSkills,
+			skillName:   "managed-tool",
+			wantSubstr: "/skills/managed-tool/scripts/run.py",
+		},
+		{
+			name:        "per-user layer maps to /root/.agents/skills/<name>",
+			skillLayer:  userSkills,
+			skillName:   "user-tool",
+			wantSubstr: "/root/.agents/skills/user-tool/scripts/run.py",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			skillDir := filepath.Join(tc.skillLayer, tc.skillName)
+			if err := os.MkdirAll(skillDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := "---\nname: " + tc.skillName + "\ndescription: test.\n---\n\nRun {baseDir}/scripts/run.py"
+			if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			r := NewRegistry(t.TempDir(), t.TempDir())
+			// Order mirrors SkillsLoader.allSkillDirs: per-user dir is passed
+			// AND identified via the userSkillsHostDir argument.
+			RegisterLoadSkill(r, []string{managedSkills, userSkills}, userSkills)
+
+			rawArgs, err := json.Marshal(map[string]string{"name": tc.skillName})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := r.GetFunc("load_skill")(context.Background(), rawArgs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("expected %q in output, got:\n%s", tc.wantSubstr, got)
+			}
+		})
 	}
 }

--- a/internal/agent/tools/preference.go
+++ b/internal/agent/tools/preference.go
@@ -61,7 +61,7 @@ func makeSetPreference(st store.Store, r *Registry) ToolFunc {
 			return "", fmt.Errorf("value is required")
 		}
 
-		chatterUID := r.ChatterUserID()
+		chatterUID := r.chatterFromCtx(ctx)
 		if chatterUID == "" {
 			return "", fmt.Errorf("no chatter identity on this turn — cannot persist preference")
 		}

--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -78,11 +78,16 @@ const IdentityFileRefusal = "[refused: this file is part of the agent's private 
 // identityFileBlocked reports whether the current caller should be
 // refused access to an identity file at `path`. Returns true only
 // when the path resolves to one of the protected basenames AND the
-// per-turn caller flag says the chatter is not the owner / admin.
-// Callers should `return IdentityFileRefusal, nil` so the model sees
-// a tool-shaped, model-readable refusal instead of an opaque error.
-func (r *Registry) identityFileBlocked(path string) bool {
-	return !r.callerIsAdmin && isIdentityFilePath(path)
+// per-turn caller flag (read from ctx) says the chatter is not the
+// owner / admin. Callers should `return IdentityFileRefusal, nil` so
+// the model sees a tool-shaped, model-readable refusal instead of an
+// opaque error.
+func (r *Registry) identityFileBlocked(ctx context.Context, path string) bool {
+	isAdmin := false
+	if tc := FromContext(ctx); tc != nil {
+		isAdmin = tc.CallerIsAdmin
+	}
+	return !isAdmin && isIdentityFilePath(path)
 }
 
 // SkillManifestRefusal is the read/edit refusal for a bundled skill's
@@ -132,8 +137,16 @@ func (r *Registry) isProtectedSkillManifestPath(path string) bool {
 // left open so a chatter can still author their OWN skills via the
 // skill-creator flow (those land in the per-user bucket, and writes to
 // the agent's bundled `/skills` mount fail anyway — it's read-only).
-func (r *Registry) skillManifestBlocked(path string) bool {
-	return !r.callerIsAdmin && r.isProtectedSkillManifestPath(path)
+//
+// callerIsAdmin is read from ctx (per-turn), so concurrent turns don't
+// race on a shared field — a non-admin chatter can never briefly inherit
+// an admin's flag mid-turn.
+func (r *Registry) skillManifestBlocked(ctx context.Context, path string) bool {
+	isAdmin := false
+	if tc := FromContext(ctx); tc != nil {
+		isAdmin = tc.CallerIsAdmin
+	}
+	return !isAdmin && r.isProtectedSkillManifestPath(path)
 }
 
 // ToolFunc is a function that executes a tool with JSON arguments and returns a result string.
@@ -411,16 +424,68 @@ func (r *Registry) SetUserSkillsRoot(dir string) {
 // to. Identity files (SOUL/IDENTITY/AGENTS/BOOTSTRAP/TOOLS/HEARTBEAT/
 // agent.json) route to agentOwnerUserID so the "shared template" lives
 // under a single, owner-keyed row; per-user files (USER.md, MEMORY.md)
-// route to the per-turn chatter (chatterUserID when set, otherwise the
-// UserSpace owner userID). Falls back to userID when the agent owner
-// isn't set — that's the single-user / legacy case where they coincide
-// anyway.
-func (r *Registry) systemFileUserID(filename string) string {
+// route to the per-turn chatter (read from ctx via TurnContext, falling
+// back to the UserSpace owner userID when no per-turn chatter is set).
+// Falls back to userID when the agent owner isn't set — that's the
+// single-user / legacy case where they coincide anyway.
+//
+// The per-turn chatter is taken from ctx, NOT r.chatterUserID, so two
+// concurrent turns on the same agent can't race on the field — each
+// tool call resolves its own chatter from the ctx the loop attached at
+// turn start.
+func (r *Registry) systemFileUserID(ctx context.Context, filename string) string {
 	if r.agentOwnerUserID != "" && identityFiles[filepath.Base(filepath.Clean(filename))] {
 		return r.agentOwnerUserID
 	}
-	if r.chatterUserID != "" {
-		return r.chatterUserID
+	if tc := FromContext(ctx); tc != nil && tc.ChatterUserID != "" {
+		return tc.ChatterUserID
+	}
+	return r.userID
+}
+
+// chatterFromCtx resolves the per-turn chatter userID: the TurnContext
+// value (set by the loop from the resolved chatter) when present, else
+// the boot-time UserSpace owner (r.userID) as the legacy / single-user
+// fallback. Tools that key per-chatter state (cron jobs, timezone, prefs)
+// should read through this so concurrent turns don't race on a shared
+// registry field.
+func (r *Registry) chatterFromCtx(ctx context.Context) string {
+	if tc := FromContext(ctx); tc != nil && tc.ChatterUserID != "" {
+		return tc.ChatterUserID
+	}
+	return r.userID
+}
+
+// SessionIDFromCtx returns the per-turn chat session id (the channel-level
+// chatID) from TurnContext, or "" when no TurnContext is attached. Callers
+// in other packages (e.g. internal/agent runtime tools) that can't use the
+// unexported turnOrZero helper read through this so they also resolve
+// their own per-turn scoping from ctx instead of a shared field.
+func (r *Registry) SessionIDFromCtx(ctx context.Context) string {
+	return turnOrZero(ctx).SessionID
+}
+
+// ProjectIDFromCtx returns the per-turn project id from TurnContext, or "".
+func (r *Registry) ProjectIDFromCtx(ctx context.Context) string {
+	return turnOrZero(ctx).ProjectID
+}
+
+// GoalSessionKeyFromCtx returns the per-turn goal session key from
+// TurnContext, or "". Loop code in other packages (e.g. runPostTurn, which
+// builds HookContexts outside the turn function that owns the TurnContext
+// local) reads through this so it resolves the right value from ctx instead
+// of a stale shared field.
+func (r *Registry) GoalSessionKeyFromCtx(ctx context.Context) string {
+	return turnOrZero(ctx).GoalSessionKey
+}
+
+// EffectiveUserIDFromCtx mirrors EffectiveUserID but resolves the per-turn
+// chatter from ctx: the TurnContext chatter when set, else the boot-time
+// UserSpace owner (r.userID). This is the ctx-aware variant runtime tools
+// should use so concurrent turns don't race on a shared registry field.
+func (r *Registry) EffectiveUserIDFromCtx(ctx context.Context) string {
+	if tc := FromContext(ctx); tc != nil && tc.ChatterUserID != "" {
+		return tc.ChatterUserID
 	}
 	return r.userID
 }
@@ -458,10 +523,30 @@ func (r *Registry) SetSandboxRequired(required bool) {
 	r.sandboxRequired = required
 }
 
+// The per-turn setters and getters below (SetSessionID, SetProjectID,
+// SetCodingRootScope, SetCodingSubdir, SetMessageContext, SetCallerIsAdmin,
+// SetGoalSessionKey, SetChatterUserID, and the matching *ID/Channel/Admin/
+// GoalSessionKey/ChatterUserID getters) are LEGACY: they mutate shared
+// Registry fields that the agent loop used to set per-turn. That mutation
+// was a data race when two turns overlapped on one agent (public agents,
+// cron + live chat, …).
+//
+// Per-turn state now flows through TurnContext on ctx (see turnctx.go,
+// FromContext, and the *FromCtx helpers). Tool implementations read it via
+// turnOrZero(ctx) / FromContext(ctx); the agent loop attaches it in
+// bindSession. These setters/getters remain ONLY for boot/admin paths that
+// run outside any chat turn and for tests that model a single turn — do NOT
+// call them from per-turn (HandleMessage / tool) code, and prefer the
+// ctx-aware helpers (chatterFromCtx, SessionIDFromCtx, ProjectIDFromCtx,
+// EffectiveUserIDFromCtx, GoalSessionKeyFromCtx) when you have a ctx.
+
 // SetSessionID scopes the registry's workspace.Store calls (write_file /
 // read_file / list_dir) to a single chat session. The agent loop calls
 // this at the top of each turn with msg.ChatID. An empty session falls
 // back to the agent-shared scope (no session isolation).
+//
+// Deprecated per the LEGACY note above: per-turn callers must attach a
+// TurnContext to ctx instead. Retained for boot/admin/test paths.
 func (r *Registry) SetSessionID(sessionID string) {
 	r.sessionID = sessionID
 }
@@ -530,12 +615,15 @@ func (r *Registry) SetCodingRootScope(v bool) {
 
 // scopeSessionID is the session segment the file tools pass to the
 // workspace store. It collapses to "" in coding-root-scope mode so writes
-// land at the project root the dev server serves.
-func (r *Registry) scopeSessionID() string {
-	if r.codingRootScope {
+// land at the project root the dev server serves. Both codingRootScope and
+// sessionID are per-turn values read from ctx, so concurrent turns on the
+// same agent each resolve their own scoping.
+func (r *Registry) scopeSessionID(ctx context.Context) string {
+	tc := turnOrZero(ctx)
+	if tc.CodingRootScope {
 		return ""
 	}
-	return r.sessionID
+	return tc.SessionID
 }
 
 // SetCodingSubdir redirects the file tools into a subfolder of the scope
@@ -555,16 +643,18 @@ func (r *Registry) CodingSubdir() string { return r.codingSubdir }
 // wsPath maps a tool-supplied path into the active coding subdir. It is
 // idempotent: a path already under the subdir (e.g. one the agent copied
 // from a list_dir result) is returned unchanged, so the agent can use
-// either "src/x" or "app/src/x" and both resolve to the same file.
-func (r *Registry) wsPath(p string) string {
-	if r.codingSubdir == "" {
+// either "src/x" or "app/src/x" and both resolve to the same file. The
+// subdir is a per-turn value read from ctx.
+func (r *Registry) wsPath(ctx context.Context, p string) string {
+	sub := turnOrZero(ctx).CodingSubdir
+	if sub == "" {
 		return p
 	}
 	clean := strings.TrimLeft(filepath.ToSlash(p), "/")
-	if clean == r.codingSubdir || strings.HasPrefix(clean, r.codingSubdir+"/") {
+	if clean == sub || strings.HasPrefix(clean, sub+"/") {
 		return clean
 	}
-	return r.codingSubdir + "/" + clean
+	return sub + "/" + clean
 }
 
 // SetMessageContext records the bus address of the in-flight turn so

--- a/internal/agent/tools/skill_manifest_gate_test.go
+++ b/internal/agent/tools/skill_manifest_gate_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -37,8 +38,11 @@ func TestSkillManifestBlockedRespectsCallerFlag(t *testing.T) {
 		{"empty", "", false, "", false},
 	}
 	for _, c := range cases {
-		r := &Registry{callerIsAdmin: c.admin, userSkillsRoot: c.userSkillsRoot}
-		if got := r.skillManifestBlocked(c.path); got != c.want {
+		// callerIsAdmin is per-turn (TurnContext on ctx); userSkillsRoot
+		// is boot-stable (stays on the registry).
+		ctx := WithTurnContext(context.Background(), &TurnContext{CallerIsAdmin: c.admin})
+		r := &Registry{userSkillsRoot: c.userSkillsRoot}
+		if got := r.skillManifestBlocked(ctx, c.path); got != c.want {
 			t.Errorf("%s: skillManifestBlocked(%q) admin=%v userRoot=%q = %v, want %v",
 				c.name, c.path, c.admin, c.userSkillsRoot, got, c.want)
 		}

--- a/internal/agent/tools/timezone.go
+++ b/internal/agent/tools/timezone.go
@@ -60,7 +60,7 @@ func makeSetTimezone(st store.Store, r *Registry) ToolFunc {
 		if err != nil {
 			return "", fmt.Errorf("unknown timezone %q — use an IANA name like 'Asia/Shanghai': %w", args.Timezone, err)
 		}
-		chatterUID := r.ChatterUserID()
+		chatterUID := r.chatterFromCtx(ctx)
 		if chatterUID == "" {
 			return "", fmt.Errorf("no chatter identity on this turn — cannot persist timezone")
 		}
@@ -69,7 +69,7 @@ func makeSetTimezone(st store.Store, r *Registry) ToolFunc {
 		// chatterLocation() reads USER.md first, so this guarantees the
 		// date line shows the correct timezone on every future session.
 		if r.systemFileStore != nil {
-			userMDUID := r.systemFileUserID("USER.md")
+			userMDUID := r.systemFileUserID(ctx, "USER.md")
 			upsertUserMDTimezone(ctx, r, userMDUID, args.Timezone)
 		}
 

--- a/internal/agent/tools/turnctx.go
+++ b/internal/agent/tools/turnctx.go
@@ -1,0 +1,113 @@
+package tools
+
+import "context"
+
+// turnctx carries the per-turn identity + session state that tool
+// implementations need to scope their side effects (which workspace
+// path, which chatter's USER.md row, which chat to route a cron replay
+// to, …). It is threaded through context.Context instead of mutating
+// shared fields on *Registry, so two concurrent turns on the same agent
+// (e.g. a public agent serving two chatters) cannot race on that state.
+//
+// Mirrors the ctx-tagging convention already used by
+// internal/store/chatterctx.go and internal/sandbox/userctx.go: an
+// unexported struct-typed key, WithTurnContext as the writer (no-op on
+// nil), FromContext as the reader (nil when unset → tools fall back to
+// zero values, preserving legacy behavior).
+//
+// Boot-stable identity (agent owner, skills roots, sandbox config, the
+// workspace store handles) stays on *Registry and is NOT duplicated
+// here — those never change across turns. Only the values that bindSession
+// used to write per-turn belong in TurnContext.
+
+// TurnContext is the per-turn snapshot of identity + scoping. All fields
+// are read-only once constructed; build one at the top of a turn and
+// attach it to ctx via WithTurnContext.
+type TurnContext struct {
+	// SessionID is the channel-level chat identifier (msg.ChatID). Used as
+	// the session segment of workspace.Store paths so each chat's files
+	// are isolated.
+	SessionID string
+	// ProjectID scopes workspace.Store calls to a project folder when
+	// non-empty, overriding the session scope.
+	ProjectID string
+	// CodingRootScope drops the session segment from workspace scoping so
+	// file tools address the project ROOT (the tree a coding-agent dev
+	// server serves). Only on for agents with a project runtime.
+	CodingRootScope bool
+	// CodingSubdir redirects file-tool paths into this subfolder of the
+	// scope workspace (the folder a project runtime scaffolds its app
+	// into). Empty disables the redirect.
+	CodingSubdir string
+	// Channel / AccountID / ChatID name the bus address of the in-flight
+	// turn. create_cron_job stamps them onto persisted rows so a fired
+	// reminder routes back to the originating web/IM thread.
+	Channel    string
+	AccountID  string
+	ChatID     string
+	// GoalSessionKey is the durable session.Session key goal tools use to
+	// address their rows. Distinct from SessionID (the channel chatID).
+	GoalSessionKey string
+	// ChatterUserID is the resolved per-turn chatter (IM per-sender
+	// app_user, or the UserSpace owner for direct web chats). Per-user
+	// files (USER.md / MEMORY.md) route here.
+	ChatterUserID string
+	// CallerIsAdmin marks this turn's chatter as the agent owner / channel
+	// admin. File tools gate identity-file (SOUL.md, …) ops on it.
+	CallerIsAdmin bool
+}
+
+type turnCtxKey struct{}
+
+// WithTurnContext returns ctx tagged with tc. A nil tc is a no-op so the
+// caller doesn't have to nil-check before wrapping — tools then see
+// FromContext()==nil and fall back to zero values.
+func WithTurnContext(ctx context.Context, tc *TurnContext) context.Context {
+	if tc == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, turnCtxKey{}, tc)
+}
+
+// FromContext returns the TurnContext attached by WithTurnContext, or nil
+// when none is set (background ctx, boot/admin paths, legacy tests). Tool
+// implementations must tolerate nil — read fields through turnOrZero,
+// never by dereferencing the returned pointer directly.
+func FromContext(ctx context.Context) *TurnContext {
+	if ctx == nil {
+		return nil
+	}
+	v, _ := ctx.Value(turnCtxKey{}).(*TurnContext)
+	return v
+}
+
+// turnOrZero returns a pointer to the ctx's TurnContext, or a pointer to
+// a zero-valued TurnContext when none is attached. The zero value is the
+// correct "no per-turn state" fallback for every field (empty strings,
+// false bools) — it matches what a boot/admin path with no chat in flight
+// should see. Always returns non-nil so callers can do
+// `tc := turnOrZero(ctx); tc.SessionID` without nil-guarding.
+func turnOrZero(ctx context.Context) *TurnContext {
+	if tc := FromContext(ctx); tc != nil {
+		return tc
+	}
+	return &TurnContext{}
+}
+
+// OwnerKeyFor folds the (agentID, chatterUserID, sessionKey) identity
+// triple into a single deterministic string used to isolate background
+// shells (shellManager.Start/Get). It mirrors the scoping
+// workspace.Store uses, so a shell started in one chat can only be
+// observed by a later tool call from the same chat/chatter.
+//
+// Empty agentID means "no agent context" (shouldn't happen in a real
+// turn) — the returned key is still well-formed, just less specific.
+// Callers that genuinely have no chat tenancy (boot, admin reload, some
+// tests) pass "" to opt out of isolation entirely at the Get site.
+func OwnerKeyFor(agentID, chatterUserID, sessionKey string) string {
+	// A separator that can't appear in any of the three id spaces:
+	// agentIDs/chatter ids are "ag_…"/"u_…" and sessionKeys are "s-…",
+	// none contain a NUL. NUL also can't be typed via a guessed bash_id,
+	// so it doubles as a trivial injection guard.
+	return agentID + "\x00" + chatterUserID + "\x00" + sessionKey
+}

--- a/internal/agent/tools/turnctx_concurrency_test.go
+++ b/internal/agent/tools/turnctx_concurrency_test.go
@@ -1,0 +1,167 @@
+package tools
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fastclaw-ai/fastclaw/internal/workspace"
+)
+
+// recordingStore is a minimal workspace.Store that records every Put's
+// resolved (projectID, sessionID, path) + content. Used by the concurrency
+// tests to prove per-turn scoping doesn't race across concurrent turns.
+type recordingStore struct {
+	mu   sync.Mutex
+	puts []recordedPut
+}
+
+type recordedPut struct {
+	projectID string
+	sessionID string
+	path      string
+	content   string
+}
+
+func (s *recordingStore) Put(_ context.Context, _, projectID, sessionID, path string, r io.Reader, _ int64, _ string) error {
+	b, _ := io.ReadAll(r)
+	s.mu.Lock()
+	s.puts = append(s.puts, recordedPut{projectID: projectID, sessionID: sessionID, path: path, content: string(b)})
+	s.mu.Unlock()
+	return nil
+}
+func (s *recordingStore) Get(context.Context, string, string, string, string) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (s *recordingStore) Stat(context.Context, string, string, string, string) ( *workspace.ObjectInfo, error) {
+	return nil, nil
+}
+func (s *recordingStore) List(context.Context, string, string, string) ([]workspace.ObjectInfo, error) {
+	return nil, nil
+}
+func (s *recordingStore) Delete(context.Context, string, string, string, string) error { return nil }
+func (s *recordingStore) Move(context.Context, string, string, string, string, string) error {
+	return nil
+}
+func (s *recordingStore) SignedURL(context.Context, string, string, string, string, time.Duration) (string, error) {
+	return "", nil
+}
+
+// TestWriteFile_ConcurrentTurnsNoCrossContamination is the headline P2
+// regression test. Before the TurnContext refactor, write_file read its
+// session scoping off shared Registry fields that bindSession mutated
+// per turn — so two concurrent turns on one agent could interleave and
+// land a chatter's file in another chatter's session scope. Now each
+// turn attaches its own TurnContext to ctx, and every scope resolution
+// reads from ctx. This test runs N concurrent writes with distinct
+// TurnContexts through ONE shared Registry and asserts every Put landed
+// in its own scope.
+//
+// Run with -race to also catch any data race on shared state.
+func TestWriteFile_ConcurrentTurnsNoCrossContamination(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+	r.agentID = "ag_shared"
+	store := &recordingStore{}
+	r.SetWorkspaceStore(store, "ag_shared")
+
+	// Each "turn" is a distinct chatter + session. The shared Registry
+	// is the same instance for all of them — exactly the public-agent /
+	// multi-session scenario that used to race.
+	turns := []struct {
+		chatter, session, project, path, content string
+	}{
+		{"u_alice", "s-aaa", "", "notes.md", "alice's notes"},
+		{"u_bob", "s-bbb", "", "notes.md", "bob's notes"},
+		{"u_carol", "s-ccc", "proj-1", "report.md", "carol's report"},
+		{"u_dave", "s-ddd", "", "draft.md", "dave's draft"},
+		{"u_eve", "s-eee", "proj-2", "spec.md", "eve's spec"},
+	}
+
+	var wg sync.WaitGroup
+	for _, tn := range turns {
+		wg.Add(1)
+		go func(tn struct {
+			chatter, session, project, path, content string
+		}) {
+			defer wg.Done()
+			ctx := WithTurnContext(context.Background(), &TurnContext{
+				ChatterUserID: tn.chatter,
+				SessionID:     tn.session,
+				ProjectID:     tn.project,
+			})
+			args := `{"path":"` + tn.path + `","content":"` + tn.content + `"}`
+			if _, err := r.Execute(ctx, "write_file", args); err != nil {
+				t.Errorf("write_file for %s: %v", tn.chatter, err)
+			}
+		}(tn)
+	}
+	wg.Wait()
+
+	// Every recorded Put must carry its own turn's scope — no leakage.
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.puts) != len(turns) {
+		t.Fatalf("got %d puts, want %d", len(store.puts), len(turns))
+	}
+	seen := map[string]string{} // "project|session|path" → content
+	for _, p := range store.puts {
+		key := p.projectID + "|" + p.sessionID + "|" + p.path
+		if prev, dup := seen[key]; dup {
+			t.Errorf("duplicate scope key %q: %q then %q — concurrent turns collided", key, prev, p.content)
+		}
+		seen[key] = p.content
+	}
+	// Each turn's content must land under its own session/project.
+	for _, tn := range turns {
+		key := tn.project + "|" + tn.session + "|" + tn.path
+		got, ok := seen[key]
+		if !ok {
+			t.Errorf("turn %s: no Put recorded at its own scope %q — write lost", tn.chatter, key)
+			continue
+		}
+		if got != tn.content {
+			t.Errorf("turn %s: content at %q = %q, want %q — cross-chatter contamination",
+				tn.chatter, key, got, tn.content)
+		}
+	}
+}
+
+// TestIdentityFileGate_ConcurrentAdminFlags proves the admin gate no
+// longer races: an admin turn and a non-admin turn running concurrently
+// must each see their OWN callerIsAdmin, so a non-admin chatter can't
+// transiently inherit an admin's flag (which would let them read SOUL.md).
+//
+// The concurrent goroutines hammer the gate from many turns at once (to
+// surface any data race under -race); the correctness assertion is that
+// every admin ctx resolves to "allowed" and every non-admin ctx to
+// "blocked", regardless of interleaving.
+func TestIdentityFileGate_ConcurrentAdminFlags(t *testing.T) {
+	r := NewRegistry(t.TempDir(), t.TempDir())
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(2)
+		// Admin turn: SOUL.md read must be allowed.
+		go func() {
+			defer wg.Done()
+			ctx := WithTurnContext(context.Background(), &TurnContext{CallerIsAdmin: true})
+			if r.identityFileBlocked(ctx, "SOUL.md") {
+				t.Errorf("admin turn: SOUL.md read wrongly blocked")
+			}
+		}()
+		// Non-admin turn: SOUL.md read must be blocked. The critical
+		// assertion is that this NEVER flips to allowed because of a
+		// racing admin turn that used to share the registry field.
+		go func() {
+			defer wg.Done()
+			ctx := WithTurnContext(context.Background(), &TurnContext{CallerIsAdmin: false})
+			if !r.identityFileBlocked(ctx, "SOUL.md") {
+				t.Errorf("SECURITY: non-admin turn: SOUL.md read allowed — admin flag raced")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/store/cron_pg_test.go
+++ b/internal/store/cron_pg_test.go
@@ -1,0 +1,252 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// pgTestDSN is read from the environment to opt this test in. CI without a
+// Postgres instance skips; a developer running ./scripts/run-postgres.sh sets
+// it (the helper exports a matching DSN) to exercise the real backend.
+const pgTestDSNEnv = "FASTCLAW_TEST_PG_DSN"
+
+// openTestPG connects to the Postgres instance named by FASTCLAW_TEST_PG_DSN,
+// creates a uniquely-named throwaway database, and returns a migrated *DBStore
+// pointing at it plus a cleanup that drops the DB and closes the admin handle.
+// The fresh database means every test starts from a clean schema — the
+// timestamptz migration runs on CREATE TABLE + convert, exercising the same
+// path a brand-new install takes.
+func openTestPG(t *testing.T) (*DBStore, func()) {
+	t.Helper()
+	dsn := os.Getenv(pgTestDSNEnv)
+	if dsn == "" {
+		t.Skipf("%s not set — skipping Postgres integration test", pgTestDSNEnv)
+	}
+	// Connect to the maintenance DB (the DSN already targets a DB, but we need
+	// a server-level handle to CREATE the scratch database). Reuse the creds by
+	// rewriting the path to "postgres".
+	adminDSN := pgRewriteDB(dsn, "postgres")
+	admin, err := sql.Open("postgres", adminDSN)
+	if err != nil {
+		t.Fatalf("open admin conn: %v", err)
+	}
+	scratch := fmt.Sprintf("fc_test_%x", time.Now().UnixNano())
+	// DROP+CREATE: escape the identifier just in case, though the name is hex.
+	if _, err := admin.Exec(fmt.Sprintf(`DROP DATABASE IF EXISTS %q`, scratch)); err != nil {
+		admin.Close()
+		t.Fatalf("drop scratch db: %v", err)
+	}
+	if _, err := admin.Exec(fmt.Sprintf(`CREATE DATABASE %q`, scratch)); err != nil {
+		admin.Close()
+		t.Fatalf("create scratch db: %v", err)
+	}
+	storeDSN := pgRewriteDB(dsn, scratch)
+	st, err := NewDBStore("postgres", storeDSN)
+	if err != nil {
+		admin.Exec(fmt.Sprintf(`DROP DATABASE IF EXISTS %q`, scratch))
+		admin.Close()
+		t.Fatalf("open store: %v", err)
+	}
+	if err := st.Migrate(context.Background()); err != nil {
+		st.Close()
+		admin.Exec(fmt.Sprintf(`DROP DATABASE IF EXISTS %q`, scratch))
+		admin.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	cleanup := func() {
+		st.Close()
+		_, _ = admin.Exec(fmt.Sprintf(`DROP DATABASE IF EXISTS %q`, scratch))
+		admin.Close()
+	}
+	return st, cleanup
+}
+
+// pgRewriteDB returns a copy of a lib/pq DSN with the database path replaced
+// by newDB. It handles both the "postgres://…/dbname?…" URL form and the
+// "host=… dbname=…" keyword form. Used to retarget a connection at the
+// maintenance "postgres" DB or a per-test scratch DB.
+func pgRewriteDB(dsn, newDB string) string {
+	// URL form: scheme://user:pass@host:port/dbname?params
+	if i := strings.Index(dsn, "://"); i >= 0 {
+		pathStart := i + 3
+		// find start of path after the authority (first '/' after host[:port])
+		slash := strings.IndexByte(dsn[pathStart:], '/')
+		if slash < 0 {
+			return dsn + "/" + newDB
+		}
+		slash += pathStart
+		query := strings.IndexByte(dsn[slash+1:], '?')
+		if query < 0 {
+			return dsn[:slash+1] + newDB
+		}
+		return dsn[:slash+1] + newDB + dsn[slash+1+query:]
+	}
+	// Keyword form: replace dbname=… value (space-terminated).
+	if k := strings.Index(dsn, "dbname="); k >= 0 {
+		rest := dsn[k+len("dbname="):]
+		sp := strings.IndexByte(rest, ' ')
+		if sp < 0 {
+			return dsn[:k] + "dbname=" + newDB
+		}
+		return dsn[:k] + "dbname=" + newDB + rest[sp:]
+	}
+	return dsn + " dbname=" + newDB
+}
+
+// TestCronJobsPGTimestampTZ verifies the timezone fix on Postgres. The cron
+// schedule columns must be timestamptz so a Go time.Time carrying a non-UTC
+// offset survives the write/read round-trip as the exact same instant.
+//
+// This is the regression guard for the bug where a Beijing-time "09:00" job
+// was stored as 09:00 wall-clock and reinterpreted as 09:00 UTC = 17:00
+// Beijing, firing 8h late. Before the fix the drift assertion fails.
+func TestCronJobsPGTimestampTZ(t *testing.T) {
+	st, cleanup := openTestPG(t)
+	defer cleanup()
+	ctx := context.Background()
+	db := st.DB()
+
+	// Schema assertion: the four time columns are timestamptz, not timestamp.
+	for _, col := range []string{"next_run", "last_run", "locked_at", "created_at"} {
+		isTZ, err := st.columnIsTimestampTZ(ctx, "cron_jobs", col)
+		if err != nil {
+			t.Fatalf("probe %s: %v", col, err)
+		}
+		if !isTZ {
+			t.Errorf("cron_jobs.%s is not timestamptz — timezone bug not migrated", col)
+		}
+	}
+
+	// Regression: write a non-UTC-offset instant (Beijing 09:00 = 01:00 UTC)
+	// and confirm the stored instant reads back exactly, with no drift.
+	beijing, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load Asia/Shanghai: %v", err)
+	}
+	want := time.Date(2026, 7, 2, 9, 0, 0, 0, beijing) // 09:00 +08 = 01:00 UTC
+
+	job := &CronJobRecord{
+		ID:        "tz-test-1",
+		AgentID:   "a_tz",
+		Name:      "beijing 9am",
+		Type:      "cron",
+		Schedule:  "0 9 * * *",
+		Message:   "wake up",
+		Channel:   "web",
+		ChatID:    "c",
+		Timezone:  "Asia/Shanghai",
+		Enabled:   true,
+		NextRun:   &want,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := st.SaveCronJob(ctx, job); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := st.GetCronJob(ctx, "tz-test-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.NextRun == nil {
+		t.Fatal("NextRun nil after round-trip")
+	}
+	drift := got.NextRun.Sub(want)
+	if drift < -time.Second || drift > time.Second {
+		t.Errorf("next_run drift after round-trip = %v (want ~0). wrote %s, read %s",
+			drift, want.Format(time.RFC3339), got.NextRun.Format(time.RFC3339))
+	}
+
+	// GetNextDueTime must return the same instant — the scheduler sleeps
+	// until it, so any drift here directly shifts the fire time.
+	nextDue, err := st.GetNextDueTime(ctx)
+	if err != nil {
+		t.Fatalf("GetNextDueTime: %v", err)
+	}
+	dueDrift := nextDue.Sub(want)
+	if dueDrift < -time.Second || dueDrift > time.Second {
+		t.Errorf("GetNextDueTime drift = %v (want ~0). want %s, got %s",
+			dueDrift, want.Format(time.RFC3339), nextDue.Format(time.RFC3339))
+	}
+
+	// Sanity: also confirm a second column (last_run via UpdateCronJobRun)
+	// round-trips. last_run is written through UpdateCronJobRun.
+	lastRun := time.Date(2026, 7, 1, 9, 0, 0, 0, beijing)
+	future := want.Add(24 * time.Hour)
+	if err := st.UpdateCronJobRun(ctx, "tz-test-1", lastRun, future); err != nil {
+		t.Fatalf("UpdateCronJobRun: %v", err)
+	}
+	got2, err := st.GetCronJob(ctx, "tz-test-1")
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if got2.LastRun == nil {
+		t.Fatal("LastRun nil after update")
+	}
+	lastDrift := got2.LastRun.Sub(lastRun)
+	if lastDrift < -time.Second || lastDrift > time.Second {
+		t.Errorf("last_run drift = %v. wrote %s, read %s",
+			lastDrift, lastRun.Format(time.RFC3339), got2.LastRun.Format(time.RFC3339))
+	}
+
+	// locked_at is exercised by LockCronJob. Verify it too for completeness.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE cron_jobs SET locked_at = $1 WHERE id = $2`, want, "tz-test-1"); err != nil {
+		t.Fatalf("set locked_at: %v", err)
+	}
+	var lockedAt time.Time
+	if err := db.QueryRowContext(ctx,
+		`SELECT locked_at FROM cron_jobs WHERE id = $1`, "tz-test-1").Scan(&lockedAt); err != nil {
+		t.Fatalf("read locked_at: %v", err)
+	}
+	lockDrift := lockedAt.Sub(want)
+	if lockDrift < -time.Second || lockDrift > time.Second {
+		t.Errorf("locked_at drift = %v. wrote %s, read %s",
+			lockDrift, want.Format(time.RFC3339), lockedAt.Format(time.RFC3339))
+	}
+}
+
+// TestCronJobsPGMigrationIdempotent asserts that re-running Migrate on an
+// already-converted schema is a no-op (no error, columns stay timestamptz,
+// no data loss on the row we leave behind). The migration must be safe to
+// run repeatedly — daemon restarts call Migrate on every boot.
+func TestCronJobsPGMigrationIdempotent(t *testing.T) {
+	st, cleanup := openTestPG(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Leave a row in place, then re-run Migrate. The idempotent path must
+	// detect timestamptz and skip — it must NOT truncate.
+	keep := time.Now().Add(time.Hour).UTC()
+	job := &CronJobRecord{
+		ID: "keep-1", AgentID: "a", Type: "interval", Schedule: "1h",
+		Message: "x", Channel: "web", ChatID: "c", Timezone: "UTC",
+		Enabled: true, NextRun: &keep, CreatedAt: time.Now().UTC(),
+	}
+	if err := st.SaveCronJob(ctx, job); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("second Migrate failed: %v", err)
+	}
+
+	// Row must survive (no truncation on the idempotent path).
+	got, err := st.GetCronJob(ctx, "keep-1")
+	if err != nil {
+		t.Fatalf("get after re-migrate: %v (row was wrongly truncated)", err)
+	}
+	if got.NextRun == nil {
+		t.Fatal("NextRun nil after re-migrate")
+	}
+	drift := got.NextRun.Sub(keep)
+	if drift < -time.Second || drift > time.Second {
+		t.Errorf("next_run changed on idempotent re-migrate: drift=%v", drift)
+	}
+}

--- a/internal/store/database.go
+++ b/internal/store/database.go
@@ -169,6 +169,13 @@ func (d *DBStore) Migrate(ctx context.Context) error {
 	if err := d.migrateConfigsDropLegacyColumns(ctx); err != nil {
 		return fmt.Errorf("migrate configs drop legacy columns: %w", err)
 	}
+	// Promote cron_jobs time columns to timestamptz. Runs last among the
+	// cron_jobs migrations so the table has its final column shape before
+	// the type conversion (ADD COLUMN works on any column type, so the
+	// earlier failure_count / user_id steps don't depend on this one).
+	if err := d.migrateCronJobsTimestampTZ(ctx); err != nil {
+		return fmt.Errorf("migrate cron_jobs timestamptz: %w", err)
+	}
 	return nil
 }
 
@@ -949,6 +956,110 @@ func (d *DBStore) migrateCronJobsFailureCount(ctx context.Context) error {
 		return fmt.Errorf("add failure_count: %w", err)
 	}
 	return nil
+}
+
+// migrateCronJobsTimestampTZ fixes the timezone bug on the cron schedule
+// columns. The time columns (next_run, last_run, locked_at, created_at)
+// were declared TIMESTAMP without time zone. lib/pq sends each Go
+// time.Time to the server carrying its original zone offset
+// ("2006-01-02 15:04:05.999999999Z07:00"), but a TIMESTAMP-without-tz
+// column silently drops the offset and keeps only the wall-clock text.
+// Reading it back yields a UTC instant whose wall-clock equals the
+// chatter's local wall-clock — so a "09:00 Asia/Shanghai" job is stored
+// as 09:00 and reinterpreted as 09:00 UTC = 17:00 Beijing, firing 8h
+// late. SQLite is unaffected (its driver stores the full instant).
+//
+// Fix: promote the columns to timestamptz. That type preserves the
+// instant across write/read regardless of offset or session TimeZone
+// (verified end-to-end against lib/pq). This is Postgres-only; SQLite
+// has no separate timestamptz type and already stores instants losslessly.
+//
+// Existing rows are wiped rather than converted: their stored
+// wall-clocks are wrong (offset already dropped), so any conversion
+// would just freeze the bug into the new type. Truncating is safe here
+// because cron rows are ephemeral schedule state, not history — the
+// scheduler rewrites next_run on every fire and deletes "once" rows
+// after firing, so a clean reschedule is the correct recovery and
+// cheaper than per-row guesswork.
+//
+// Idempotent: the probe on pg_catalog.format_type short-circuits once a
+// column is already timestamptz, so re-runs and fresh installs are no-ops.
+// On SQLite the tableHasColumnType probe returns (false, nil) and the
+// whole step is skipped.
+func (d *DBStore) migrateCronJobsTimestampTZ(ctx context.Context) error {
+	if d.dialect != "postgres" {
+		return nil
+	}
+	cols := []string{"next_run", "last_run", "locked_at", "created_at"}
+	needConvert := false
+	for _, col := range cols {
+		isTZ, err := d.columnIsTimestampTZ(ctx, "cron_jobs", col)
+		if err != nil {
+			return fmt.Errorf("probe cron_jobs.%s type: %w", col, err)
+		}
+		if !isTZ {
+			needConvert = true
+			break
+		}
+	}
+	if !needConvert {
+		return nil
+	}
+	// Count first so the upgrade is observable: a non-zero count tells an
+	// operator that existing schedule state is about to be wiped and must be
+	// recreated (see CHANGELOG). The count is logged before the TRUNCATE so
+	// it survives even if the type conversion that follows were to fail.
+	var wiping int
+	if err := d.db.QueryRowContext(ctx, `SELECT count(*) FROM cron_jobs`).Scan(&wiping); err != nil {
+		return fmt.Errorf("count cron_jobs before tz migration: %w", err)
+	}
+	if wiping > 0 {
+		slog.Warn("resetting cron schedule state for timestamptz migration — existing jobs must be recreated",
+			"rows", wiping,
+			"reason", "stored next_run values carry the pre-fix wrong timezone; see CHANGELOG")
+	}
+	// Wipe the schedule state in place, then widen the columns. Doing the
+	// DELETE before the ALTER means the type change is instant on an empty
+	// table (no heap rewrite), and there are no stale rows to convert.
+	if _, err := d.db.ExecContext(ctx, `TRUNCATE TABLE cron_jobs`); err != nil {
+		return fmt.Errorf("truncate cron_jobs: %w", err)
+	}
+	for _, col := range cols {
+		// AT TIME ZONE 'UTC' is a no-op type-wise but documents intent: the
+		// emptied column is interpreted in UTC when repopulated. The column
+		// type becomes timestamptz in all cases.
+		stmt := fmt.Sprintf(
+			`ALTER TABLE cron_jobs ALTER COLUMN %s TYPE timestamptz USING %s AT TIME ZONE 'UTC'`,
+			col, col)
+		if _, err := d.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("convert cron_jobs.%s to timestamptz: %w\nSQL: %s", col, err, stmt)
+		}
+	}
+	return nil
+}
+
+// columnIsTimestampTZ reports whether the column's Postgres type is
+// timestamptz (timestamp with time zone). Used by migrations that need
+// to promote a TIMESTAMP-without-tz column and stay idempotent. Returns
+// (false, nil) on SQLite — callers must gate on dialect themselves.
+func (d *DBStore) columnIsTimestampTZ(ctx context.Context, table, column string) (bool, error) {
+	if d.dialect != "postgres" {
+		return false, nil
+	}
+	var dataType string
+	err := d.db.QueryRowContext(ctx,
+		`SELECT format_type(a.atttypid, a.atttypmod)
+		   FROM pg_attribute a
+		   JOIN pg_class c ON c.oid = a.attrelid
+		  WHERE c.relname = $1 AND a.attname = $2 AND a.attnum > 0`,
+		table, column).Scan(&dataType)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return dataType == "timestamp with time zone", nil
 }
 
 // migrateUsersAvatarURL retrofits the avatar_url column onto pre-feature


### PR DESCRIPTION
## Problem

`load_skill` replaced the `{baseDir}` placeholder in `SKILL.md` with the skill's **host** directory (e.g. `/home/<user>/.fastclaw/skills/<name>/...`). But the sandbox bind-mounts those scripts at a different path — `/skills/<name>/` for per-agent & managed skills, `/root/.agents/skills/<name>/` for per-user skills — so **every skill that referenced its scripts via `{baseDir}` produced a path that does not exist inside the container and failed at exec time.**

### Repro
A `SKILL.md` containing:
```
Run {baseDir}/scripts/render.py
```
made `load_skill` emit:
```
Run /home/<user>/.fastclaw/.../scripts/render.py   ← does NOT exist in container
```
which the container failed to resolve (`MODULE_NOT_FOUND` / `No such file`). Only skills whose authors hardcoded the container path `/skills/<name>/...` worked at all.

### Root cause
`load_skill.go`:
```go
skillDir, _ := filepath.Abs(filepath.Join(dir, args.Name))   // host path
content := strings.ReplaceAll(string(data), "{baseDir}", skillDir)
```
`dir` comes from `SkillsLoader.allSkillDirs()` (host dirs), so `{baseDir}` always resolved to a host path — which is meaningless inside the container.

A second, related gap: the sandbox system prompt only documented `/skills/<name>/`. Per-user skill scripts live under `/root/.agents/skills/<name>/` (a separate RW whole-directory mount for `npx skills add -g`), so the model had no way to discover them on its own.

## Fix

**1. Map `{baseDir}` to the correct in-container path** — `internal/agent/tools/load_skill.go`
- New `containerBaseDir()` helper: returns `/root/.agents/skills/<name>` when the matched skill layer is the per-user dir (its scripts are RW-mounted there), otherwise `/skills/<name>` (per-agent / managed layers).
- `RegisterLoadSkill` now takes the chatter's per-user host dir (from the new `SkillsLoader.UserSkillsDir()`) so the layer can be identified; threaded through the three call sites in `loop.go`.

```go
containerBase := containerBaseDir(dir, userSkillsHostDir, args.Name)
content := strings.ReplaceAll(string(data), "{baseDir}", containerBase)
```

**2. Surface the per-user mount path in the sandbox system prompt** — `internal/agent/prompt_modules.go`

Document both paths so the model can locate per-user scripts:
```
- /skills/<name>/                 ← per-agent & managed skills (read-only)
- /root/.agents/skills/<name>/    ← your PER-USER skills (read-write)
```

## Layer → container path mapping (after fix)

| Skill layer | Host dir | `{baseDir}` resolves to | mount |
|---|---|---|---|
| per-agent / managed | `~/.fastclaw/{agents/<id>/agent/,}skills` | `/skills/<name>` | `:ro`, per-entry (SKILL.md excluded) |
| per-user | `~/.fastclaw/users/<uid>/skills` | `/root/.agents/skills/<name>` | `:rw`, whole dir |
| team / extra | (not currently mounted) | `/skills/<name>` | — |

## Verification

- `go build ./...` and `go vet ./...` clean.
- Existing `load_skill` tests updated: assert the **container** path is emitted, and assert the **host** path is NOT leaked.
- New table-driven test `TestLoadSkillPerUserLayerMapsBaseDirToAgentSkills` covers both the managed-layer → `/skills/<name>` and per-user-layer → `/root/.agents/skills/<name>` mappings.
- **End-to-end**: a `{baseDir}`-referencing probe skill failed before this change (`Cannot find module '/home/.../probe.js'`) and runs from `/skills/path-probe/scripts/probe.js` after.

```
Test 1 ({baseDir}):     FAILED before → OK after   ← fix
Test 2 (relative path): depends on cwd (independent of this fix)
Test 3 (/skills/...):   OK before and after
```

## What this does NOT change

- `/skills/` read-only mount: intentional (scripts dir stays immutable; skill-root writes go to the container overlay and don't pollute the host).
- `SKILL.md` excluded from `/skills/` mounts: intentional exfil guard.
- Relative-path references (`./foo.js`): inherently unreliable because the container cwd is `/workspace`, not the skill dir. Authors should use `{baseDir}/foo.js` instead. Not addressed by code — it's a doc/authoring concern, and `{baseDir}` now reliably resolves to the correct absolute path.

## Files changed
- `internal/agent/tools/load_skill.go` — `containerBaseDir()` + `{baseDir}` replacement
- `internal/agent/skills.go` — exported `UserSkillsDir()`
- `internal/agent/loop.go` — thread `UserSkillsDir()` to the 3 `RegisterLoadSkill` call sites
- `internal/agent/prompt_modules.go` — document per-user mount path
- `internal/agent/tools/load_skill_test.go` — updated assertions + new table-driven test