### PR TITLE
fix(skills): resolve {baseDir} to in-container path so skill scripts run

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -305,7 +305,7 @@ func NewAgentWithSkillsCfg(rc config.ResolvedAgent, prov provider.Provider, mb *
 	// executor-pool failure would silently fall through to /bin/sh on the
 	// host, defeating the security boundary the user asked for.
 	skillDirs := loader.AllSkillDirs()
-	tools.RegisterLoadSkill(registry, skillDirs)
+	tools.RegisterLoadSkill(registry, skillDirs, loader.UserSkillsDir())
 	var sbCfg *tools.SandboxConfig
 	if rc.Sandbox.Enabled {
 		sbCfg = &tools.SandboxConfig{Enabled: true}
@@ -3308,7 +3308,7 @@ func (a *Agent) refreshSkillsFromStore(userID string) {
 	skills := loader.LoadSkills()
 	summary := loader.BuildSkillsSummary(skills)
 	a.ctxBuilder.SetSkillsSummary(summary)
-	tools.RegisterLoadSkill(a.registry, loader.AllSkillDirs())
+	tools.RegisterLoadSkill(a.registry, loader.AllSkillDirs(), loader.UserSkillsDir())
 	// Per-turn fingerprint of the skill set the system prompt will
 	// ship. Lets us diff IM vs web for the same (agent, chatter) and
 	// confirm — or rule out — that agent-scope skills are reaching
@@ -3342,7 +3342,7 @@ func (a *Agent) ReloadWorkspaceFiles() {
 	}
 	skills := loader.LoadSkills()
 	skillsSummary := loader.BuildSkillsSummary(skills)
-	tools.RegisterLoadSkill(a.registry, loader.AllSkillDirs())
+	tools.RegisterLoadSkill(a.registry, loader.AllSkillDirs(), loader.UserSkillsDir())
 	a.ctxBuilder = NewContextBuilder(a.homePath, a.memory, skillsSummary)
 	a.ctxBuilder.SetWorkspace(a.workspacePath)
 	a.ctxBuilder.SetPromptMode(a.promptMode)

--- a/internal/agent/prompt_modules.go
+++ b/internal/agent/prompt_modules.go
@@ -498,6 +498,13 @@ You have access to a sandbox environment for executing code. Key rules:
                                     so the next sandbox start picks it up). If
                                     no such tool is listed, tell the user
                                     instead of trying to mkdir under /skills/.
+- /root/.agents/skills/<name>/    ← your PER-USER skills live here. When a skill
+                                    was created by you mid-chat (or installed via
+                                    ` + "`npx skills add -g -y`" + `), its scripts are mounted HERE,
+                                    read-write — NOT under /skills/. So if you
+                                    cannot find a skill's scripts under /skills/<name>/,
+                                    look under /root/.agents/skills/<name>/ before
+                                    concluding they are missing.
 - Host paths (anything starting with /Users/, /home/, /var/, etc.) DO NOT EXIST in the sandbox. Never reference them.
 
 ## Shell quirks

--- a/internal/agent/skills.go
+++ b/internal/agent/skills.go
@@ -478,6 +478,15 @@ func (sl *SkillsLoader) allSkillDirs() []string {
 	return dirs
 }
 
+// UserSkillsDir returns the chatter's per-user skills host directory
+// (~/.fastclaw/users/<uid>/skills), or "" when there is no per-user layer.
+// Exported so load_skill can map a per-user skill's {baseDir} placeholder to
+// its in-container mount path /root/.agents/skills/<name> instead of the
+// default /skills/<name> used by per-agent / managed skills.
+func (sl *SkillsLoader) UserSkillsDir() string {
+	return sl.userSkillsDir()
+}
+
 // userSkillsDir returns ~/.fastclaw/users/<uid>/skills (FASTCLAW_HOME-aware).
 // Empty when no userID is set so the loader skips the layer entirely on
 // single-user installs / legacy paths.

--- a/internal/agent/tools/load_skill.go
+++ b/internal/agent/tools/load_skill.go
@@ -16,7 +16,16 @@ type loadSkillArgs struct {
 }
 
 // RegisterLoadSkill registers the load_skill tool that reads full SKILL.md content.
-func RegisterLoadSkill(r *Registry, skillDirs []string) {
+//
+// userSkillsHostDir is the chatter's per-user skills host directory
+// (~/.fastclaw/users/<uid>/skills), or "" when there is no per-user layer.
+// It lets makeLoadSkill map a per-user skill's {baseDir} placeholder to its
+// in-container path /root/.agents/skills/<name> (the read-write mount used by
+// `npx skills add -g -y`), instead of the default /skills/<name> used by the
+// per-agent / managed layers. Without this, a skill referenced via {baseDir}
+// resolves to a host path that does not exist inside the sandbox and the
+// script can't be found.
+func RegisterLoadSkill(r *Registry, skillDirs []string, userSkillsHostDir string) {
 	r.Register("load_skill", "Load the full content of a skill by name. Use this when you need detailed instructions for a specific skill.", map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
@@ -26,10 +35,10 @@ func RegisterLoadSkill(r *Registry, skillDirs []string) {
 			},
 		},
 		"required": []string{"name"},
-	}, makeLoadSkill(skillDirs))
+	}, makeLoadSkill(skillDirs, userSkillsHostDir))
 }
 
