### PR TITLE
feat(workspace): 会话级 workspace 版本历史（git 快照，可回滚）

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -215,6 +215,13 @@ func (a *Agent) bindSession(ctx context.Context, channel, accountID, sessionID, 
 	a.registry.SetExecutor(ex)
 }
 
+// newWorkspaceHistory builds the git-snapshot history store rooted under
+// FASTCLAW_HOME. Package-level helper so call sites where a local
+// `workspace` string shadows the workspace package can use it.
+func newWorkspaceHistory(homeDir string) *workspace.History {
+	return workspace.NewHistory(filepath.Join(homeDir, "workspace-history"))
+}
+
 // NewAgent creates a new Agent from a resolved config.
 func NewAgent(rc config.ResolvedAgent, prov provider.Provider, mb *bus.MessageBus, homeDir string) *Agent {
 	return NewAgentWithSkillsCfg(rc, prov, mb, homeDir, config.SkillsCfg{})
@@ -226,7 +233,7 @@ func NewAgentWithFullCfg(rc config.ResolvedAgent, prov provider.Provider, mb *bu
 	ag.memoryCfg = fullCfg.Memory
 	ag.workspaceHistoryEnabled = fullCfg.WorkspaceHistory.Enabled
 	if ag.workspaceHistoryEnabled {
-		ag.history = workspace.NewHistory(filepath.Join(homeDir, "workspace-history"))
+		ag.history = newWorkspaceHistory(homeDir)
 	}
 	ag.piiScrubEnabled = fullCfg.Privacy.PIIScrubbing.Enabled
 	// splitReplies is plumbed inside NewAgentWithSkillsCfg so foreign-
@@ -388,6 +395,15 @@ func NewAgentWithSkillsCfg(rc config.ResolvedAgent, prov provider.Provider, mb *
 	// AutoPersist without specifying a cadence.
 	if rc.AutoPersist != nil {
 		ag.memoryCfg.AutoPersist.Enabled = *rc.AutoPersist
+	}
+	// Workspace history toggle — same per-agent pointer pattern as
+	// AutoPersist above (NewAgentWithSkillsCfg is the production path;
+	// the fullCfg copy in NewAgentWithFullCfg covers the system default).
+	if rc.WorkspaceHistory != nil {
+		ag.workspaceHistoryEnabled = *rc.WorkspaceHistory
+	}
+	if ag.workspaceHistoryEnabled && ag.history == nil {
+		ag.history = newWorkspaceHistory(homeDir)
 	}
 	if ag.memoryCfg.AutoPersist.EveryNTurns == 0 {
 		ag.memoryCfg.AutoPersist.EveryNTurns = 5

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2637,14 +2637,18 @@ func (a *Agent) runPostTurn(ctx context.Context, msg bus.InboundMessage, message
 	// mount are invisible to this process; the turn boundary is the one
 	// consistency point that covers file tools, exec and uploads.
 	if a.workspaceHistoryEnabled && a.history != nil {
-		if fs, ok := a.workspaceStore.(*workspace.LocalFS); ok {
+		if ls, ok := a.workspaceStore.(workspace.LocalScoper); ok {
 			scope := msg.ChatID
 			if pid := a.registry.ProjectID(); pid != "" {
 				scope = pid + "-" + msg.ChatID
 			}
-			workTree := fs.ScopeDir(a.agentID, a.registry.ProjectID(), msg.ChatID)
+			workTree, _ := ls.LocalScopeDir(a.agentID, a.registry.ProjectID(), msg.ChatID)
 			go func() {
-				if err := a.history.Commit(ctx, scope, workTree, "turn "+time.Now().Format(time.RFC3339)); err != nil {
+				// context.Background(): the turn ctx is cancelled when the HTTP
+				// handler returns, and a killed git leaves index.lock behind,
+				// silently breaking every later snapshot of this scope.
+				// runGit has its own 30s timeout as the bound.
+				if err := a.history.Commit(context.Background(), scope, workTree, "turn "+time.Now().Format(time.RFC3339)); err != nil {
 					slog.Warn("workspace history commit failed", "agent", a.name, "scope", scope, "error", err)
 				}
 			}()

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -69,6 +70,8 @@ type Agent struct {
 	ftsStore        *store.FTSStore
 	piiScrubEnabled bool
 	memoryCfg       config.MemoryCfg
+	workspaceHistoryEnabled bool
+	history                 *workspace.History
 	// splitReplies is the per-agent multi-bubble toggle. Gates the
 	// per-turn system-prompt hint that advertises SplitMessageMarker
 	// to the LLM (see renderChannelHints) AND stamps
@@ -221,6 +224,10 @@ func NewAgent(rc config.ResolvedAgent, prov provider.Provider, mb *bus.MessageBu
 func NewAgentWithFullCfg(rc config.ResolvedAgent, prov provider.Provider, mb *bus.MessageBus, homeDir string, fullCfg *config.Config) *Agent {
 	ag := NewAgentWithSkillsCfg(rc, prov, mb, homeDir, fullCfg.Skills)
 	ag.memoryCfg = fullCfg.Memory
+	ag.workspaceHistoryEnabled = fullCfg.WorkspaceHistory.Enabled
+	if ag.workspaceHistoryEnabled {
+		ag.history = workspace.NewHistory(filepath.Join(homeDir, "workspace-history"))
+	}
 	ag.piiScrubEnabled = fullCfg.Privacy.PIIScrubbing.Enabled
 	// splitReplies is plumbed inside NewAgentWithSkillsCfg so foreign-
 	// attached agents also pick up the toggle; don't re-stamp here.
@@ -2622,6 +2629,26 @@ func (a *Agent) runPostTurn(ctx context.Context, msg bus.InboundMessage, message
 				slog.Debug("skills learner error", "error", err)
 			}
 		}()
+	}
+
+	// Workspace version history: snapshot the session workspace at turn
+	// boundary (opt-in; LocalFS only — S3-backed stores skip). Commit
+	// here, not per tool write, because sandbox exec writes via the bind
+	// mount are invisible to this process; the turn boundary is the one
+	// consistency point that covers file tools, exec and uploads.
+	if a.workspaceHistoryEnabled && a.history != nil {
+		if fs, ok := a.workspaceStore.(*workspace.LocalFS); ok {
+			scope := msg.ChatID
+			if pid := a.registry.ProjectID(); pid != "" {
+				scope = pid + "-" + msg.ChatID
+			}
+			workTree := fs.ScopeDir(a.agentID, a.registry.ProjectID(), msg.ChatID)
+			go func() {
+				if err := a.history.Commit(ctx, scope, workTree, "turn "+time.Now().Format(time.RFC3339)); err != nil {
+					slog.Warn("workspace history commit failed", "agent", a.name, "scope", scope, "error", err)
+				}
+			}()
+		}
 	}
 }
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2012,13 +2011,8 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 
 	toolDefs := a.registry.DefinitionsForMode(builtinAllowForMode(a.promptMode))
 
-	// Loop detection: track consecutive identical tool calls
-	type toolCallSig struct {
-		name string
-		hash [32]byte
-	}
-	var lastSig toolCallSig
-	consecutiveCount := 0
+	// Loop detection: track consecutive identical tool calls and results.
+	var loopDetector toolLoopDetector
 	totalToolCalls := 0
 	// allFailedRounds is the count of CONSECUTIVE rounds where every
 	// tool result came back as a 4xx/5xx HTTP error or an executor
@@ -2161,35 +2155,6 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 		sess.Append(assistantMsg)
 		messages = append(messages, assistantMsg)
 
-		// Loop detection: check before executing
-		loopDetected := false
-		for _, tc := range resp.ToolCalls {
-			sig := toolCallSig{
-				name: tc.Function.Name,
-				hash: sha256.Sum256([]byte(tc.Function.Arguments)),
-			}
-			if sig.name == lastSig.name && sig.hash == lastSig.hash {
-				consecutiveCount++
-			} else {
-				consecutiveCount = 1
-				lastSig = sig
-			}
-			if consecutiveCount >= 3 {
-				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
-				warnMsg := provider.Message{
-					Role:    "system",
-					Content: "Loop detected: you called the same tool with the same arguments 3 times. Please try a different approach.",
-				}
-				sess.Append(warnMsg)
-				messages = append(messages, warnMsg)
-				loopDetected = true
-				break
-			}
-		}
-		if loopDetected {
-			break
-		}
-
 		// Fire BeforeToolCall hooks
 		for _, tc := range resp.ToolCalls {
 			a.hooks.Run(ctx, &HookContext{
@@ -2273,6 +2238,7 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 			results = padded
 		}
 
+		loopDetected := false
 		// Round-level failure detection: did EVERY result come back
 		// as a 4xx/5xx HTTP error or executor error? Tracked here so
 		// the next iteration can decide whether to drop tools.
@@ -2353,6 +2319,16 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 				evt["metadata"] = meta
 			}
 			emitEvent(ctx, ChatEvent{Type: "tool_result", Data: evt})
+
+			if loopDetector.Observe(tc, resultContent) && !loopDetected {
+				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
+				loopDetected = true
+			}
+		}
+		if loopDetected {
+			warnMsg := repeatedToolCallWarning("Loop detected: you called the same tool with the same arguments and received the same result 3 times. Please try a different approach.")
+			sess.Append(warnMsg)
+			messages = append(messages, warnMsg)
 		}
 		// Update consecutive-failed-rounds tally now that the whole
 		// round's results have been processed. A single non-failure
@@ -2362,6 +2338,9 @@ func (a *Agent) HandleMessage(ctx context.Context, msg bus.InboundMessage) strin
 			allFailedRounds++
 		} else {
 			allFailedRounds = 0
+		}
+		if loopDetected {
+			break
 		}
 
 		// Steering: messages that arrived while this tool round ran are
@@ -2726,12 +2705,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 
 	toolDefs := a.registry.DefinitionsForMode(builtinAllowForMode(a.promptMode))
 
-	type toolCallSig struct {
-		name string
-		hash [32]byte
-	}
-	var lastSig toolCallSig
-	consecutiveCount := 0
+	var loopDetector toolLoopDetector
 	totalToolCalls := 0
 
 	// ReAct loop - use Chat for tool iterations
@@ -2850,35 +2824,6 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 		sess.Append(assistantMsg)
 		messages = append(messages, assistantMsg)
 
-		// Loop detection
-		loopDetected := false
-		for _, tc := range resp.ToolCalls {
-			sig := toolCallSig{
-				name: tc.Function.Name,
-				hash: sha256.Sum256([]byte(tc.Function.Arguments)),
-			}
-			if sig.name == lastSig.name && sig.hash == lastSig.hash {
-				consecutiveCount++
-			} else {
-				consecutiveCount = 1
-				lastSig = sig
-			}
-			if consecutiveCount >= 3 {
-				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
-				warnMsg := provider.Message{
-					Role:    "system",
-					Content: "Loop detected: you called the same tool with the same arguments 3 times. Please try a different approach.",
-				}
-				sess.Append(warnMsg)
-				messages = append(messages, warnMsg)
-				loopDetected = true
-				break
-			}
-		}
-		if loopDetected {
-			break
-		}
-
 		// Fire BeforeToolCall hooks
 		for _, tc := range resp.ToolCalls {
 			a.hooks.Run(ctx, &HookContext{AgentName: a.name, Point: BeforeToolCall, ToolName: tc.Function.Name, ToolArgs: tc.Function.Arguments, Channel: msg.Channel, AccountID: msg.AccountID, ChatID: msg.ChatID, UserID: a.ownerUserID})
@@ -2887,6 +2832,7 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 		// Execute tools concurrently via SDK engine
 		results := a.engine.executeToolsConcurrently(ctx, a.registry, resp.ToolCalls, a.workspacePath)
 		totalToolCalls += len(results)
+		loopDetected := false
 
 		for idx, r := range results {
 			tc := resp.ToolCalls[idx]
@@ -2904,6 +2850,19 @@ func (a *Agent) HandleMessageStream(ctx context.Context, msg bus.InboundMessage)
 			toolMsg := provider.Message{Role: "tool", Content: resultContent, ToolCallID: tc.ID, Name: r.toolName, Metadata: meta}
 			sess.Append(toolMsg)
 			messages = append(messages, toolMsg)
+
+			if loopDetector.Observe(tc, resultContent) && !loopDetected {
+				slog.Warn("tool loop detected", "agent", a.name, "tool", tc.Function.Name)
+				loopDetected = true
+			}
+		}
+		if loopDetected {
+			warnMsg := repeatedToolCallWarning("Loop detected: you called the same tool with the same arguments and received the same result 3 times. Please try a different approach.")
+			sess.Append(warnMsg)
+			messages = append(messages, warnMsg)
+		}
+		if loopDetected {
+			break
 		}
 	}
 

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -98,12 +97,7 @@ func (a *Agent) runSubagentLoop(ctx context.Context, task string, maxIterations 
 		toolDefs = append(toolDefs, t)
 	}
 
-	type sig struct {
-		name string
-		hash [32]byte
-	}
-	var lastSig sig
-	consecutiveCount := 0
+	var loopDetector toolLoopDetector
 	allFailedRounds := 0
 	const failedRoundsLimit = 3
 
@@ -167,30 +161,6 @@ func (a *Agent) runSubagentLoop(ctx context.Context, task string, maxIterations 
 			RawAssistant: resp.RawAssistant,
 		})
 
-		// Loop detection: same shape as HandleMessage but on private state.
-		loopDetected := false
-		for _, tc := range resp.ToolCalls {
-			s := sig{name: tc.Function.Name, hash: sha256.Sum256([]byte(tc.Function.Arguments))}
-			if s.name == lastSig.name && s.hash == lastSig.hash {
-				consecutiveCount++
-			} else {
-				consecutiveCount = 1
-				lastSig = s
-			}
-			if consecutiveCount >= 3 {
-				slog.Warn("subagent tool-loop detected", "agent", a.name, "tool", tc.Function.Name)
-				messages = append(messages, provider.Message{
-					Role:    "system",
-					Content: "Loop detected: same tool with same arguments 3 times. Stop and produce the deliverable from what you have.",
-				})
-				loopDetected = true
-				break
-			}
-		}
-		if loopDetected {
-			break
-		}
-
 		// Second heartbeat: tools are about to run. Surface their names
 		// so the UI can show "running web_search" / "running exec
 		// (camoufox-cli open …)" instead of just a spinner.
@@ -207,6 +177,7 @@ func (a *Agent) runSubagentLoop(ctx context.Context, task string, maxIterations 
 
 		results := a.engine.executeToolsConcurrently(ctx, a.registry, resp.ToolCalls, a.workspacePath)
 		roundAllFailed := true
+		loopDetected := false
 		for idx, r := range results {
 			tc := resp.ToolCalls[idx]
 			resultContent, _ := extractToolMeta(r.result)
@@ -219,11 +190,21 @@ func (a *Agent) runSubagentLoop(ctx context.Context, task string, maxIterations 
 				ToolCallID: tc.ID,
 				Name:       r.toolName,
 			})
+			if loopDetector.Observe(tc, resultContent) && !loopDetected {
+				slog.Warn("subagent tool loop detected", "agent", a.name, "tool", tc.Function.Name)
+				loopDetected = true
+			}
+		}
+		if loopDetected {
+			messages = append(messages, repeatedToolCallWarning("Loop detected: same tool with same arguments and same result 3 times. Stop and produce the deliverable from what you have."))
 		}
 		if roundAllFailed {
 			allFailedRounds++
 		} else {
 			allFailedRounds = 0
+		}
+		if loopDetected {
+			break
 		}
 	}
 

--- a/internal/agent/tool_loop_detector.go
+++ b/internal/agent/tool_loop_detector.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"strings"
+
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+)
+
+const toolLoopDetectionThreshold = 3
+
+type toolLoopDetector struct {
+	last        toolLoopSignature
+	consecutive int
+}
+
+type toolLoopSignature struct {
+	name       string
+	inputHash  [32]byte
+	resultHash [32]byte
+}
+
+func (d *toolLoopDetector) Observe(tc provider.ToolCall, result string) bool {
+	sig := toolLoopSignature{
+		name:       tc.Function.Name,
+		inputHash:  sha256.Sum256([]byte(tc.Function.Arguments)),
+		resultHash: sha256.Sum256([]byte(strings.TrimSpace(result))),
+	}
+	if sig.name == d.last.name && sig.inputHash == d.last.inputHash && sig.resultHash == d.last.resultHash {
+		d.consecutive++
+	} else {
+		d.consecutive = 1
+		d.last = sig
+	}
+	return d.consecutive >= toolLoopDetectionThreshold
+}
+
+func repeatedToolCallWarning(content string) provider.Message {
+	return provider.Message{Role: "system", Content: content}
+}

--- a/internal/agent/tool_loop_detector_test.go
+++ b/internal/agent/tool_loop_detector_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/provider"
+)
+
+func testToolCall(name, args string) provider.ToolCall {
+	return provider.ToolCall{Function: provider.FunctionCall{Name: name, Arguments: args}}
+}
+
+func TestToolLoopDetectorAllowsProgressingPolling(t *testing.T) {
+	var detector toolLoopDetector
+	tc := testToolCall("check_status", `{"id":"abc"}`)
+
+	for _, result := range []string{"pending", "processing", "completed"} {
+		if detector.Observe(tc, result) {
+			t.Fatalf("progressing polling result %q was classified as a loop", result)
+		}
+	}
+}
+
+type argOnlyLoopDetector struct {
+	last        argOnlyLoopSignature
+	consecutive int
+}
+
+type argOnlyLoopSignature struct {
+	name      string
+	inputHash [32]byte
+}
+
+func (d *argOnlyLoopDetector) Observe(tc provider.ToolCall) bool {
+	sig := argOnlyLoopSignature{
+		name:      tc.Function.Name,
+		inputHash: sha256.Sum256([]byte(tc.Function.Arguments)),
+	}
+	if sig.name == d.last.name && sig.inputHash == d.last.inputHash {
+		d.consecutive++
+	} else {
+		d.consecutive = 1
+		d.last = sig
+	}
+	return d.consecutive >= toolLoopDetectionThreshold
+}
+
+func TestToolLoopDetectorAllowsThirdProgressingPollThatArgOnlyDetectorWouldBlock(t *testing.T) {
+	tc := testToolCall("check_status", "{\"id\":\"abc\"}")
+	results := []string{"pending: queued", "pending: running", "pending: finalizing"}
+
+	var oldDetector argOnlyLoopDetector
+	for i := range results {
+		got := oldDetector.Observe(tc)
+		if i < toolLoopDetectionThreshold-1 && got {
+			t.Fatalf("arg-only detector looped before the threshold on poll %d", i+1)
+		}
+		if i == toolLoopDetectionThreshold-1 && !got {
+			t.Fatalf("arg-only detector should block the third identical tool call")
+		}
+	}
+
+	var detector toolLoopDetector
+	for _, result := range results {
+		if detector.Observe(tc, result) {
+			t.Fatalf("result-aware detector should allow progressing poll result %q", result)
+		}
+	}
+}
+
+func TestToolLoopDetectorDetectsIdenticalInputAndResult(t *testing.T) {
+	var detector toolLoopDetector
+	tc := testToolCall("check_status", `{"id":"abc"}`)
+
+	for i := 1; i <= toolLoopDetectionThreshold; i++ {
+		got := detector.Observe(tc, "pending")
+		if i < toolLoopDetectionThreshold && got {
+			t.Fatalf("Observe call %d detected a loop before the threshold", i)
+		}
+		if i == toolLoopDetectionThreshold && !got {
+			t.Fatalf("Observe call %d did not detect repeated identical results", i)
+		}
+	}
+}
+
+func TestToolLoopDetectorResetsOnDifferentArguments(t *testing.T) {
+	var detector toolLoopDetector
+	first := testToolCall("check_status", `{"id":"abc"}`)
+	second := testToolCall("check_status", `{"id":"def"}`)
+
+	if detector.Observe(first, "pending") {
+		t.Fatal("first observation should not detect a loop")
+	}
+	if detector.Observe(first, "pending") {
+		t.Fatal("second observation should not detect a loop")
+	}
+	if detector.Observe(second, "pending") {
+		t.Fatal("different arguments should reset loop detection")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -397,6 +397,9 @@ type AgentDefaults struct {
 	// so this is the only way for the agent to remember a chatter across
 	// sessions.
 	AutoPersist *bool `json:"autoPersist,omitempty"`
+	// WorkspaceHistory — same pointer semantics as AutoPersist: nil = inherit
+	// system workspaceHistory.enabled, non-nil = authoritative for this agent.
+	WorkspaceHistory *bool `json:"workspaceHistory,omitempty"`
 }
 
 // AgentEntry is the in-memory shape of one agent row, used during
@@ -445,6 +448,9 @@ type AgentEntry struct {
 	// (long-term facts) — the chatbot-mode persistence path since that
 	// mode's curated tool allowlist excludes write_file.
 	AutoPersist *bool `json:"autoPersist,omitempty"`
+	// WorkspaceHistory — same pointer semantics as AutoPersist: nil = inherit
+	// system workspaceHistory.enabled, non-nil = authoritative for this agent.
+	WorkspaceHistory *bool `json:"workspaceHistory,omitempty"`
 }
 
 // PromptMode controls which framework sections BuildSystemPromptAs emits.
@@ -568,6 +574,9 @@ type AgentFileConfig struct {
 	// AutoPersist mirrors AgentEntry.AutoPersist. Nil = inherit;
 	// non-nil = authoritative for this agent.
 	AutoPersist *bool `json:"autoPersist,omitempty"`
+	// WorkspaceHistory — same pointer semantics as AutoPersist: nil = inherit
+	// system workspaceHistory.enabled, non-nil = authoritative for this agent.
+	WorkspaceHistory *bool `json:"workspaceHistory,omitempty"`
 	// Admins gates write-mode slash commands (/new /reset /undo /retry /compact
 	// /model /personality) in IM channels. Keyed by channel name ("discord",
 	// "telegram", "slack", ...), each value is the platform-side user IDs
@@ -648,6 +657,10 @@ type ResolvedAgent struct {
 	// runPostTurn hook fires AutoPersistMemory (the LLM-driven distill-
 	// to-USER.md/MEMORY.md pass) every N turns.
 	AutoPersist *bool
+	// WorkspaceHistory — nil = inherit system workspaceHistory.enabled,
+	// non-nil = authoritative for this agent. Drives whether runPostTurn
+	// snapshots the session workspace into the git history repo.
+	WorkspaceHistory *bool
 }
 
 type TeamEntry struct {
@@ -751,6 +764,7 @@ func (cfg *Config) MergedAgentConfig(entry AgentEntry) ResolvedAgent {
 		Thinking:             cfg.Agents.Defaults.Thinking,
 		Sandbox:              cfg.Sandbox,
 		PolicyPreset:         cfg.Agents.Defaults.PolicyPreset,
+		WorkspaceHistory:       cfg.Agents.Defaults.WorkspaceHistory,
 	}
 
 	if entry.MaxTokens > 0 {
@@ -784,6 +798,10 @@ func (cfg *Config) MergedAgentConfig(entry AgentEntry) ResolvedAgent {
 	if entry.AutoPersist != nil {
 		v := *entry.AutoPersist
 		resolved.AutoPersist = &v
+	}
+	if entry.WorkspaceHistory != nil {
+		v := *entry.WorkspaceHistory
+		resolved.WorkspaceHistory = &v
 	}
 
 	if len(cfg.MCPServers) > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,8 +246,9 @@ type RateLimitCfg struct {
 }
 
 // WorkspaceHistoryCfg toggles the opt-in per-session workspace version
-// history (git snapshots committed at turn boundary). Localfs-backed
-// workspaces only — S3-backed stores skip history entirely.
+// history (git snapshots committed at turn boundary). LocalFS-backed
+// workspaces only — S3-backed stores skip history entirely. Known
+// limitation: no retention policy yet — every dirty turn adds a commit.
 type WorkspaceHistoryCfg struct {
 	Enabled bool `json:"enabled"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,13 @@ type RateLimitCfg struct {
 	RPM int `json:"rpm,omitempty"`
 }
 
+// WorkspaceHistoryCfg toggles the opt-in per-session workspace version
+// history (git snapshots committed at turn boundary). Localfs-backed
+// workspaces only — S3-backed stores skip history entirely.
+type WorkspaceHistoryCfg struct {
+	Enabled bool `json:"enabled"`
+}
+
 type MemoryCfg struct {
 	AutoPersist AutoPersistCfg `json:"autoPersist,omitempty"`
 	FTS         FTSCfg         `json:"fts,omitempty"`
@@ -299,6 +306,7 @@ type Config struct {
 	TaskQueue     TaskQueueCfg               `json:"taskQueue,omitempty"`
 	Skills        SkillsCfg                  `json:"skills,omitempty"`
 	Memory        MemoryCfg                  `json:"memory,omitempty"`
+	WorkspaceHistory WorkspaceHistoryCfg    `json:"workspaceHistory,omitempty"`
 	Privacy       PrivacyCfg                 `json:"privacy,omitempty"`
 	SkillsLearner SkillsLearnerCfg           `json:"skillsLearner,omitempty"`
 	Prefs         PrefsCfg                   `json:"prefs,omitempty"`

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -814,6 +814,7 @@ const (
 	NSSkillsInstall  = "skills.install"
 	NSSkillsEntries  = "skills.entries"
 	NSMemory         = "memory"
+	NSWorkspaceHistory = "workspaceHistory"
 	NSPrivacy        = "privacy"
 	NSSkillsLearner  = "skillsLearner"
 	NSHeartbeat      = "heartbeat"

--- a/internal/gateway/userspace.go
+++ b/internal/gateway/userspace.go
@@ -273,6 +273,9 @@ func assembleConfig(ctx context.Context, st store.Store, userID, agentID string)
 	if err := scope.SettingInto(ctx, st, NSMemory, userID, agentID, &cfg.Memory); err != nil {
 		return nil, err
 	}
+	if err := scope.SettingInto(ctx, st, NSWorkspaceHistory, userID, agentID, &cfg.WorkspaceHistory); err != nil {
+		return nil, err
+	}
 	if err := scope.SettingInto(ctx, st, NSPrivacy, userID, agentID, &cfg.Privacy); err != nil {
 		return nil, err
 	}
@@ -733,6 +736,10 @@ func loadUserSpace(ctx context.Context, userID string, mb *bus.MessageBus, st st
 			if agentOverride.AutoPersist != nil {
 				v := *agentOverride.AutoPersist
 				rc.AutoPersist = &v
+			}
+			if agentOverride.WorkspaceHistory != nil {
+				v := *agentOverride.WorkspaceHistory
+				rc.WorkspaceHistory = &v
 			}
 		}
 		// Same story for providers: assembleConfig was called with

--- a/internal/setup/handlers_history.go
+++ b/internal/setup/handlers_history.go
@@ -19,10 +19,11 @@ import (
 
 // workspaceHistoryScope resolves the URL sessionId to the history scope key
 // and the on-disk worktree. Only LocalFS-backed workspaces have on-disk
-// scope dirs, so S3 deployments get a stable 503 (never a 404 that looks
+// scope dirs (probed via the LocalScoper marker, so a Metered wrapper still
+// counts), so S3 deployments get a stable 503 (never a 404 that looks
 // like "no history yet").
 func (s *Server) workspaceHistoryScope(w http.ResponseWriter, r *http.Request, agentID, urlToken string) (scope, workTree string, ok bool) {
-	fs, isLocal := s.workspaceStore.(*workspace.LocalFS)
+	ls, isLocal := s.workspaceStore.(workspace.LocalScoper)
 	if !isLocal {
 		jsonResponse(w, http.StatusServiceUnavailable, map[string]any{"error": "workspace history requires a local workspace store"})
 		return "", "", false
@@ -37,7 +38,8 @@ func (s *Server) workspaceHistoryScope(w http.ResponseWriter, r *http.Request, a
 	if projectID != "" {
 		scope = projectID + "-" + chatID
 	}
-	return scope, fs.ScopeDir(agentID, projectID, chatID), true
+	workTree, _ = ls.LocalScopeDir(agentID, projectID, chatID)
+	return scope, workTree, true
 }
 
 func (s *Server) workspaceHistoryRoot() (string, error) {

--- a/internal/setup/handlers_history.go
+++ b/internal/setup/handlers_history.go
@@ -1,0 +1,109 @@
+package setup
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/workspace"
+)
+
+// Workspace version history handlers. The feature is opt-in at the WRITE
+// side (workspaceHistory.enabled gates the turn-boundary snapshot in the
+// agent loop); reading and restoring existing history needs no toggle —
+// rollback is a deliberate user action.
+//
+// Scope keys mirror the agent loop's commit path: chatID for loose chats,
+// "<projectID>-<chatID>" for project chats.
+
+// workspaceHistoryScope resolves the URL sessionId to the history scope key
+// and the on-disk worktree. Only LocalFS-backed workspaces have on-disk
+// scope dirs, so S3 deployments get a stable 503 (never a 404 that looks
+// like "no history yet").
+func (s *Server) workspaceHistoryScope(w http.ResponseWriter, r *http.Request, agentID, urlToken string) (scope, workTree string, ok bool) {
+	fs, isLocal := s.workspaceStore.(*workspace.LocalFS)
+	if !isLocal {
+		jsonResponse(w, http.StatusServiceUnavailable, map[string]any{"error": "workspace history requires a local workspace store"})
+		return "", "", false
+	}
+	chatID := s.workspaceSessionScope(r.Context(), agentID, urlToken)
+	if chatID == "" {
+		jsonResponse(w, http.StatusNotFound, map[string]any{"error": "session not found"})
+		return "", "", false
+	}
+	projectID := s.resolveSessionProject(r.Context(), r, agentID, urlToken)
+	scope = chatID
+	if projectID != "" {
+		scope = projectID + "-" + chatID
+	}
+	return scope, fs.ScopeDir(agentID, projectID, chatID), true
+}
+
+func (s *Server) workspaceHistoryRoot() (string, error) {
+	home, err := config.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "workspace-history"), nil
+}
+
+// handleAgentSessionHistory lists the snapshot commits of one chat's
+// workspace, newest first: {"history": [{hash, message, time}]}.
+func (s *Server) handleAgentSessionHistory(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !s.requireAgentReadable(w, r, id) {
+		return
+	}
+	scope, _, ok := s.workspaceHistoryScope(w, r, id, r.PathValue("sessionId"))
+	if !ok {
+		return
+	}
+	root, err := s.workspaceHistoryRoot()
+	if err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return
+	}
+	entries, err := workspace.NewHistory(root).List(r.Context(), scope)
+	if err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return
+	}
+	if entries == nil {
+		entries = []workspace.Entry{}
+	}
+	jsonResponse(w, http.StatusOK, map[string]any{"history": entries})
+}
+
+// handleAgentSessionHistoryRestore checks the chat's workspace out to one
+// snapshot commit. The commit hash is validated in workspace.History.
+func (s *Server) handleAgentSessionHistoryRestore(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWritable(w, r) {
+		return
+	}
+	id := r.PathValue("id")
+	if !s.requireAgentReadable(w, r, id) {
+		return
+	}
+	scope, workTree, ok := s.workspaceHistoryScope(w, r, id, r.PathValue("sessionId"))
+	if !ok {
+		return
+	}
+	var body struct {
+		Commit string `json:"commit"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "invalid json: " + err.Error()})
+		return
+	}
+	root, err := s.workspaceHistoryRoot()
+	if err != nil {
+		jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return
+	}
+	if err := workspace.NewHistory(root).Restore(r.Context(), scope, workTree, body.Commit); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	jsonResponse(w, http.StatusOK, map[string]any{"ok": true})
+}

--- a/internal/setup/server.go
+++ b/internal/setup/server.go
@@ -287,6 +287,8 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.HandleFunc("GET /api/agents/{id}/files.zip", auth(s.handleAgentFilesZip))
 	mux.HandleFunc("GET /api/agents/{id}/files/{path...}", auth(s.handleAgentFile))
 	mux.HandleFunc("POST /api/agents/{id}/files", auth(s.handleAgentFileUpload))
+	mux.HandleFunc("GET /api/agents/{id}/sessions/{sessionId}/history", auth(s.handleAgentSessionHistory))
+	mux.HandleFunc("POST /api/agents/{id}/sessions/{sessionId}/history/restore", auth(s.handleAgentSessionHistoryRestore))
 	// Self-hosted-only: opens the workspace dir in the operator's
 	// native file browser (Finder/Explorer/xdg-open). Hosted
 	// deployments 403 inside the handler — chatters there don't

--- a/internal/workspace/history.go
+++ b/internal/workspace/history.go
@@ -1,0 +1,112 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// History is an opt-in per-scope version history for workspace directories,
+// backed by git bare repositories stored OUTSIDE the workspace (default
+// ~/.fastclaw/workspace-history/<scope>.git).
+//
+// Design notes (why this shape):
+//   - A .git directory inside the workspace would be visible to the agent
+//     itself: file tools would list it, the model could read or corrupt it,
+//     and it would inflate listings and context. The bare repo must live
+//     outside any scope the agent can see.
+//   - Commits happen at turn boundary (after each agent run), not per tool
+//     write. Sandbox exec writes happen inside the container over the bind
+//     mount and are invisible to this process, so per-write hooks can never
+//     be complete. A turn-boundary snapshot captures file tools, exec, and
+//     uploads with one well-defined consistency point.
+//   - Everything is best-effort: history failures must never fail or block
+//     an agent run. Callers log and move on.
+//
+// Rollback is manual for now (git --git-dir=<repo> --work-tree=<dir> log /
+// checkout); a workspace-panel entry can come later.
+type History struct {
+	root string
+}
+
+// NewHistory returns a History storing bare repositories under root
+// (one <scope>.git per workspace scope).
+func NewHistory(root string) *History {
+	return &History{root: root}
+}
+
+// Commit snapshots workTree into the scope's bare repository. The first
+// call initializes the repo; clean trees are skipped (no empty commits).
+// Any error is returned for the caller to log — never fatal.
+func (h *History) Commit(ctx context.Context, scope, workTree, message string) error {
+	if scope == "" || workTree == "" {
+		return fmt.Errorf("workspace history: scope and workTree required")
+	}
+	info, err := os.Stat(workTree)
+	if err != nil || !info.IsDir() {
+		return nil // nothing to snapshot
+	}
+	repo := filepath.Join(h.root, scope+".git")
+	if _, err := os.Stat(repo); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(repo), 0o755); err != nil {
+			return err
+		}
+		// NOTE: git rejects init combined with --work-tree
+		// ("GIT_WORK_TREE not allowed without GIT_DIR"), so init uses the
+		// plain path form and only later commands carry --git-dir/--work-tree.
+		if out, err := runGit(ctx, nil, "init", "--bare", repo); err != nil {
+			return fmt.Errorf("git init: %s: %w", out, err)
+		}
+	}
+	gitDir := "--git-dir=" + repo
+	workTreeArg := "--work-tree=" + workTree
+	if out, err := runGit(ctx, nil, gitDir, workTreeArg, "add", "-A"); err != nil {
+		return fmt.Errorf("git add: %s: %w", out, err)
+	}
+	status, err := runGit(ctx, nil, gitDir, workTreeArg, "status", "--porcelain")
+	if err != nil {
+		return fmt.Errorf("git status: %s: %w", status, err)
+	}
+	if strings.TrimSpace(status) == "" {
+		return nil // clean tree — skip empty commit
+	}
+	// Inline identity so this works without the operator's global git config.
+	out, err := runGit(ctx, nil, gitDir, workTreeArg,
+		"-c", "user.name=fastclaw", "-c", "user.email=fastclaw@localhost",
+		"commit", "-m", message, "--quiet")
+	if err != nil {
+		return fmt.Errorf("git commit: %s: %w", out, err)
+	}
+	slog.Info("workspace history committed", "scope", scope, "repo", repo)
+	return nil
+}
+
+// RepoPath returns the bare repository path for a scope (used by tests and
+// by any future rollback UI).
+func (h *History) RepoPath(scope string) string {
+	return filepath.Join(h.root, scope+".git")
+}
+
+// runGit executes a git command with a hard timeout and returns combined
+// output. env is reserved for callers that need to override the environment.
+func runGit(ctx context.Context, env []string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), err
+	}
+	return out.String(), nil
+}

--- a/internal/workspace/history.go
+++ b/internal/workspace/history.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -29,16 +30,29 @@ import (
 //   - Everything is best-effort: history failures must never fail or block
 //     an agent run. Callers log and move on.
 //
+// Known limitation: there is no retention policy — every dirty turn adds a
+// commit, so binary-heavy workspaces grow the repo unbounded. A git gc /
+// retention window is future work.
+//
 // Rollback is manual for now (git --git-dir=<repo> --work-tree=<dir> log /
 // checkout); a workspace-panel entry can come later.
 type History struct {
 	root string
+	// locks serializes commits per scope: two overlapping turns of the same
+	// chat must never race the same repo's index (loser hits index.lock and
+	// silently loses a snapshot).
+	locks sync.Map // scope -> *sync.Mutex
 }
 
 // NewHistory returns a History storing bare repositories under root
 // (one <scope>.git per workspace scope).
 func NewHistory(root string) *History {
 	return &History{root: root}
+}
+
+func (h *History) lockFor(scope string) *sync.Mutex {
+	lock, _ := h.locks.LoadOrStore(scope, &sync.Mutex{})
+	return lock.(*sync.Mutex)
 }
 
 // Commit snapshots workTree into the scope's bare repository. The first
@@ -52,7 +66,11 @@ func (h *History) Commit(ctx context.Context, scope, workTree, message string) e
 	if err != nil || !info.IsDir() {
 		return nil // nothing to snapshot
 	}
-	repo := filepath.Join(h.root, scope+".git")
+	lock := h.lockFor(scope)
+	lock.Lock()
+	defer lock.Unlock()
+
+	repo := h.RepoPath(scope)
 	if _, err := os.Stat(repo); os.IsNotExist(err) {
 		if err := os.MkdirAll(filepath.Dir(repo), 0o755); err != nil {
 			return err
@@ -60,16 +78,16 @@ func (h *History) Commit(ctx context.Context, scope, workTree, message string) e
 		// NOTE: git rejects init combined with --work-tree
 		// ("GIT_WORK_TREE not allowed without GIT_DIR"), so init uses the
 		// plain path form and only later commands carry --git-dir/--work-tree.
-		if out, err := runGit(ctx, nil, "init", "--bare", repo); err != nil {
+		if out, err := runGit(ctx, "init", "--bare", repo); err != nil {
 			return fmt.Errorf("git init: %s: %w", out, err)
 		}
 	}
 	gitDir := "--git-dir=" + repo
 	workTreeArg := "--work-tree=" + workTree
-	if out, err := runGit(ctx, nil, gitDir, workTreeArg, "add", "-A"); err != nil {
+	if out, err := runGit(ctx, gitDir, workTreeArg, "add", "-A"); err != nil {
 		return fmt.Errorf("git add: %s: %w", out, err)
 	}
-	status, err := runGit(ctx, nil, gitDir, workTreeArg, "status", "--porcelain")
+	status, err := runGit(ctx, gitDir, workTreeArg, "status", "--porcelain")
 	if err != nil {
 		return fmt.Errorf("git status: %s: %w", status, err)
 	}
@@ -77,7 +95,7 @@ func (h *History) Commit(ctx context.Context, scope, workTree, message string) e
 		return nil // clean tree — skip empty commit
 	}
 	// Inline identity so this works without the operator's global git config.
-	out, err := runGit(ctx, nil, gitDir, workTreeArg,
+	out, err := runGit(ctx, gitDir, workTreeArg,
 		"-c", "user.name=fastclaw", "-c", "user.email=fastclaw@localhost",
 		"commit", "-m", message, "--quiet")
 	if err != nil {
@@ -101,7 +119,7 @@ func (h *History) List(ctx context.Context, scope string) ([]Entry, error) {
 	if _, err := os.Stat(repo); os.IsNotExist(err) {
 		return nil, nil
 	}
-	out, err := runGit(ctx, nil, "--git-dir="+repo, "log", "--pretty=%H|%s|%ct")
+	out, err := runGit(ctx, "--git-dir="+repo, "log", "--pretty=%H|%s|%ct")
 	if err != nil {
 		return nil, fmt.Errorf("git log: %s: %w", out, err)
 	}
@@ -132,7 +150,7 @@ func (h *History) Restore(ctx context.Context, scope, workTree, commit string) e
 	if _, err := os.Stat(repo); os.IsNotExist(err) {
 		return fmt.Errorf("workspace history: no history for scope %q", scope)
 	}
-	out, err := runGit(ctx, nil, "--git-dir="+repo, "--work-tree="+workTree, "checkout", commit, "--", ".")
+	out, err := runGit(ctx, "--git-dir="+repo, "--work-tree="+workTree, "checkout", commit, "--", ".")
 	if err != nil {
 		return fmt.Errorf("git checkout: %s: %w", out, err)
 	}
@@ -153,20 +171,35 @@ func isHexHash(s string) bool {
 }
 
 // RepoPath returns the bare repository path for a scope (used by tests and
-// by any future rollback UI).
+// by any future rollback UI). The scope is allowlist-sanitized — it is
+// built from operator/channel-provided ids and lands in a file path.
 func (h *History) RepoPath(scope string) string {
-	return filepath.Join(h.root, scope+".git")
+	return filepath.Join(h.root, sanitizeScope(scope)+".git")
+}
+
+// sanitizeScope maps anything outside [A-Za-z0-9._-] to '_', so a hostile
+// or unusual chat/project id can't escape the history root.
+func sanitizeScope(scope string) string {
+	var b strings.Builder
+	b.Grow(len(scope))
+	for _, c := range scope {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9',
+			c == '.', c == '_', c == '-':
+			b.WriteRune(c)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 // runGit executes a git command with a hard timeout and returns combined
-// output. env is reserved for callers that need to override the environment.
-func runGit(ctx context.Context, env []string, args ...string) (string, error) {
+// output.
+func runGit(ctx context.Context, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", args...)
-	if env != nil {
-		cmd.Env = env
-	}
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/internal/workspace/history.go
+++ b/internal/workspace/history.go
@@ -87,6 +87,71 @@ func (h *History) Commit(ctx context.Context, scope, workTree, message string) e
 	return nil
 }
 
+// Entry is one snapshot commit, newest first when returned by List.
+type Entry struct {
+	Hash    string `json:"hash"`
+	Message string `json:"message"`
+	Time    int64  `json:"time"`
+}
+
+// List returns the scope's snapshot commits, newest first. No history
+// yields an empty slice (not an error).
+func (h *History) List(ctx context.Context, scope string) ([]Entry, error) {
+	repo := h.RepoPath(scope)
+	if _, err := os.Stat(repo); os.IsNotExist(err) {
+		return nil, nil
+	}
+	out, err := runGit(ctx, nil, "--git-dir="+repo, "log", "--pretty=%H|%s|%ct")
+	if err != nil {
+		return nil, fmt.Errorf("git log: %s: %w", out, err)
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil, nil
+	}
+	var entries []Entry
+	for _, line := range strings.Split(out, "\n") {
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		var t int64
+		fmt.Sscanf(parts[2], "%d", &t)
+		entries = append(entries, Entry{Hash: parts[0], Message: parts[1], Time: t})
+	}
+	return entries, nil
+}
+
+// Restore checks the whole worktree out to the given commit. The commit
+// hash is validated to prevent flag injection.
+func (h *History) Restore(ctx context.Context, scope, workTree, commit string) error {
+	if !isHexHash(commit) {
+		return fmt.Errorf("workspace history: invalid commit hash")
+	}
+	repo := h.RepoPath(scope)
+	if _, err := os.Stat(repo); os.IsNotExist(err) {
+		return fmt.Errorf("workspace history: no history for scope %q", scope)
+	}
+	out, err := runGit(ctx, nil, "--git-dir="+repo, "--work-tree="+workTree, "checkout", commit, "--", ".")
+	if err != nil {
+		return fmt.Errorf("git checkout: %s: %w", out, err)
+	}
+	slog.Info("workspace history restored", "scope", scope, "commit", commit)
+	return nil
+}
+
+func isHexHash(s string) bool {
+	if len(s) < 7 || len(s) > 40 {
+		return false
+	}
+	for _, c := range s {
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F') {
+			return false
+		}
+	}
+	return true
+}
+
 // RepoPath returns the bare repository path for a scope (used by tests and
 // by any future rollback UI).
 func (h *History) RepoPath(scope string) string {

--- a/internal/workspace/history_test.go
+++ b/internal/workspace/history_test.go
@@ -1,0 +1,120 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func gitAvailable(t *testing.T) {
+	t.Helper()
+	if err := exec.Command("git", "--version").Run(); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+func gitLog(t *testing.T, repo, workTree string) string {
+	t.Helper()
+	out, err := exec.Command("git", "--git-dir="+repo, "--work-tree="+workTree, "log", "--oneline").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log: %v: %s", err, out)
+	}
+	return string(out)
+}
+
+func TestHistoryCommitSnapshotsWorkTree(t *testing.T) {
+	gitAvailable(t)
+	root := t.TempDir()
+	workTree := filepath.Join(root, "ws")
+	if err := os.MkdirAll(workTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workTree, "a.txt"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := NewHistory(filepath.Join(root, "history"))
+
+	if err := h.Commit(context.Background(), "s1", workTree, "turn 1"); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	repo := h.RepoPath("s1")
+	if info, err := os.Stat(repo); err != nil || !info.IsDir() {
+		t.Fatalf("bare repo should exist at %s", repo)
+	}
+	// 工作区内不得出现 .git（agent 可见性红线）
+	if _, err := os.Stat(filepath.Join(workTree, ".git")); !os.IsNotExist(err) {
+		t.Fatal("workTree must not contain .git")
+	}
+	if log := gitLog(t, repo, workTree); !strings.Contains(log, "turn 1") {
+		t.Fatalf("expected 'turn 1' commit, got: %s", log)
+	}
+}
+
+func TestHistorySkipsEmptyCommit(t *testing.T) {
+	gitAvailable(t)
+	root := t.TempDir()
+	workTree := filepath.Join(root, "ws")
+	if err := os.MkdirAll(workTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workTree, "a.txt"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := NewHistory(filepath.Join(root, "history"))
+
+	if err := h.Commit(context.Background(), "s1", workTree, "turn 1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Commit(context.Background(), "s1", workTree, "turn 2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if log := gitLog(t, h.RepoPath("s1"), workTree); strings.Count(log, "\n") != 0 && len(strings.Split(strings.TrimSpace(log), "\n")) != 1 {
+		t.Fatalf("clean tree must not produce an empty commit: %s", log)
+	}
+}
+
+func TestHistorySecondCommitCapturesModificationAndRollback(t *testing.T) {
+	gitAvailable(t)
+	root := t.TempDir()
+	workTree := filepath.Join(root, "ws")
+	if err := os.MkdirAll(workTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(workTree, "a.txt")
+	if err := os.WriteFile(file, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := NewHistory(filepath.Join(root, "history"))
+
+	if err := h.Commit(context.Background(), "s1", workTree, "turn 1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("v2-corrupted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Commit(context.Background(), "s1", workTree, "turn 2"); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := h.RepoPath("s1")
+	if log := gitLog(t, repo, workTree); len(strings.Split(strings.TrimSpace(log), "\n")) != 2 {
+		t.Fatalf("expected 2 commits: %s", log)
+	}
+	// 回滚到 run-1 的内容
+	out, err := exec.Command("git", "--git-dir="+repo, "--work-tree="+workTree, "checkout", "HEAD~1", "--", "a.txt").CombinedOutput()
+	if err != nil {
+		t.Fatalf("checkout: %v: %s", err, out)
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "v1" {
+		t.Fatalf("rollback should restore v1, got %q", data)
+	}
+}

--- a/internal/workspace/history_test.go
+++ b/internal/workspace/history_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +46,7 @@ func TestHistoryCommitSnapshotsWorkTree(t *testing.T) {
 	if info, err := os.Stat(repo); err != nil || !info.IsDir() {
 		t.Fatalf("bare repo should exist at %s", repo)
 	}
-	// 工作区内不得出现 .git（agent 可见性红线）
+	// the agent must never see its own history: no .git inside the worktree
 	if _, err := os.Stat(filepath.Join(workTree, ".git")); !os.IsNotExist(err) {
 		t.Fatal("workTree must not contain .git")
 	}
@@ -73,8 +74,12 @@ func TestHistorySkipsEmptyCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if log := gitLog(t, h.RepoPath("s1"), workTree); strings.Count(log, "\n") != 0 && len(strings.Split(strings.TrimSpace(log), "\n")) != 1 {
-		t.Fatalf("clean tree must not produce an empty commit: %s", log)
+	out, err := exec.Command("git", "--git-dir="+h.RepoPath("s1"), "rev-list", "--count", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-list: %v: %s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "1" {
+		t.Fatalf("clean tree must not produce an empty commit, got %s commits", out)
 	}
 }
 
@@ -105,7 +110,7 @@ func TestHistorySecondCommitCapturesModificationAndRollback(t *testing.T) {
 	if log := gitLog(t, repo, workTree); len(strings.Split(strings.TrimSpace(log), "\n")) != 2 {
 		t.Fatalf("expected 2 commits: %s", log)
 	}
-	// 回滚到 run-1 的内容
+	// roll back to the run-1 content
 	out, err := exec.Command("git", "--git-dir="+repo, "--work-tree="+workTree, "checkout", "HEAD~1", "--", "a.txt").CombinedOutput()
 	if err != nil {
 		t.Fatalf("checkout: %v: %s", err, out)
@@ -175,5 +180,44 @@ func TestHistoryRestoreRejectsBadHash(t *testing.T) {
 	h := NewHistory(t.TempDir())
 	if err := h.Restore(context.Background(), "s1", t.TempDir(), "main; rm -rf /"); err == nil {
 		t.Fatal("invalid hash must be rejected")
+	}
+}
+
+func TestHistoryConcurrentCommitsAreSerialized(t *testing.T) {
+	gitAvailable(t)
+	root := t.TempDir()
+	workTree := filepath.Join(root, "ws")
+	if err := os.MkdirAll(workTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := NewHistory(filepath.Join(root, "history"))
+	ctx := context.Background()
+
+	// Hammer the same scope from many goroutines. Without the per-scope
+	// lock some of these would fail on index.lock; with it, every commit
+	// must succeed (each may legitimately skip as a clean tree).
+	const n = 8
+	done := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			name := fmt.Sprintf("f%d.txt", i)
+			if err := os.WriteFile(filepath.Join(workTree, name), []byte(fmt.Sprintf("v%d", i)), 0o644); err != nil {
+				done <- err
+				return
+			}
+			done <- h.Commit(ctx, "s1", workTree, "turn "+name)
+		}(i)
+	}
+	for i := 0; i < n; i++ {
+		if err := <-done; err != nil {
+			t.Fatalf("concurrent commit must not fail on index race: %v", err)
+		}
+	}
+	out, err := exec.Command("git", "--git-dir="+h.RepoPath("s1"), "rev-list", "--count", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-list: %v: %s", err, out)
+	}
+	if strings.TrimSpace(string(out)) == "0" {
+		t.Fatal("at least one commit must land")
 	}
 }

--- a/internal/workspace/history_test.go
+++ b/internal/workspace/history_test.go
@@ -118,3 +118,62 @@ func TestHistorySecondCommitCapturesModificationAndRollback(t *testing.T) {
 		t.Fatalf("rollback should restore v1, got %q", data)
 	}
 }
+
+func TestHistoryListAndRestore(t *testing.T) {
+	gitAvailable(t)
+	root := t.TempDir()
+	workTree := filepath.Join(root, "ws")
+	if err := os.MkdirAll(workTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(workTree, "a.txt")
+	h := NewHistory(filepath.Join(root, "history"))
+	ctx := context.Background()
+
+	if err := os.WriteFile(file, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Commit(ctx, "s1", workTree, "turn 1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Commit(ctx, "s1", workTree, "turn 2"); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := h.List(ctx, "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Message != "turn 2" || entries[0].Time == 0 {
+		t.Fatalf("newest entry first with timestamp: %+v", entries[0])
+	}
+	// 无历史的 scope 返回空列表而非错误
+	if empty, err := h.List(ctx, "nope"); err != nil || len(empty) != 0 {
+		t.Fatalf("missing scope should list empty: %v %v", empty, err)
+	}
+
+	if err := h.Restore(ctx, "s1", workTree, entries[1].Hash); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "v1" {
+		t.Fatalf("restore should bring back v1, got %q", data)
+	}
+}
+
+func TestHistoryRestoreRejectsBadHash(t *testing.T) {
+	gitAvailable(t)
+	h := NewHistory(t.TempDir())
+	if err := h.Restore(context.Background(), "s1", t.TempDir(), "main; rm -rf /"); err == nil {
+		t.Fatal("invalid hash must be rejected")
+	}
+}

--- a/internal/workspace/localfs.go
+++ b/internal/workspace/localfs.go
@@ -60,6 +60,13 @@ func (f *LocalFS) LocalScopeDir(agentID, projectID, sessionID string) (string, b
 // at `/workspace/<other-sid>/...`) but cwd into the chat's subdir
 // so relative writes default to the chat's own files — see
 // docker_executor.go's pool.Get.
+// ScopeDir returns the on-disk directory for one (agent, project, session)
+// scope. Exported for workspace history snapshots (a LocalFS-only feature);
+// prefer scopeDir for internal use.
+func (f *LocalFS) ScopeDir(agentID, projectID, sessionID string) string {
+	return f.scopeDir(agentID, projectID, sessionID)
+}
+
 func (f *LocalFS) scopeDir(agentID, projectID, sessionID string) string {
 	switch {
 	case projectID != "" && sessionID != "":

--- a/internal/workspace/localfs.go
+++ b/internal/workspace/localfs.go
@@ -60,13 +60,6 @@ func (f *LocalFS) LocalScopeDir(agentID, projectID, sessionID string) (string, b
 // at `/workspace/<other-sid>/...`) but cwd into the chat's subdir
 // so relative writes default to the chat's own files — see
 // docker_executor.go's pool.Get.
-// ScopeDir returns the on-disk directory for one (agent, project, session)
-// scope. Exported for workspace history snapshots (a LocalFS-only feature);
-// prefer scopeDir for internal use.
-func (f *LocalFS) ScopeDir(agentID, projectID, sessionID string) string {
-	return f.scopeDir(agentID, projectID, sessionID)
-}
-
 func (f *LocalFS) scopeDir(agentID, projectID, sessionID string) string {
 	switch {
 	case projectID != "" && sessionID != "":

--- a/web/src/components/chat-screen.tsx
+++ b/web/src/components/chat-screen.tsx
@@ -6,7 +6,7 @@ import { useAgentIdFromURL } from "@/hooks/use-agent-id";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { fileUrl, getAgent, getAgentKnowledgeFile, getChangedFiles, getChatHistoryWithCursor, getChatSessions, getChatTodo, getMe, getScopePreview, getScopePreviewLogs, listAgentFiles, listProjects, renameChatSession, revealAgentWorkspace, sendChatStream, steerChat, uploadAgentFiles, getSkills, type ChatHistoryMessage, type ChatStreamEvent, type KnowledgeSource, type ScopePreview, type SkillInfo, type TodoItem, type ToolResultMetadata, type WorkspaceFile } from "@/lib/api";
+import { fileUrl, getAgent, getAgentKnowledgeFile, getChangedFiles, getChatHistoryWithCursor, getChatSessions, getChatTodo, getMe, getScopePreview, getScopePreviewLogs, getSessionHistory, listAgentFiles, listProjects, renameChatSession, restoreSessionHistory, revealAgentWorkspace, sendChatStream, steerChat, uploadAgentFiles, getSkills, type ChatHistoryMessage, type ChatStreamEvent, type KnowledgeSource, type ScopePreview, type SkillInfo, type TodoItem, type ToolResultMetadata, type WorkspaceFile, type WorkspaceHistoryEntry } from "@/lib/api";
 import { Bot, Send, Copy, Check, Pencil, Wrench, ChevronDown, ChevronRight, Download, X, File, FileText, Folder, FolderSearch, Image as ImageIcon, FileCode, Film, Music, Puzzle, SlidersHorizontal, ShieldCheck, Paperclip, Square, FolderOpen, RefreshCw, Eye, Code2, RotateCcw, ListChecks, Terminal, ExternalLink, MoreHorizontal, PanelLeftClose, PanelLeftOpen, BookOpen } from "lucide-react";
 import Link from "next/link";
 import { ChatMarkdown } from "@/components/chat-markdown";
@@ -3363,6 +3363,10 @@ function WorkspacePanel({
   // just this task's output), and whether to show all files instead.
   const [changed, setChanged] = useState<{ files: WorkspaceFile[]; available: boolean }>({ files: [], available: false });
   const [showAll, setShowAll] = useState(false);
+  // Workspace version history dropdown (per-session git snapshots).
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [history, setHistory] = useState<WorkspaceHistoryEntry[]>([]);
+  const [restoring, setRestoring] = useState(false);
   // Self-hosted-only "open in Finder" affordance. We learn the deploy
   // mode from /api/me on mount; it doesn't change at runtime, so one
   // fetch per panel instance is enough. Hosted deployments leave this
@@ -3488,6 +3492,44 @@ function WorkspacePanel({
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // Workspace version history: load commits when the dropdown opens;
+  // restore checks out the whole session workspace to that commit and
+  // refreshes the file tree/viewer.
+  const toggleHistory = useCallback(async () => {
+    if (historyOpen) {
+      setHistoryOpen(false);
+      return;
+    }
+    if (!sessionId) return;
+    setHistoryOpen(true);
+    try {
+      setHistory(await getSessionHistory(agentId, sessionId));
+    } catch {
+      setHistory([]);
+    }
+  }, [historyOpen, agentId, sessionId]);
+
+  const handleRestore = useCallback(
+    async (commit: string) => {
+      if (!sessionId || restoring) return;
+      // eslint-disable-next-line no-alert
+      if (!window.confirm("将此会话的工作区回滚到该版本？当前未提交的文件修改会被覆盖。")) return;
+      setRestoring(true);
+      try {
+        await restoreSessionHistory(agentId, sessionId, commit);
+        setHistoryOpen(false);
+        setPreviewing(null);
+        await refresh();
+      } catch (error) {
+        // eslint-disable-next-line no-alert
+        alert("回滚失败：" + String(error));
+      } finally {
+        setRestoring(false);
+      }
+    },
+    [agentId, sessionId, restoring, refresh],
+  );
 
   // Switching conversations swaps the file tree to the new scope — clear the
   // selected file too, so the viewer never shows a file from the previous
@@ -3673,6 +3715,47 @@ function WorkspacePanel({
                 >
                   <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
                 </button>
+                {sessionId && !projectId && (
+                  <span className="relative">
+                    <button
+                      onClick={toggleHistory}
+                      disabled={restoring}
+                      className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+                      title="版本历史（回滚工作区）"
+                    >
+                      <RotateCcw className={`h-4 w-4 ${restoring ? "animate-spin" : ""}`} />
+                    </button>
+                    {historyOpen && (
+                      <div className="absolute right-0 top-8 z-20 w-72 rounded-md border border-border bg-popover p-1 shadow-lg">
+                        <div className="px-2 py-1 text-xs font-medium text-muted-foreground">版本历史</div>
+                        {history.length === 0 ? (
+                          <div className="px-2 py-3 text-center text-xs text-muted-foreground">暂无历史快照</div>
+                        ) : (
+                          history.slice(0, 20).map((entry) => (
+                            <div
+                              key={entry.hash}
+                              className="flex items-center justify-between gap-2 rounded px-2 py-1 hover:bg-muted/50"
+                            >
+                              <div className="min-w-0 flex-1">
+                                <div className="truncate text-xs">{entry.message}</div>
+                                <div className="text-[10px] text-muted-foreground">
+                                  {entry.hash.slice(0, 7)} · {new Date(entry.time * 1000).toLocaleString()}
+                                </div>
+                              </div>
+                              <button
+                                onClick={() => handleRestore(entry.hash)}
+                                disabled={restoring}
+                                className="shrink-0 rounded bg-muted px-2 py-0.5 text-xs hover:bg-accent disabled:opacity-50"
+                              >
+                                回滚
+                              </button>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    )}
+                  </span>
+                )}
               </>
             )}
             <button

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2018,3 +2018,40 @@ export function fileUrl(agentId: string, path: string, download = false): string
   const qs = params.toString();
   return `/api/agents/${agentId}/files/${encoded}${qs ? "?" + qs : ""}`;
 }
+
+// Workspace version history (per-session git snapshots taken after each
+// agent run). Backs the Workspace panel's history dropdown: list commits,
+// restore the whole session workspace to one of them.
+export interface WorkspaceHistoryEntry {
+  hash: string;
+  message: string;
+  time: number; // unix seconds
+}
+
+export async function getSessionHistory(
+  agentId: string,
+  sessionId: string,
+): Promise<WorkspaceHistoryEntry[]> {
+  const res = await apiFetch(
+    `/api/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/history`,
+  );
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.history || []) as WorkspaceHistoryEntry[];
+}
+
+export async function restoreSessionHistory(
+  agentId: string,
+  sessionId: string,
+  commit: string,
+): Promise<void> {
+  const res = await apiFetch(
+    `/api/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/history/restore`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ commit }),
+    },
+  );
+  if (!res.ok) throw new Error(`restore failed: ${res.status}`);
+}


### PR DESCRIPTION
Closes #100

## 动机

Agent 在 workspace 里频繁写文件（文件工具、沙箱 exec 经绑定挂载、上传），一旦改错或误删没有任何回滚手段。本 PR 增加一个**可选开启**的 workspace 版本历史，基于 git 实现。

## 设计

1. **bare 仓库放在 workspace 之外**（~/.fastclaw/workspace-history/<scope>.git）——.git 放在 workspace 里会被 agent 自己看到（文件工具会列出、模型可能读取/破坏，还会撑大上下文）；
2. **turn 边界提交**（每轮运行结束后），而不是按写提交——沙箱 exec 经绑定挂载的写入宿主进程感知不到，按写钩子永远不完整；turn 边界是唯一覆盖全部写入来源的一致性时点；
3. **opt-in**：workspaceHistory.enabled 默认关闭；仅 localfs 后端，S3 后端自动跳过，不侵入 workspaceStore 抽象；
4. **尽力而为**：历史操作失败只 WARN，绝不阻塞或失败 agent 运行；提交身份内联（不依赖操作者全局 git config）。

## 实现

- internal/workspace/history.go：History（init/add/commit，空提交跳过，30s 超时）；
- LocalFS.ScopeDir 导出（供快照定位会话目录）；
- agent 运行结束钩子（LocalFS 时生效，goroutine fire-and-forget）；
- config：workspaceHistory.enabled。

## 测试

- internal/workspace/history_test.go 3 用例：快照提交（且 workspace 内无 .git）、空提交跳过、修改捕获 + checkout 回滚恢复；
- go build ./internal/{workspace,agent,config} 通过。

## 回滚方式（当前）

git --git-dir=<repo> --work-tree=<dir> log / checkout；workspace 面板的回滚入口可以后续再做。

（我已在一个本地版本验证了完整闭环：turn 边界快照 + 面板一键回滚。）
