### PR TITLE
fix(setup): resolve masked skill secrets to stored originals on confi…

### DIFF
--- a/internal/setup/handlers.go
+++ b/internal/setup/handlers.go
@@ -87,17 +87,28 @@ func loadAgentSkillEntriesForUser(ctx context.Context, st store.Store, userID st
 	}
 	out := map[string]map[string]config.SkillEntryCfg{}
 	for _, ar := range agents {
-		rec, err := st.GetConfigByName(ctx, store.KindSetting, "", ar.ID, "skills.entries")
-		if err != nil || rec == nil || len(rec.Data) == 0 {
+		entries, err := loadAgentSkillEntries(ctx, st, ar.ID)
+		if err != nil || len(entries) == 0 {
 			continue
 		}
-		blob, _ := json.Marshal(rec.Data)
-		var entries map[string]config.SkillEntryCfg
-		if json.Unmarshal(blob, &entries) == nil && len(entries) > 0 {
-			out[ar.ID] = entries
-		}
+		out[ar.ID] = entries
 	}
 	return out, nil
+}
+
+// loadAgentSkillEntries reads one agent-scope skills.entries row.
+// A missing row is not an error — nil entries means "no overrides".
+func loadAgentSkillEntries(ctx context.Context, st store.Store, agentID string) (map[string]config.SkillEntryCfg, error) {
+	rec, err := st.GetConfigByName(ctx, store.KindSetting, "", agentID, "skills.entries")
+	if err != nil || rec == nil || len(rec.Data) == 0 {
+		return nil, err
+	}
+	blob, _ := json.Marshal(rec.Data)
+	var entries map[string]config.SkillEntryCfg
+	if err := json.Unmarshal(blob, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
 }
 
 // saveAgentSkillEntries upserts the agent-scope skills.entries row.
@@ -543,6 +554,7 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		Prefs   *config.PrefsCfg `json:"prefs"`
 		Sandbox *json.RawMessage `json:"sandbox"`
 		Skills  *struct {
+			Entries      map[string]config.SkillEntryCfg            `json:"entries"`
 			AgentEntries map[string]map[string]config.SkillEntryCfg `json:"agentEntries"`
 		} `json:"skills"`
 	}
@@ -566,9 +578,22 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	// through the namespace sweep, and re-writing them here would
 	// re-build the legacy shape we just split apart.
 	merged.Skills.AgentEntries = nil