-func makeLoadSkill(skillDirs []string) ToolFunc {
+func makeLoadSkill(skillDirs []string, userSkillsHostDir string) ToolFunc {
 	return func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 		var args loadSkillArgs
 		if err := json.Unmarshal(rawArgs, &args); err != nil {
@@ -48,8 +57,16 @@ func makeLoadSkill(skillDirs []string) ToolFunc {
 			skillPath := filepath.Join(dir, args.Name, "SKILL.md")
 			data, err := os.ReadFile(skillPath)
 			if err == nil {
-				skillDir, _ := filepath.Abs(filepath.Join(dir, args.Name))
-				content := strings.ReplaceAll(string(data), "{baseDir}", skillDir)
+				// {baseDir} must resolve to the script's IN-CONTAINER path, not the
+				// host path. The sandbox bind-mounts each skill folder:
+				//   per-agent / managed layers → /skills/<name>/          (read-only)
+				//   per-user layer             → /root/.agents/skills/<name>/  (read-write)
+				// Replacing {baseDir} with the host path (the old behavior) produced
+				// "/home/<user>/.fastclaw/.../scripts/render.py" — a path that does
+				// NOT exist inside the container, so every skill that referenced its
+				// scripts via {baseDir} failed at exec time.
+				containerBase := containerBaseDir(dir, userSkillsHostDir, args.Name)
+				content := strings.ReplaceAll(string(data), "{baseDir}", containerBase)
 				if reason := unavailableReason(data); reason != "" {
 					content = "[SKILL CURRENTLY UNAVAILABLE: " + reason +
 						". Explain this to the user and ask an administrator to configure the missing requirement before using authenticated operations.]\n\n" +
@@ -61,6 +78,24 @@ func makeLoadSkill(skillDirs []string) ToolFunc {
 
 		return "", fmt.Errorf("skill %q not found", args.Name)
 	}
+}
+
+// containerBaseDir maps a skill's host layer directory to the path where its
+// scripts are visible INSIDE the sandbox container. The match against
+// userSkillsHostDir is exact: the per-user mount is a single whole-directory
+// bind (<base>/users/<uid>/skills → /root/.agents/skills), so only the layer
+// dir itself maps to that container path — every other layer (per-agent,
+// managed, team, extra) is enumerated and mounted under /skills/<name>.
+//
+// Team / extra dirs are not currently mounted into the container at all
+// (skillDirsForAgent only returns per-agent + managed), but we still return
+// /skills/<name> for them: it matches the documented convention and avoids
+// fabricating a host path that is definitely wrong.
+func containerBaseDir(hostSkillLayerDir, userSkillsHostDir, skillName string) string {
+	if userSkillsHostDir != "" && hostSkillLayerDir == userSkillsHostDir {
+		return "/root/.agents/skills/" + skillName
+	}
+	return "/skills/" + skillName
 }
 
 // wrapSkillContentInternal prefixes SKILL.md content with an explicit

--- a/internal/agent/tools/load_skill_test.go
+++ b/internal/agent/tools/load_skill_test.go
@@ -26,7 +26,7 @@ Run {baseDir}/scripts/render.py with JSON input.`
 	}
 
 	r := NewRegistry(t.TempDir(), t.TempDir())
-	RegisterLoadSkill(r, []string{filepath.Join(home, "skills")})
+	RegisterLoadSkill(r, []string{filepath.Join(home, "skills")}, "")
 
 	fn := r.GetFunc("load_skill")
 	if fn == nil {
@@ -41,8 +41,14 @@ Run {baseDir}/scripts/render.py with JSON input.`
 		t.Fatal(err)
 	}
 
-	if !strings.Contains(got, "Run "+skillDir+"/scripts/render.py") {
-		t.Fatalf("load_skill did not return full content with baseDir replaced:\n%s", got)
+	// {baseDir} must resolve to the IN-CONTAINER path, not the host path.
+	// The sandbox mounts per-agent/managed skills at /skills/<name>, so the
+	// placeholder should become /skills/chart-maker — never the host dir.
+	if !strings.Contains(got, "Run /skills/chart-maker/scripts/render.py") {
+		t.Fatalf("load_skill did not return full content with baseDir replaced by container path:\n%s", got)
+	}
+	if strings.Contains(got, skillDir+"/scripts/render.py") {
+		t.Fatalf("load_skill leaked the HOST skill path into output:\n%s", got)
 	}
 	if !strings.Contains(got, "INTERNAL CONTEXT") {
 		t.Fatalf("load_skill output missing internal wrapper:\n%s", got)
@@ -65,7 +71,7 @@ func TestLoadSkillUsesDirectoryPrecedence(t *testing.T) {
 	}
 
 	r := NewRegistry(t.TempDir(), t.TempDir())
-	RegisterLoadSkill(r, []string{agentSkills, userSkills})
+	RegisterLoadSkill(r, []string{agentSkills, userSkills}, "")
 	rawArgs, err := json.Marshal(map[string]string{"name": "shared"})
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +110,7 @@ Authenticated instructions.`
 	}
 
 	r := NewRegistry(t.TempDir(), t.TempDir())
-	RegisterLoadSkill(r, []string{filepath.Join(home, "skills")})
+	RegisterLoadSkill(r, []string{filepath.Join(home, "skills")}, "")
 	rawArgs, err := json.Marshal(map[string]string{"name": "deepcoin-trade"})
 	if err != nil {
 		t.Fatal(err)
@@ -119,5 +125,67 @@ Authenticated instructions.`
 	}
 	if !strings.Contains(got, "DC_API_KEY, DC_SECRET_KEY") {
 		t.Fatalf("load_skill output missing env names:\n%s", got)
+	}
+}
+
+// TestLoadSkillPerUserLayerMapsBaseDirToAgentSkills verifies that a skill
+// installed at the per-user layer resolves {baseDir} to the per-user in-container
+// mount path /root/.agents/skills/<name>, not the default /skills/<name> used by
+// per-agent/managed skills. The per-user layer is bind-mounted RW as a whole
+// directory at /root/.agents/skills (the location `npx skills add -g` writes to),
+// so its scripts are NOT under /skills/.
+func TestLoadSkillPerUserLayerMapsBaseDirToAgentSkills(t *testing.T) {
+	home := t.TempDir()
+	// managed layer dir (for contrast — should still map to /skills/<name>)
+	managedSkills := filepath.Join(home, "skills")
+	// per-user layer dir — mimics ~/.fastclaw/users/<uid>/skills
+	userSkills := filepath.Join(home, "users", "u_test", "skills")
+
+	for _, tc := range []struct {
+		name        string
+		skillLayer  string // host dir holding the skill folder
+		skillName   string
+		wantSubstr string // expected in-container path the placeholder resolves to
+	}{
+		{
+			name:        "managed layer maps to /skills/<name>",
+			skillLayer:  managedSkills,
+			skillName:   "managed-tool",
+			wantSubstr: "/skills/managed-tool/scripts/run.py",
+		},
+		{
+			name:        "per-user layer maps to /root/.agents/skills/<name>",
+			skillLayer:  userSkills,
+			skillName:   "user-tool",
+			wantSubstr: "/root/.agents/skills/user-tool/scripts/run.py",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			skillDir := filepath.Join(tc.skillLayer, tc.skillName)
+			if err := os.MkdirAll(skillDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := "---\nname: " + tc.skillName + "\ndescription: test.\n---\n\nRun {baseDir}/scripts/run.py"
+			if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			r := NewRegistry(t.TempDir(), t.TempDir())
+			// Order mirrors SkillsLoader.allSkillDirs: per-user dir is passed
+			// AND identified via the userSkillsHostDir argument.
+			RegisterLoadSkill(r, []string{managedSkills, userSkills}, userSkills)
+
+			rawArgs, err := json.Marshal(map[string]string{"name": tc.skillName})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := r.GetFunc("load_skill")(context.Background(), rawArgs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("expected %q in output, got:\n%s", tc.wantSubstr, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

`load_skill` replaced the `{baseDir}` placeholder in `SKILL.md` with the skill's **host** directory (e.g. `/home/<user>/.fastclaw/skills/<name>/...`). But the sandbox bind-mounts those scripts at a different path — `/skills/<name>/` for per-agent & managed skills, `/root/.agents/skills/<name>/` for per-user skills — so **every skill that referenced its scripts via `{baseDir}` produced a path that does not exist inside the container and failed at exec time.**

### Repro
A `SKILL.md` containing:
~~~
Run {baseDir}/scripts/render.py
~~~
made `load_skill` emit:
~~~
Run /home/<user>/.fastclaw/.../scripts/render.py   ← does NOT exist in container
~~~
which the container failed to resolve (`MODULE_NOT_FOUND` / `No such file`). Only skills whose authors hardcoded the container path `/skills/<name>/...` worked at all.

### Root cause
`load_skill.go`:
```go
skillDir, _ := filepath.Abs(filepath.Join(dir, args.Name))   // host path
content := strings.ReplaceAll(string(data), "{baseDir}", skillDir)
```
`dir` comes from `SkillsLoader.allSkillDirs()` (host dirs), so `{baseDir}` always resolved to a host path — which is meaningless inside the container.

A second, related gap: the sandbox system prompt only documented `/skills/<name>/`. Per-user skill scripts live under `/root/.agents/skills/<name>/` (a separate RW whole-directory mount for `npx skills add -g`), so the model had no way to discover them on its own.

## Fix

**1. Map `{baseDir}` to the correct in-container path** — `internal/agent/tools/load_skill.go`
- New `containerBaseDir()` helper: returns `/root/.agents/skills/<name>` when the matched skill layer is the per-user dir (its scripts are RW-mounted there), otherwise `/skills/<name>` (per-agent / managed layers).
- `RegisterLoadSkill` now takes the chatter's per-user host dir (from the new `SkillsLoader.UserSkillsDir()`) so the layer can be identified; threaded through the three call sites in `loop.go`.

```go
containerBase := containerBaseDir(dir, userSkillsHostDir, args.Name)
content := strings.ReplaceAll(string(data), "{baseDir}", containerBase)
```

**2. Surface the per-user mount path in the sandbox system prompt** — `internal/agent/prompt_modules.go`

Document both paths so the model can locate per-user scripts:
~~~
- /skills/<name>/                 ← per-agent & managed skills (read-only)
- /root/.agents/skills/<name>/    ← your PER-USER skills (read-write)
~~~

## Layer → container path mapping (after fix)

| Skill layer | Host dir | `{baseDir}` resolves to | mount |
|---|---|---|---|
| per-agent / managed | `~/.fastclaw/{agents/<id>/agent/,}skills` | `/skills/<name>` | `:ro`, per-entry (SKILL.md excluded) |
| per-user | `~/.fastclaw/users/<uid>/skills` | `/root/.agents/skills/<name>` | `:rw`, whole dir |
| team / extra | (not currently mounted) | `/skills/<name>` | — |

## Verification

- `go build ./...` and `go vet ./...` clean on top of latest `dev`.
- Existing `load_skill` tests updated: assert the **container** path is emitted, and assert the **host** path is NOT leaked.
- New table-driven test `TestLoadSkillPerUserLayerMapsBaseDirToAgentSkills` covers both the managed-layer → `/skills/<name>` and per-user-layer → `/root/.agents/skills/<name>` mappings.
- **End-to-end**: a `{baseDir}`-referencing probe skill failed before this change (`Cannot find module '/home/.../probe.js'`) and runs from `/skills/path-probe/scripts/probe.js` after.

| test | before | after |
|---|---|---|
| `{baseDir}` reference | FAILED (`Cannot find module '/home/...'`) | **OK** (runs from `/skills/<name>/`) |
| relative path | depends on cwd (independent of this fix) | unchanged |
| container-abs `/skills/...` | OK | OK |

## What this does NOT change

- `/skills/` read-only mount: intentional (scripts dir stays immutable; skill-root writes go to the container overlay and don't pollute the host).
- `SKILL.md` excluded from `/skills/` mounts: intentional exfil guard.
- Relative-path references (`./foo.js`): inherently unreliable because the container cwd is `/workspace`, not the skill dir. Authors should use `{baseDir}/foo.js` instead — which this PR makes resolve reliably.

## Files changed (5)
- `internal/agent/tools/load_skill.go` — `containerBaseDir()` + `{baseDir}` replacement
- `internal/agent/skills.go` — exported `UserSkillsDir()`
- `internal/agent/loop.go` — thread `UserSkillsDir()` to the 3 `RegisterLoadSkill` call sites
- `internal/agent/prompt_modules.go` — document per-user mount path
- `internal/agent/tools/load_skill_test.go` — updated assertions + new table-driven test