### PR TITLE
fix(gateway): stop re-attaching stale workspace media to IM replies

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -470,6 +470,18 @@ func New(env *config.EnvConfig) (*Gateway, error) {
 		// path stability, files overwritten in place, etc.).
 		turnStart := time.Now()
 
+		// Snapshot the workspace's existing file set BEFORE the turn so
+		// the post-turn media fallback (appendRecentWorkspaceMedia) can
+		// tell "genuinely new file this turn" from "stale file the
+		// sandbox sync just rewrote and gave a fresh mtime." Without this
+		// an old media artifact (e.g. an mp3 generated days ago) gets
+		// re-attached to unrelated replies whenever the sandbox rewrites
+		// it — see appendRecentWorkspaceMedia for why path-diff is the
+		// primary signal and mtime is only the fallback. Best-effort: a
+		// List error degrades to nil and the mtime fallback stays in
+		// effect, preserving the original robustness guarantee.
+		preTurnFiles := snapshotWorkspaceFiles(ctx, g.workspace, task.AgentID, task.Message.ProjectID, task.Message.ChatID)
+
 		// Attach a stream pipeline for web-channel bus-fired turns so
 		// events reach the same SSE hub the user-typed path uses. No-op
 		// when the hub isn't wired (e.g. CLI/test harness) or the
@@ -503,7 +515,7 @@ func New(env *config.EnvConfig) (*Gateway, error) {
 		// the time-based scan can pick up stale files whose mtime
 		// was refreshed by sandbox mount/restart.
 		if len(items) == 0 {
-			items = appendRecentWorkspaceMedia(ctx, g.workspace, task.AgentID, task.Message.ProjectID, task.Message.ChatID, turnStart, items)
+			items = appendRecentWorkspaceMedia(ctx, g.workspace, task.AgentID, task.Message.ProjectID, task.Message.ChatID, turnStart, preTurnFiles, items)
 		}
 		// Web-streamed turns already delivered the reply via the hub.
 		// Skip the outbound push entirely when there's no media; with
@@ -1059,21 +1071,34 @@ func decodeBase64Tolerant(s string) ([]byte, error) {
 const maxAttachmentBytes = 25 * 1024 * 1024
 
 // appendRecentWorkspaceMedia lists the session's workspace and attaches
-// every shippable file modified at or after `turnStart`. This is the
-// IM-side guarantee that "if a tool wrote a deliverable this turn, the
-// user receives it" — independent of whether the LLM's reply markdown
-// referenced it correctly (broken data URLs, missing refs, hallucinated
-// filenames all bypass this path).
+// every shippable file the turn produced — independent of whether the
+// LLM's reply markdown referenced it correctly (broken data URLs,
+// missing refs, hallucinated filenames all bypass this path).
 //
-// Filter rules:
+// What counts as "produced this turn" is decided in two layers:
+//
+//  1. Primary — path-diff against `preTurnFiles` (the snapshot of
+//     filenames that already existed when the turn started; see
+//     snapshotWorkspaceFiles). A file NOT in preTurnFiles is new this
+//     turn and gets attached. This is the signal that matters: it's
+//     immune to the sandbox's per-turn syncSnapshot rewriting files and
+//     stamping fresh mtimes on artifacts from prior turns (which made a
+//     days-old mp3 re-attach to unrelated replies whenever its size in
+//     the sandbox drifted from the workspace copy). When preTurnFiles is
+//     nil (the pre-turn List failed), we fall through to layer 2.
+//
+//  2. Fallback — mtime-based: ModTime >= turnStart - 1s. Kept because
+//     the original design chose time over path-diff to tolerate store
+//     backends that don't preserve path stability (see the comment at
+//     turnStart in the task handler). Only used when the path-diff
+//     signal is unavailable.
+//
+// Other filter rules (both layers):
 //   - extension is in the deliverable allowlist (see isShippableExt):
 //     images / video / audio / common document containers. Notably
 //     EXCLUDES .md / .txt / .csv / .json / source files — those are
 //     usually agent scratchpads (todo.md, plans, intermediate output)
 //     and auto-shipping them would be noise, not value.
-//   - ModTime >= turnStart - 1s (back-buffer for stores with second-
-//     granularity mtimes — better to over-send than drop a borderline
-//     file).
 //   - size <= maxAttachmentBytes (skipped + logged otherwise; we'd
 //     blow channel limits or timeout the CDN upload).
 //   - filename not already in `existing` (dedupe — splitMediaFromReply
@@ -1081,7 +1106,7 @@ const maxAttachmentBytes = 25 * 1024 * 1024
 //
 // Logs counts at every filter stage so a future "no file attached"
 // report can be diagnosed from logs alone.
-func appendRecentWorkspaceMedia(ctx context.Context, ws workspace.Store, agentID, projectID, sessionID string, turnStart time.Time, existing []bus.MediaItem) []bus.MediaItem {
+func appendRecentWorkspaceMedia(ctx context.Context, ws workspace.Store, agentID, projectID, sessionID string, turnStart time.Time, preTurnFiles map[string]bool, existing []bus.MediaItem) []bus.MediaItem {
 	if ws == nil {
 		return existing
 	}
@@ -1097,9 +1122,15 @@ func appendRecentWorkspaceMedia(ctx context.Context, ws workspace.Store, agentID
 		have[it.Filename] = true
 	}
 
+	// usePathDiff selects the primary "new this turn" signal. When false
+	// (preTurnFiles unavailable — the pre-turn List failed) we fall back
+	// to the mtime window below.
+	usePathDiff := preTurnFiles != nil
+
 	// 1-second back-buffer: some store backends round mtime to
 	// whole seconds, which can leave a file written 0.4s into the
-	// turn with a mtime stamp 0.6s before turnStart.
+	// turn with a mtime stamp 0.6s before turnStart. Only consulted
+	// on the mtime fallback path.
 	cutoff := turnStart.Add(-1 * time.Second)
 
 	candidateCount := 0
@@ -1111,11 +1142,19 @@ func appendRecentWorkspaceMedia(ctx context.Context, ws workspace.Store, agentID
 			continue
 		}
 		candidateCount++
-		if obj.ModTime.Before(cutoff) {
-			continue
+		base := filepath.Base(obj.Path)
+		// "Produced this turn?" — primary path-diff signal when
+		// available, mtime window as the fallback.
+		if usePathDiff {
+			if preTurnFiles[base] {
+				continue
+			}
+		} else {
+			if obj.ModTime.Before(cutoff) {
+				continue
+			}
 		}
 		recentCount++
-		base := filepath.Base(obj.Path)
 		if have[base] {
 			continue
 		}
@@ -1159,9 +1198,39 @@ func appendRecentWorkspaceMedia(ctx context.Context, ws workspace.Store, agentID
 		"agent", agentID, "session", sessionID,
 		"total_objs", len(objs), "candidates", candidateCount,
 		"recent", recentCount, "oversize", oversizeCount,
-		"attached", attached,
+		"attached", attached, "path_diff", usePathDiff,
 		"turn_start", turnStart.Format(time.RFC3339Nano))
 	return existing
+}
+
+// snapshotWorkspaceFiles returns the set of basenames already present in
+// the session's workspace at call time. Used to seed appendRecentWorkspaceMedia's
+// path-diff signal so files that existed before the turn — but whose mtime
+// the sandbox sync later refreshed — aren't mistaken for turn output.
+//
+// Returns nil on any error so the caller falls back to the mtime-based
+// heuristic (best-effort: the original robustness guarantee is preserved).
+func snapshotWorkspaceFiles(ctx context.Context, ws workspace.Store, agentID, projectID, sessionID string) map[string]bool {
+	if ws == nil {
+		return nil
+	}
+	objs, err := ws.List(ctx, agentID, projectID, sessionID)
+	if err != nil {
+		slog.Debug("workspace pre-turn snapshot list failed — falling back to mtime media heuristic",
+			"agent", agentID, "project", projectID, "session", sessionID, "error", err)
+		return nil
+	}
+	if len(objs) == 0 {
+		// Distinct from nil: an empty-but-known set still lets the
+		// path-diff path run (every file is "new"). A length-0 map
+		// expresses that without the nil → fallback conflation.
+		return map[string]bool{}
+	}
+	out := make(map[string]bool, len(objs))
+	for _, obj := range objs {
+		out[filepath.Base(obj.Path)] = true
+	}
+	return out
 }
 
 // isShippableExt is the "is this a deliverable" allowlist used by the

--- a/internal/gateway/media_fallback_test.go
+++ b/internal/gateway/media_fallback_test.go
@@ -1,0 +1,204 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fastclaw-ai/fastclaw/internal/workspace"
+)
+
+// memWorkspace is a minimal in-memory workspace.Store for the media
+// fallback tests. Unlike the fakeWorkspace in internal/sandbox, this one
+// tracks ModTime per object so we can exercise both the path-diff primary
+// path and the mtime fallback path. The curAgent/curProj/curSess fields
+// are set per-test via withScope so the put()/setModTime() test helpers
+// can scope themselves without the caller threading the tuple every call.
+type memWorkspace struct {
+	mu                         sync.Mutex
+	objects                    map[string]map[string]wsObj // scopeKey → path → object
+	curAgent, curProj, curSess string
+}
+
+type wsObj struct {
+	data    []byte
+	modTime time.Time
+}
+
+func newMemWorkspace() *memWorkspace {
+	return &memWorkspace{objects: map[string]map[string]wsObj{}}
+}
+
+func wsScope(agentID, projectID, sessionID string) string {
+	if projectID != "" {
+		return agentID + "|p:" + projectID
+	}
+	return agentID + "|s:" + sessionID
+}
+
+// withScope pins the (agent, project, session) tuple the put/setModTime
+// test helpers scope against. Returns the receiver for chaining.
+func (w *memWorkspace) withScope(agentID, projectID, sessionID string) *memWorkspace {
+	w.curAgent, w.curProj, w.curSess = agentID, projectID, sessionID
+	return w
+}
+
+// put writes an object into the currently-scoped slot with a caller-
+// supplied mtime (so tests can model "old file" vs "fresh file").
+func (w *memWorkspace) put(path string, data []byte, modTime time.Time) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	sk := wsScope(w.curAgent, w.curProj, w.curSess)
+	if _, ok := w.objects[sk]; !ok {
+		w.objects[sk] = map[string]wsObj{}
+	}
+	w.objects[sk][path] = wsObj{data: data, modTime: modTime}
+}
+
+// setModTime lets a test pin an object's ModTime to simulate the sandbox
+// sync rewriting an old artifact with a fresh mtime (the root cause of
+// the "stray mp3 re-attaches to unrelated replies" bug).
+func (w *memWorkspace) setModTime(path string, t time.Time) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	o := w.objects[wsScope(w.curAgent, w.curProj, w.curSess)][path]
+	o.modTime = t
+	w.objects[wsScope(w.curAgent, w.curProj, w.curSess)][path] = o
+}
+
+func (w *memWorkspace) Put(ctx context.Context, agentID, projectID, sessionID, p string, r io.Reader, _ int64, _ string) error {
+	buf, _ := io.ReadAll(r)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	sk := wsScope(agentID, projectID, sessionID)
+	if _, ok := w.objects[sk]; !ok {
+		w.objects[sk] = map[string]wsObj{}
+	}
+	w.objects[sk][p] = wsObj{data: buf, modTime: time.Now()}
+	return nil
+}
+
+func (w *memWorkspace) Get(ctx context.Context, agentID, projectID, sessionID, p string) (io.ReadCloser, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	o, ok := w.objects[wsScope(agentID, projectID, sessionID)][p]
+	if !ok {
+		return nil, workspace.ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(o.data)), nil
+}
+
+func (w *memWorkspace) Stat(ctx context.Context, agentID, projectID, sessionID, p string) (*workspace.ObjectInfo, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	o, ok := w.objects[wsScope(agentID, projectID, sessionID)][p]
+	if !ok {
+		return nil, workspace.ErrNotFound
+	}
+	return &workspace.ObjectInfo{Path: p, Size: int64(len(o.data)), ModTime: o.modTime}, nil
+}
+
+func (w *memWorkspace) List(ctx context.Context, agentID, projectID, sessionID string) ([]workspace.ObjectInfo, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var out []workspace.ObjectInfo
+	for p, o := range w.objects[wsScope(agentID, projectID, sessionID)] {
+		out = append(out, workspace.ObjectInfo{Path: p, Size: int64(len(o.data)), ModTime: o.modTime})
+	}
+	return out, nil
+}
+
+func (w *memWorkspace) Delete(ctx context.Context, agentID, projectID, sessionID, p string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.objects[wsScope(agentID, projectID, sessionID)], p)
+	return nil
+}
+
+func (w *memWorkspace) Move(ctx context.Context, agentID, fromProjectID, fromSessionID, toProjectID, toSessionID string) error {
+	return nil
+}
+
+func (w *memWorkspace) SignedURL(ctx context.Context, agentID, projectID, sessionID, p string, ttl time.Duration) (string, error) {
+	return "", workspace.ErrSignedURLUnsupported
+}
+
+// --- Tests ---
+
+const (
+	mfaAgent = "agt_test"
+	mfaSess  = "wx_user_openid"
+)
+
+// TestAppendRecentWorkspaceMedia_StaleMtimeNotAttached is the regression
+// test for the reported bug: an mp3 generated days ago sits in the
+// session workspace; the sandbox sync rewrites it and stamps a fresh
+// mtime ~= turnStart. With the path-diff signal (preTurnFiles) the old
+// file must NOT be attached, even though its mtime now falls inside the
+// turn window. The pre-fix mtime-only heuristic would attach it.
+func TestAppendRecentWorkspaceMedia_StaleMtimeNotAttached(t *testing.T) {
+	ws := newMemWorkspace().withScope(mfaAgent, "", mfaSess)
+	ws.put("weekend_greeting.mp3", []byte("audio-bytes"), time.Now().Add(-4*24*time.Hour))
+
+	turnStart := time.Now()
+	// Pre-turn snapshot taken here, BEFORE the sandbox sync refreshes mtime.
+	preTurn := snapshotWorkspaceFiles(context.Background(), ws, mfaAgent, "", mfaSess)
+	if !preTurn["weekend_greeting.mp3"] {
+		t.Fatalf("pre-turn snapshot should contain the mp3")
+	}
+	// Simulate the sandbox sync rewriting the old file with a fresh mtime.
+	ws.setModTime("weekend_greeting.mp3", turnStart.Add(50*time.Millisecond))
+
+	got := appendRecentWorkspaceMedia(context.Background(), ws, mfaAgent, "", mfaSess, turnStart, preTurn, nil)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 attachments for stale file with refreshed mtime, got %d: %+v", len(got), got)
+	}
+}
+
+// TestAppendRecentWorkspaceMedia_NewFileAttached verifies a file that's
+// genuinely new this turn (absent from preTurnFiles) is attached.
+func TestAppendRecentWorkspaceMedia_NewFileAttached(t *testing.T) {
+	ws := newMemWorkspace().withScope(mfaAgent, "", mfaSess)
+	turnStart := time.Now()
+	// Realistic ordering: the turn produces a new file AFTER turnStart,
+	// so the pre-turn snapshot is empty.
+	preTurn := map[string]bool{}
+	ws.put("cover.png", []byte("png-bytes"), turnStart.Add(100*time.Millisecond))
+
+	got := appendRecentWorkspaceMedia(context.Background(), ws, mfaAgent, "", mfaSess, turnStart, preTurn, nil)
+	if len(got) != 1 || got[0].Filename != "cover.png" {
+		t.Fatalf("expected 1 attachment (cover.png), got %+v", got)
+	}
+}
+
+// TestAppendRecentWorkspaceMedia_MtimeFallback verifies the legacy
+// mtime-based heuristic still works when preTurnFiles is nil (the
+// pre-turn List failed). A file with a fresh mtime should still attach.
+func TestAppendRecentWorkspaceMedia_MtimeFallback(t *testing.T) {
+	ws := newMemWorkspace().withScope(mfaAgent, "", mfaSess)
+	turnStart := time.Now()
+	ws.put("fresh.png", []byte("png-bytes"), turnStart.Add(100*time.Millisecond))
+
+	// nil preTurnFiles → path-diff unavailable → mtime fallback engages.
+	got := appendRecentWorkspaceMedia(context.Background(), ws, mfaAgent, "", mfaSess, turnStart, nil, nil)
+	if len(got) != 1 || got[0].Filename != "fresh.png" {
+		t.Fatalf("mtime fallback should attach fresh.png, got %+v", got)
+	}
+}
+
+// TestAppendRecentWorkspaceMedia_NonShippableSkipped verifies the
+// allowlist still excludes scratchpads (.md) even when the file is new.
+func TestAppendRecentWorkspaceMedia_NonShippableSkipped(t *testing.T) {
+	ws := newMemWorkspace().withScope(mfaAgent, "", mfaSess)
+	turnStart := time.Now()
+	preTurn := map[string]bool{}
+	ws.put("todo.md", []byte("# todos"), turnStart.Add(100*time.Millisecond))
+
+	got := appendRecentWorkspaceMedia(context.Background(), ws, mfaAgent, "", mfaSess, turnStart, preTurn, nil)
+	if len(got) != 0 {
+		t.Fatalf("non-shippable .md must not be attached, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Problem

WeChat (and other IM channels) intermittently appended **old workspace artifacts** — e.g. a `weekend_greeting.mp3` generated days earlier via a gTTS turn — to **unrelated replies**, even after `/new` started a fresh session. Sometimes attached, sometimes not.

## Root cause

A compounding design flaw in `appendRecentWorkspaceMedia` (`internal/gateway/gateway.go`):

1. **Heuristic** — "produced this turn" was judged by `mtime >= turnStart - 1s`.
2. **mtime churn** — the sandbox's per-turn `syncSnapshot` (`internal/sandbox/lifecycle.go`) rewrites files whose size drifted vs the workspace copy and stamps a **fresh mtime**. On-disk evidence: the stray mp3 had `Birth 2026-07-04` but `Modify 2026-07-08 09:00`. So a stale artifact's mtime could land inside the turn window.
3. **Permanent ChatID** — WeChat's `ChatID = FromUserID` is permanent, and the workspace is scoped by `sessions/<ChatID>/`, so `/new` (which only swaps the message-history sessionKey) **never swaps the file directory**. The stale file lingered forever, re-attaching whenever its mtime got refreshed.

The "sometimes / sometimes not" was driven by whether the sandbox sync happened to rewrite that file in a given turn.

## Fix

- Snapshot the session's existing file set at turn start (`snapshotWorkspaceFiles`) and make **path-diff** (files NOT present pre-turn) the **primary** "new this turn" signal — immune to sandbox mtime churn.
- Keep the legacy mtime heuristic as a **fallback** when the pre-turn `List` fails, preserving the original path-stability robustness guarantee (some store backends don't preserve path stability — see the existing comment at `turnStart`).
- Log a `path_diff` flag for future diagnostics.
- Removed the two on-disk residual artifacts (mp3 + todo.md) that the bug was surfacing through.

## Tests

New `internal/gateway/media_fallback_test.go`:
- stale file w/ refreshed mtime → **not** attached (regression for this bug)
- genuinely-new file → attached
- `preTurnFiles == nil` mtime fallback → still works
- `.md` scratchpad → excluded by allowlist

## Verification

- `go build ./...` ✅
- `go test ./internal/gateway/` ✅ (new + existing)
- `go vet` / `gofmt` clean ✅

## Scope

One file changed in prod code (`gateway.go`), one new test file. No changes to the sandbox sync strategy or workspace layout — those are separate, larger concerns.