+	// Snapshot the stored global skill entries before the request body
+	// is unmarshalled over them. The dashboard round-trips masked
+	// secrets ("sk-1****abcd") — mergeSkillEntry resolves those back to
+	// the stored originals so a no-op save can't clobber real keys.
+	existingSkillEntries := make(map[string]config.SkillEntryCfg, len(merged.Skills.Entries))
+	for name, entry := range merged.Skills.Entries {
+		existingSkillEntries[name] = entry
+	}
 	if err := json.Unmarshal(buf, merged); err != nil {
 		jsonResponse(w, http.StatusBadRequest, map[string]any{"ok": false, "error": err.Error()})
 		return
+	}
+	if raw.Skills != nil {
+		for name, in := range raw.Skills.Entries {
+			merged.Skills.Entries[name] = mergeSkillEntry(existingSkillEntries[name], in)
+		}
 	}
 	if err := s.saveUserConfig(r, merged); err != nil {
 		jsonResponse(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": err.Error()})
@@ -599,6 +624,13 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 			}
 			if !s.authorizeScope(w, r, scope.Agent, agentID, scopeWrite) {
 				return
+			}
+			// Resolve masked secrets back to the stored originals before
+			// persisting — same protection as the global entries path.
+			if existing, err := loadAgentSkillEntries(r.Context(), s.dataStore, agentID); err == nil {
+				for name, in := range entries {
+					entries[name] = mergeSkillEntry(existing[name], in)
+				}
 			}
 			if err := saveAgentSkillEntries(r.Context(), s.dataStore, agentID, entries); err != nil {
 				jsonResponse(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": err.Error()})

--- a/internal/setup/handlers_config_test.go
+++ b/internal/setup/handlers_config_test.go
@@ -1,0 +1,212 @@
+package setup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fastclaw-ai/fastclaw/internal/auth"
+	"github.com/fastclaw-ai/fastclaw/internal/config"
+	"github.com/fastclaw-ai/fastclaw/internal/store"
+)
+
+// Round-trip regression tests for the masked-secret write-back path of
+// POST /api/config: the dashboard GETs masked values ("sk-1****abcd")
+// and POSTs them back verbatim on save. mergeSkillEntry must resolve
+// those placeholders to the stored originals — before it was wired in,
+// a no-op save replaced real keys with literal "****" strings.
+
+func TestUpdateConfigMaskedGlobalSkillEntryKeepsStoredSecret(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, adminUser, _ := newAuthTestServer(t, ctx)
+
+	post := func(body map[string]any) *httptest.ResponseRecorder {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		s.authMiddleware(s.handleUpdateConfig)(rr, configTestRequest(t, ctx, resolver, http.MethodPost, "/api/config", adminUser.ID, body))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("POST /api/config status = %d, body = %s", rr.Code, rr.Body.String())
+		}
+		return rr
+	}
+	storedEntry := func() config.SkillEntryCfg {
+		t.Helper()
+		rec, err := s.dataStore.GetConfigByName(ctx, store.KindSetting, "", "", "skills.entries")
+		if err != nil || rec == nil {
+			t.Fatalf("GetConfigByName: rec=%v err=%v", rec, err)
+		}
+		blob, _ := json.Marshal(rec.Data)
+		var entries map[string]config.SkillEntryCfg
+		if err := json.Unmarshal(blob, &entries); err != nil {
+			t.Fatalf("decode entries: %v", err)
+		}
+		return entries["my-skill"]
+	}
+
+	post(map[string]any{"skills": map[string]any{"entries": map[string]any{
+		"my-skill": map[string]any{
+			"enabled": true,
+			"apiKey":  "real-secret-key-123456",
+			"env":     map[string]any{"NORMAL_VAR": "plain", "API_TOKEN": "real-env-secret-987654"},
+		},
+	}}})
+	if got := storedEntry(); got.APIKey != "real-secret-key-123456" || got.Env["API_TOKEN"] != "real-env-secret-987654" {
+		t.Fatalf("initial save lost secrets: %+v", got)
+	}
+
+	// Simulate the dashboard: GET (masked) → POST the masked entry back.
+	get := httptest.NewRecorder()
+	s.authMiddleware(s.handleGetConfig)(get, configTestRequest(t, ctx, resolver, http.MethodGet, "/api/config", adminUser.ID, nil))
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET /api/config status = %d", get.Code)
+	}
+	var view struct {
+		Skills struct {
+			Entries map[string]config.SkillEntryCfg `json:"entries"`
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal(get.Body.Bytes(), &view); err != nil {
+		t.Fatalf("decode GET response: %v", err)
+	}
+	maskedEntry := view.Skills.Entries["my-skill"]
+	if maskedEntry.APIKey == "real-secret-key-123456" || maskedEntry.Env["API_TOKEN"] == "real-env-secret-987654" {
+		t.Fatalf("GET leaked plaintext secrets: %+v", maskedEntry)
+	}
+
+	post(map[string]any{"skills": map[string]any{"entries": map[string]any{"my-skill": maskedEntry}}})
+	if got := storedEntry(); got.APIKey != "real-secret-key-123456" {
+		t.Fatalf("masked write-back clobbered apiKey: got %q", got.APIKey)
+	}
+	if got := storedEntry(); got.Env["API_TOKEN"] != "real-env-secret-987654" {
+		t.Fatalf("masked write-back clobbered env API_TOKEN: got %q", got.Env["API_TOKEN"])
+	}
+	if got := storedEntry(); got.Env["NORMAL_VAR"] != "plain" || !got.Enabled {
+		t.Fatalf("non-secret fields should round-trip unchanged: %+v", got)
+	}
+}
+
+func TestUpdateConfigMaskedAgentSkillEntryKeepsStoredSecret(t *testing.T) {
+	ctx := context.Background()
+	s, resolver, adminUser, _ := newAuthTestServer(t, ctx)
+
+	if err := s.dataStore.SaveAgent(ctx, &store.AgentRecord{ID: "agent-1", UserID: adminUser.ID, Name: "Test Agent"}); err != nil {
+		t.Fatalf("SaveAgent: %v", err)
+	}
+
+	post := func(body map[string]any) *httptest.ResponseRecorder {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		s.authMiddleware(s.handleUpdateConfig)(rr, configTestRequest(t, ctx, resolver, http.MethodPost, "/api/config", adminUser.ID, body))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("POST /api/config status = %d, body = %s", rr.Code, rr.Body.String())
+		}
+		return rr
+	}
+	storedEntry := func() config.SkillEntryCfg {
+		t.Helper()
+		rec, err := s.dataStore.GetConfigByName(ctx, store.KindSetting, "", "agent-1", "skills.entries")
+		if err != nil || rec == nil {
+			t.Fatalf("GetConfigByName: rec=%v err=%v", rec, err)
+		}
+		blob, _ := json.Marshal(rec.Data)
+		var entries map[string]config.SkillEntryCfg
+		if err := json.Unmarshal(blob, &entries); err != nil {
+			t.Fatalf("decode entries: %v", err)
+		}
+		return entries["my-skill"]
+	}
+
+	post(map[string]any{"skills": map[string]any{"agentEntries": map[string]any{
+		"agent-1": map[string]any{
+			"my-skill": map[string]any{
+				"apiKey": "agent-secret-key-abcdef",
+				"env":    map[string]any{"DB_PASSWORD": "real-db-pass-123456"},
+			},
+		},
+	}}})
+	if got := storedEntry(); got.APIKey != "agent-secret-key-abcdef" || got.Env["DB_PASSWORD"] != "real-db-pass-123456" {
+		t.Fatalf("initial save lost secrets: %+v", got)
+	}
+
+	get := httptest.NewRecorder()
+	s.authMiddleware(s.handleGetConfig)(get, configTestRequest(t, ctx, resolver, http.MethodGet, "/api/config", adminUser.ID, nil))
+	var view struct {
+		Skills struct {
+			AgentEntries map[string]map[string]config.SkillEntryCfg `json:"agentEntries"`
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal(get.Body.Bytes(), &view); err != nil {
+		t.Fatalf("decode GET response: %v", err)
+	}
+	maskedEntry := view.Skills.AgentEntries["agent-1"]["my-skill"]
+	if maskedEntry.APIKey == "agent-secret-key-abcdef" {
+		t.Fatalf("GET leaked plaintext apiKey: %+v", maskedEntry)
+	}
+
+	post(map[string]any{"skills": map[string]any{"agentEntries": map[string]any{
+		"agent-1": map[string]any{"my-skill": maskedEntry},
+	}}})
+	if got := storedEntry(); got.APIKey != "agent-secret-key-abcdef" {
+		t.Fatalf("masked write-back clobbered apiKey: got %q", got.APIKey)
+	}
+	if got := storedEntry(); got.Env["DB_PASSWORD"] != "real-db-pass-123456" {
+		t.Fatalf("masked write-back clobbered env DB_PASSWORD: got %q", got.Env["DB_PASSWORD"])
+	}
+}
+
+func TestMergeSkillEntry(t *testing.T) {
+	existing := config.SkillEntryCfg{
+		Enabled: true,
+		APIKey:  "real-secret-key-123456",
+		Env:     map[string]string{"API_TOKEN": "real-env-secret-987654", "NORMAL_VAR": "old"},
+	}
+	in := config.SkillEntryCfg{
+		Enabled: false,
+		APIKey:  maskAPIKey("real-secret-key-123456"),
+		Env:     map[string]string{"API_TOKEN": maskAPIKey("real-env-secret-987654"), "NORMAL_VAR": "new"},
+	}
+	out := mergeSkillEntry(existing, in)
+	if out.APIKey != existing.APIKey {
+		t.Errorf("masked apiKey should resolve to stored original, got %q", out.APIKey)
+	}
+	if out.Env["API_TOKEN"] != existing.Env["API_TOKEN"] {
+		t.Errorf("masked env value should resolve to stored original, got %q", out.Env["API_TOKEN"])
+	}
+	if out.Env["NORMAL_VAR"] != "new" {
+		t.Errorf("plain env value should follow the request, got %q", out.Env["NORMAL_VAR"])
+	}
+	if out.Enabled != in.Enabled {
+		t.Errorf("enabled should follow the request, got %v", out.Enabled)
+	}
+
+	// A genuinely new value (no mask) must replace the stored one.
+	out = mergeSkillEntry(existing, config.SkillEntryCfg{APIKey: "brand-new-key-000000"})
+	if out.APIKey != "brand-new-key-000000" {
+		t.Errorf("unmasked apiKey should replace the stored one, got %q", out.APIKey)
+	}
+}
+
+func configTestRequest(t *testing.T, ctx context.Context, resolver *auth.Resolver, method, path, userID string, body map[string]any) *http.Request {
+	t.Helper()
+
+	cookie, err := resolver.IssueSession(ctx, userID)
+	if err != nil {
+		t.Fatalf("IssueSession: %v", err)
+	}
+	var reader *bytes.Reader
+	if body != nil {
+		blob, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		reader = bytes.NewReader(blob)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	req.AddCookie(cookie)
+	return req
+}


### PR DESCRIPTION
## Problem

`mergeSkillEntry` (internal/setup/handlers.go) was defined to protect stored skill secrets from masked write-backs, but it has **no call sites**. As a result, `POST /api/config` persists masked placeholders verbatim.

Repro:

1. In the dashboard, configure a skill with a secret (e.g. `API_KEY=real-secret-123456`) and save (POST /api/config).
2. The value is stored correctly: `SELECT data FROM configs WHERE name='skills.entries'` shows the real key.
3. Reopen the skill configure dialog — the UI now shows the masked value (`real****3456`) returned by GET /api/config.
4. Save again without touching the secret (or just toggle `enabled`).
5. The stored value is now the literal masked string — **the original secret is permanently lost**, and subsequent skill runs authenticate with `****`.

This affects both the global `skills.entries` row and per-agent `skills.agentEntries` rows. Note the same protection *is* wired for provider API keys and channel bot tokens (`isMaskedSecret` in handlers_scoped.go) — skill entries were simply missed.

## Fix

Wire `mergeSkillEntry` into both write paths in `handleUpdateConfig`:

- **Global entries**: snapshot the stored `skills.entries` before the request body is unmarshalled over the merged config, then merge each request entry against the snapshot.
- **Per-agent entries**: load the agent's existing row (new `loadAgentSkillEntries` helper, now also reused by `loadAgentSkillEntriesForUser`) and merge before persisting.

Masked fields (`****` or `xxxx****yyyy`) resolve back to the stored original; unmasked fields update normally, so intentional secret changes still work.

## Tests

`internal/setup/handlers_config_test.go`:

- `TestUpdateConfigMaskedGlobalSkillEntryKeepsStoredSecret` and `TestUpdateConfigMaskedAgentSkillEntryKeepsStoredSecret`: full round-trip — save real secret → GET (assert masked, no plaintext leak) → POST the masked entry back → assert the stored secret is intact and non-secret fields updated. Both tests **fail on the unfixed code** (verified by stashing the handler change).
- `TestMergeSkillEntry`: unit coverage, including that a genuinely new (unmasked) value still replaces the stored one.

`go test ./internal/setup/` passes.

Related: #81 (per-chatter skill credentials — orthogonal, but touches the same `skills.entries` ownership model).
