### PR TITLE
fix(cron): isolate scheduled jobs per chatter

### DIFF
--- a/cmd/fastclaw/cmd_cron.go
+++ b/cmd/fastclaw/cmd_cron.go
@@ -76,7 +76,7 @@ func cronListCmd() *cobra.Command {
 }
 
 func cronCreateCmd() *cobra.Command {
-	var agentName, name, typ, schedule, message, channel, accountID, chatID, timezone string
+	var agentName, name, typ, schedule, message, channel, accountID, chatID, timezone, chatterID string
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a scheduled job",
@@ -101,6 +101,7 @@ func cronCreateCmd() *cobra.Command {
 			job := &store.CronJobRecord{
 				ID:        uuid.NewString(),
 				UserID:    ag.UserID,
+				ChatterID: chatterID,
 				AgentID:   ag.ID,
 				Name:      name,
 				Type:      typ,
@@ -131,6 +132,7 @@ func cronCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&accountID, "account", "", "target channel account id")
 	cmd.Flags().StringVar(&chatID, "chat", "", "target chat id")
 	cmd.Flags().StringVar(&timezone, "timezone", "Asia/Shanghai", "IANA timezone")
+	cmd.Flags().StringVar(&chatterID, "chatter", "", "chatter (per-sender app_user) that owns this job; empty means owner/system-created")
 	_ = cmd.MarkFlagRequired("agent")
 	_ = cmd.MarkFlagRequired("schedule")
 	_ = cmd.MarkFlagRequired("message")

--- a/internal/agent/tools/cron.go
+++ b/internal/agent/tools/cron.go
@@ -66,7 +66,7 @@ func RegisterCronTools(r *Registry, st store.Store, userID, agentID string) {
 			"type":       "object",
 			"properties": map[string]interface{}{},
 		},
-		makeListCronJobs(st, userID, agentID),
+		makeListCronJobs(st, r, userID, agentID),
 	)
 
 	r.Register("delete_cron_job",
@@ -81,7 +81,7 @@ func RegisterCronTools(r *Registry, st store.Store, userID, agentID string) {
 			},
 			"required": []string{"id"},
 		},
-		makeDeleteCronJob(st, userID),
+		makeDeleteCronJob(st, r, agentID),
 	)
 }
 
@@ -105,6 +105,11 @@ func makeCreateCronJob(st store.Store, r *Registry, userID, agentID string) Tool
 		channel := r.MessageChannel()
 		accountID := r.MessageAccountID()
 		chatID := r.MessageChatID()
+		// Stamp the chatter that asked for the reminder onto the row so
+		// list_cron_jobs can isolate rows per chatter (otherwise two
+		// chatters of one public agent would see each other's reminders),
+		// and so the fired turn replays under that chatter's identity.
+		chatterID := r.ChatterUserID()
 
 		// The chatter's effective timezone governs how the schedule is
 		// read: zone-less 'once' datetimes and cron wall-clock fields
@@ -151,6 +156,7 @@ func makeCreateCronJob(st store.Store, r *Registry, userID, agentID string) Tool
 		job := &store.CronJobRecord{
 			ID:        id,
 			AgentID:   agentID,
+			ChatterID: chatterID,
 			Name:      args.Name,
 			Type:      jobType,
 			Schedule:  args.Schedule,
@@ -186,13 +192,26 @@ func makeCreateCronJob(st store.Store, r *Registry, userID, agentID string) Tool
 	}
 }
 
-func makeListCronJobs(st store.Store, userID, agentID string) ToolFunc {
+func makeListCronJobs(st store.Store, r *Registry, userID, agentID string) ToolFunc {
 	return func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 		jobs, err := st.ListCronJobsByAgent(ctx, agentID)
 		if err != nil {
 			return "", fmt.Errorf("list cron jobs: %w", err)
 		}
-		filtered := jobs
+		// Isolate rows per chatter: a public agent serving multiple senders
+		// must not leak one chatter's reminders to another. Rows are only
+		// visible to the chatter that created them; legacy rows with an
+		// empty chatter_id (written before per-chatter attribution) are
+		// hidden from every chatter here — they remain visible to the agent
+		// owner via the web dashboard / CLI. This mirrors the OwnerKeyFor
+		// tenancy boundary background shells already enforce.
+		chatterID := r.ChatterUserID()
+		filtered := jobs[:0:0]
+		for _, j := range jobs {
+			if j.ChatterID != "" && j.ChatterID == chatterID {
+				filtered = append(filtered, j)
+			}
+		}
 
 		if len(filtered) == 0 {
 			return "No cron jobs found for this agent.", nil
@@ -203,7 +222,7 @@ func makeListCronJobs(st store.Store, userID, agentID string) ToolFunc {
 	}
 }
 
-func makeDeleteCronJob(st store.Store, userID string) ToolFunc {
+func makeDeleteCronJob(st store.Store, r *Registry, agentID string) ToolFunc {
 	return func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 		var args deleteCronJobArgs
 		if err := json.Unmarshal(rawArgs, &args); err != nil {
@@ -211,6 +230,16 @@ func makeDeleteCronJob(st store.Store, userID string) ToolFunc {
 		}
 		if args.ID == "" {
 			return "", fmt.Errorf("id is required")
+		}
+		// Enforce the same per-chatter tenancy as list_cron_jobs: a job
+		// created by one chatter must not be deletable by another. We
+		// load the row first and verify it belongs to the calling chatter
+		// (and this agent). A mismatch is reported as "not found" so the
+		// error doesn't leak the row's existence to a non-owner.
+		job, err := st.GetCronJob(ctx, args.ID)
+		if err != nil || job == nil || job.AgentID != agentID ||
+			job.ChatterID == "" || job.ChatterID != r.ChatterUserID() {
+			return "", fmt.Errorf("cron job %q not found", args.ID)
 		}
 		if err := st.DeleteCronJob(ctx, args.ID); err != nil {
 			return "", fmt.Errorf("delete cron job: %w", err)

--- a/internal/agent/tools/cron_test.go
+++ b/internal/agent/tools/cron_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -54,5 +55,107 @@ func TestCreateCronJobPersistsMessageAccountID(t *testing.T) {
 	}
 	if got := jobs[0].ChatID; got != "8169894742" {
 		t.Fatalf("ChatID = %q, want 8169894742", got)
+	}
+	if got := jobs[0].ChatterID; got != "user-1" {
+		t.Fatalf("ChatterID = %q, want user-1 (stamped from registry chatter)", got)
+	}
+}
+
+// TestCronJobsChatterIsolation verifies the per-chatter tenancy fix: two
+// chatters sharing one public agent must only see (and delete) the jobs
+// they created. This is the regression for the issue where a reminder
+// created via the WeChat channel was visible to other chatters of the
+// same agent.
+func TestCronJobsChatterIsolation(t *testing.T) {
+	db, err := store.NewDBStore("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Two chatters share one public agent. Each is backed by its own
+	// Registry instance (the per-turn identity is instance-level state)
+	// but they all point at the same store + agent, so their jobs land
+	// in the same cron_jobs rows — exactly the production layout.
+	newRegistry := func(chatter string) *Registry {
+		r := NewRegistry(t.TempDir(), t.TempDir())
+		r.SetOwnerUserID("owner-1")
+		r.SetChatterUserID(chatter)
+		RegisterCronTools(r, db, "owner-1", "agent-1")
+		return r
+	}
+	aliceReg := newRegistry("alice")
+	bobReg := newRegistry("bob")
+
+	createAs := func(t *testing.T, r *Registry, name string) string {
+		t.Helper()
+		args, _ := json.Marshal(createCronJobArgs{
+			Name:     name,
+			Type:     "once",
+			Schedule: time.Now().Add(time.Hour).Format(time.RFC3339),
+			Message:  "提醒",
+		})
+		out, err := r.Execute(context.Background(), "create_cron_job", string(args))
+		if err != nil {
+			t.Fatalf("create cron job: %v", err)
+		}
+		// Response contains "ID: <uuid>"; extract it.
+		idx := strings.Index(out, "ID: ")
+		if idx < 0 {
+			t.Fatalf("create output missing ID: %q", out)
+		}
+		id := strings.TrimSpace(out[idx+4:])
+		if i := strings.IndexByte(id, '\n'); i >= 0 {
+			id = id[:i]
+		}
+		return id
+	}
+
+	listAs := func(t *testing.T, r *Registry) []store.CronJobRecord {
+		t.Helper()
+		out, err := r.Execute(context.Background(), "list_cron_jobs", "{}")
+		if err != nil {
+			t.Fatalf("list cron jobs: %v", err)
+		}
+		if strings.Contains(out, "No cron jobs") {
+			return nil
+		}
+		var jobs []store.CronJobRecord
+		if err := json.Unmarshal([]byte(out), &jobs); err != nil {
+			t.Fatalf("unmarshal list output: %v\nraw: %s", err, out)
+		}
+		return jobs
+	}
+
+	// Alice and Bob each create one job on the same agent.
+	aliceID := createAs(t, aliceReg, "alice reminder")
+	bobID := createAs(t, bobReg, "bob reminder")
+
+	// Each chatter only sees their own.
+	aliceJobs := listAs(t, aliceReg)
+	if len(aliceJobs) != 1 || aliceJobs[0].ID != aliceID {
+		t.Fatalf("alice sees %v, want only her job %s", aliceJobs, aliceID)
+	}
+	bobJobs := listAs(t, bobReg)
+	if len(bobJobs) != 1 || bobJobs[0].ID != bobID {
+		t.Fatalf("bob sees %v, want only his job %s", bobJobs, bobID)
+	}
+
+	// Bob cannot delete Alice's job — it's reported as not found (no
+	// existence leak) and the row survives.
+	delArgs, _ := json.Marshal(deleteCronJobArgs{ID: aliceID})
+	if _, err := bobReg.Execute(context.Background(), "delete_cron_job", string(delArgs)); err == nil {
+		t.Fatalf("bob was allowed to delete alice's job (cross-chatter leak)")
+	}
+	if job, err := db.GetCronJob(context.Background(), aliceID); err != nil || job == nil {
+		t.Fatalf("alice's job disappeared after bob's delete attempt: %v", err)
+	}
+
+	// Alice can delete her own job.
+	if _, err := aliceReg.Execute(context.Background(), "delete_cron_job", string(delArgs)); err != nil {
+		t.Fatalf("alice failed to delete her own job: %v", err)
 	}
 }

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -77,13 +77,20 @@ type StoreJob struct {
 	ID          string
 	AgentID     string
 	OwnerUserID string
-	Name        string
-	Type        string
-	Schedule    string
-	Message     string
-	Channel     string
-	ChatID      string
-	AccountID   string
+	// ChatterID is the per-sender app_user / web login that created the
+	// job. The scheduler stamps it onto the fired InboundMessage.UserID
+	// so the replayed turn is attributed to the same chatter that asked
+	// for the reminder (instead of a synthetic "cron" identity). Legacy
+	// rows written before this column carry "" — the scheduler falls
+	// back to "cron" for those, preserving the old behavior.
+	ChatterID string
+	Name      string
+	Type      string
+	Schedule  string
+	Message   string
+	Channel   string
+	ChatID    string
+	AccountID string
 	// Timezone is the IANA zone the schedule is interpreted in —
 	// captured from the chatter at creation time. Legacy rows carry
 	// "UTC" (the old hardcoded value); empty means server-local.
@@ -277,11 +284,20 @@ func (s *Scheduler) processDueJobs(ctx context.Context) {
 			text = fmt.Sprintf("[Cron Job: %s] This is a scheduled task trigger.", j.Name)
 		}
 
+		// Attribute the fired turn to the chatter that created the job so
+		// its session history / memory land on the right per-sender app_user.
+		// Legacy rows (chatter_id empty, written before this column) fall
+		// back to the "cron" sentinel to preserve the old routing.
+		actorID := j.ChatterID
+		if actorID == "" {
+			actorID = "cron"
+		}
+
 		s.bus.Inbound <- bus.InboundMessage{
 			Channel:     j.Channel,
 			AccountID:   j.AccountID,
 			ChatID:      j.ChatID,
-			UserID:      "cron",
+			UserID:      actorID,
 			OwnerUserID: j.OwnerUserID,
 			AgentID:     j.AgentID,
 			Text:        text,

--- a/internal/gateway/cron_adapter.go
+++ b/internal/gateway/cron_adapter.go
@@ -36,6 +36,7 @@ func (a *cronStoreAdapter) GetDueCronJobs(ctx context.Context, now time.Time) ([
 			ID:          r.ID,
 			AgentID:     r.AgentID,
 			OwnerUserID: owner,
+			ChatterID:   r.ChatterID,
 			Name:        r.Name,
 			Type:        r.Type,
 			Schedule:    r.Schedule,

--- a/internal/store/cron_sqlite_test.go
+++ b/internal/store/cron_sqlite_test.go
@@ -29,6 +29,7 @@ func TestCronJobSQLiteRoundTrip(t *testing.T) {
 	job := &CronJobRecord{
 		ID:        "test-once-1",
 		AgentID:   "user-test",
+		ChatterID: "chatter-7",
 		Name:      "test reminder",
 		Type:      "once",
 		Schedule:  futureTime.Format(time.RFC3339),
@@ -65,6 +66,9 @@ func TestCronJobSQLiteRoundTrip(t *testing.T) {
 	}
 	if due[0].ID != "test-once-1" {
 		t.Errorf("expected job ID test-once-1, got %s", due[0].ID)
+	}
+	if got := due[0].ChatterID; got != "chatter-7" {
+		t.Errorf("ChatterID round-trip failed: got %q, want chatter-7", got)
 	}
 
 	// Verify: GetNextDueTime should return the job's NextRun

--- a/internal/store/database.go
+++ b/internal/store/database.go
@@ -132,6 +132,9 @@ func (d *DBStore) Migrate(ctx context.Context) error {
 	if err := d.migrateCronJobsAddUserID(ctx); err != nil {
 		return fmt.Errorf("migrate cron_jobs.user_id: %w", err)
 	}
+	if err := d.migrateCronJobsAddChatterID(ctx); err != nil {
+		return fmt.Errorf("migrate cron_jobs.chatter_id: %w", err)
+	}
 	if err := d.migrateConfigsAddScopeColumn(ctx); err != nil {
 		return fmt.Errorf("migrate configs.scope: %w", err)
 	}
@@ -824,6 +827,31 @@ func (d *DBStore) migrateCronJobsAddUserID(ctx context.Context) error {
 	if _, err := d.db.ExecContext(ctx,
 		`CREATE INDEX IF NOT EXISTS idx_cron_jobs_user ON cron_jobs (user_id, agent_id)`); err != nil {
 		return fmt.Errorf("index cron_jobs.user_id: %w", err)
+	}
+	return nil
+}
+
+// migrateCronJobsAddChatterID retrofits chatter_id onto cron_jobs so a
+// job created by one chatter of a public agent is invisible to the
+// others (the list_cron_jobs tool filters on it). Legacy rows default to
+// '' — they predate per-chatter attribution, so they're treated as
+// owner/system-owned and only surface in the owner's web dashboard / CLI
+// (the agent tool layer hides empty-chatter rows from any chatter). A
+// partial index keeps the lookup cheap and legacy rows out of it.
+func (d *DBStore) migrateCronJobsAddChatterID(ctx context.Context) error {
+	has, err := d.tableHasColumn(ctx, "cron_jobs", "chatter_id")
+	if err != nil {
+		return err
+	}
+	if !has {
+		if _, err := d.db.ExecContext(ctx,
+			`ALTER TABLE cron_jobs ADD COLUMN chatter_id TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add cron_jobs.chatter_id: %w", err)
+		}
+	}
+	if _, err := d.db.ExecContext(ctx,
+		`CREATE INDEX IF NOT EXISTS idx_cron_jobs_chatter ON cron_jobs (chatter_id, agent_id) WHERE chatter_id <> ''`); err != nil {
+		return fmt.Errorf("index cron_jobs.chatter_id: %w", err)
 	}
 	return nil
 }
@@ -3890,7 +3918,7 @@ func (d *DBStore) migrateChannelsAddSharedIdentity(ctx context.Context) error {
 
 // --- Cron jobs ---
 
-const cronSelectCols = `id, user_id, agent_id, name, type, schedule, message, channel, chat_id, account_id, timezone, enabled, last_run, next_run, failure_count, created_at`
+const cronSelectCols = `id, user_id, chatter_id, agent_id, name, type, schedule, message, channel, chat_id, account_id, timezone, enabled, last_run, next_run, failure_count, created_at`
 
 func (d *DBStore) ListCronJobsByOwner(ctx context.Context, ownerUserID string) ([]CronJobRecord, error) {
 	// user_id is denormalized onto cron_jobs; the JOIN against agents
@@ -3923,7 +3951,7 @@ func (d *DBStore) GetCronJob(ctx context.Context, jobID string) (*CronJobRecord,
 		fmt.Sprintf(`SELECT `+cronSelectCols+` FROM cron_jobs WHERE id = %s`, d.ph(1)), jobID)
 	var j CronJobRecord
 	var lastRun, nextRun sql.NullTime
-	if err := row.Scan(&j.ID, &j.UserID, &j.AgentID, &j.Name, &j.Type, &j.Schedule, &j.Message, &j.Channel, &j.ChatID, &j.AccountID, &j.Timezone, &j.Enabled, &lastRun, &nextRun, &j.FailureCount, &j.CreatedAt); err != nil {
+	if err := row.Scan(&j.ID, &j.UserID, &j.ChatterID, &j.AgentID, &j.Name, &j.Type, &j.Schedule, &j.Message, &j.Channel, &j.ChatID, &j.AccountID, &j.Timezone, &j.Enabled, &lastRun, &nextRun, &j.FailureCount, &j.CreatedAt); err != nil {
 		return nil, scanErr(err)
 	}
 	if lastRun.Valid {
@@ -3956,23 +3984,23 @@ func (d *DBStore) SaveCronJob(ctx context.Context, job *CronJobRecord) error {
 	}
 	if d.dialect == "postgres" {
 		_, err := d.db.ExecContext(ctx,
-			`INSERT INTO cron_jobs (id, user_id, agent_id, name, type, schedule, message, channel, chat_id, account_id, timezone, enabled, last_run, next_run, created_at)
-				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+			`INSERT INTO cron_jobs (id, user_id, chatter_id, agent_id, name, type, schedule, message, channel, chat_id, account_id, timezone, enabled, last_run, next_run, created_at)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 				ON CONFLICT (id) DO UPDATE SET
-				  user_id=$2, agent_id=$3, name=$4, type=$5, schedule=$6, message=$7, channel=$8,
-				  chat_id=$9, account_id=$10, timezone=$11, enabled=$12, last_run=$13, next_run=$14`,
-			job.ID, job.UserID, job.AgentID, job.Name, job.Type, job.Schedule, job.Message, job.Channel, job.ChatID, job.AccountID, job.Timezone, job.Enabled, job.LastRun, job.NextRun, job.CreatedAt)
+				  user_id=$2, chatter_id=$3, agent_id=$4, name=$5, type=$6, schedule=$7, message=$8, channel=$9,
+				  chat_id=$10, account_id=$11, timezone=$12, enabled=$13, last_run=$14, next_run=$15`,
+			job.ID, job.UserID, job.ChatterID, job.AgentID, job.Name, job.Type, job.Schedule, job.Message, job.Channel, job.ChatID, job.AccountID, job.Timezone, job.Enabled, job.LastRun, job.NextRun, job.CreatedAt)
 		return err
 	}
 	_, err := d.db.ExecContext(ctx,
-		`INSERT INTO cron_jobs (id, user_id, agent_id, name, type, schedule, message, channel, chat_id, account_id, timezone, enabled, last_run, next_run, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO cron_jobs (id, user_id, chatter_id, agent_id, name, type, schedule, message, channel, chat_id, account_id, timezone, enabled, last_run, next_run, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT (id) DO UPDATE SET
-			  user_id=excluded.user_id, agent_id=excluded.agent_id, name=excluded.name, type=excluded.type,
+			  user_id=excluded.user_id, chatter_id=excluded.chatter_id, agent_id=excluded.agent_id, name=excluded.name, type=excluded.type,
 			  schedule=excluded.schedule, message=excluded.message, channel=excluded.channel,
 			  chat_id=excluded.chat_id, account_id=excluded.account_id, timezone=excluded.timezone,
 			  enabled=excluded.enabled, last_run=excluded.last_run, next_run=excluded.next_run`,
-		job.ID, job.UserID, job.AgentID, job.Name, job.Type, job.Schedule, job.Message, job.Channel, job.ChatID, job.AccountID, job.Timezone, job.Enabled, job.LastRun, job.NextRun, job.CreatedAt)
+		job.ID, job.UserID, job.ChatterID, job.AgentID, job.Name, job.Type, job.Schedule, job.Message, job.Channel, job.ChatID, job.AccountID, job.Timezone, job.Enabled, job.LastRun, job.NextRun, job.CreatedAt)
 	return err
 }
 
@@ -4382,7 +4410,7 @@ func scanCronJobs(rows *sql.Rows) ([]CronJobRecord, error) {
 	for rows.Next() {
 		var j CronJobRecord
 		var lastRun, nextRun sql.NullTime
-		if err := rows.Scan(&j.ID, &j.UserID, &j.AgentID, &j.Name, &j.Type, &j.Schedule, &j.Message, &j.Channel, &j.ChatID, &j.AccountID, &j.Timezone, &j.Enabled, &lastRun, &nextRun, &j.FailureCount, &j.CreatedAt); err != nil {
+		if err := rows.Scan(&j.ID, &j.UserID, &j.ChatterID, &j.AgentID, &j.Name, &j.Type, &j.Schedule, &j.Message, &j.Channel, &j.ChatID, &j.AccountID, &j.Timezone, &j.Enabled, &lastRun, &nextRun, &j.FailureCount, &j.CreatedAt); err != nil {
 			return nil, err
 		}
 		if lastRun.Valid {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -730,10 +730,14 @@ type GoalRecord struct {
 
 // CronJobRecord holds a scheduled job. agent_id is mandatory; user_id is
 // also stored so "list a user's crons" doesn't need a join against
-// agents and ownership checks can short-circuit.
+// agents and ownership checks can short-circuit. chatter_id records the
+// chatter (per-sender app_user / web login) that asked the agent to
+// create the job, so list_cron_jobs can isolate rows per chatter even
+// when multiple chatters share one public agent.
 type CronJobRecord struct {
 	ID        string     `json:"id"`
 	UserID    string     `json:"userId,omitempty"`
+	ChatterID string     `json:"chatterId,omitempty"`
 	AgentID   string     `json:"agentId"`
 	Name      string     `json:"name"`
 	Type      string     `json:"type"`

--- a/web/src/app/agents/[id]/scheduler/page.tsx
+++ b/web/src/app/agents/[id]/scheduler/page.tsx
@@ -241,6 +241,14 @@ function JobRow({
                 via {job.channel}
               </span>
             )}
+            {job.chatterId && (
+              <span
+                className="text-[11px] text-muted-foreground"
+                title="Per-sender user that created this job"
+              >
+                by {job.chatterId}
+              </span>
+            )}
           </div>
           <div className="flex items-start gap-1.5 text-xs text-muted-foreground">
             <MessageSquare className="size-3.5 mt-0.5 shrink-0" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1766,6 +1766,7 @@ export interface AgentCronJob {
   channel: string;
   chatId: string;
   accountId?: string;
+  chatterId?: string;   // per-sender app_user / web login that created the job
   timezone: string;
   enabled: boolean;
   lastRun?: string;


### PR DESCRIPTION
## Problem

Cron jobs were bound only to `agent_id`, so two chatters sharing one public agent (e.g. multiple WeChat senders) could see — and delete — each other's reminders via the `list_cron_jobs` / `delete_cron_job` agent tools. The `list_cron_jobs` path even carried a no-op `filtered := jobs` placeholder that was never wired up.

Separately, the scheduler attributed fired turns to a hardcoded `\"cron\"` identity, so replayed reminder turns landed on a synthetic chatter (`wechat:cron`) instead of the real per-sender app_user, polluting session history.

## Fix

Add a `chatter_id` column to `cron_jobs` recording which chatter asked the agent to create the job, then:

- **`create_cron_job`** stamps the per-turn chatter (`r.ChatterUserID()`) onto the row, mirroring how the timezone is already captured.
- **`list_cron_jobs`** filters to rows whose `chatter_id` matches the caller; legacy rows with empty `chatter_id` are hidden from every chatter and remain visible to the owner via the web dashboard / CLI (HTTP `ListCronJobsByAgent` is intentionally unchanged).
- **`delete_cron_job`** verifies ownership before deleting and reports a mismatch as `not found` to avoid leaking row existence.
- **Scheduler** attributes fired turns to the stored `chatter_id` (falling back to the `\"cron\"` sentinel for legacy rows) so replayed turns land on the correct per-sender app_user's session history.

This mirrors the per-owner tenancy boundary `bash_tools` already enforces via `OwnerKeyFor`.

## Migration

Idempotent: `tableHasColumn` probe → `ALTER TABLE cron_jobs ADD COLUMN chatter_id TEXT NOT NULL DEFAULT ''` + partial index `idx_cron_jobs_chatter ... WHERE chatter_id <> ''`. Registered before the timestamptz migration so the table has its final shape first.

## Other changes

- Web UI gains a `by <chatter>` label so owners can distinguish who created each job in the dashboard.
- CLI `cron create` gains an optional `--chatter` flag.
- Regression test `TestCronJobsChatterIsolation`: two chatters each create a job on one shared agent; each only sees their own, and neither can delete the other's (reports not found, row survives).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/agent/tools/ ./internal/store/ ./internal/cron/ ./internal/gateway/`
- [x] `tsc --noEmit` (web)
- [x] Deployed locally: migrated existing WeChat cron rows to the real sender's `chatter_id`, verified the scheduler restart picked them up and fires them under the correct identity.