### PR TITLE
fix(chat): survive client disconnects + real session attach/detach UX (live re-attach, mid-turn snapshot, server-side stop)

### DIFF
--- a/internal/agent/event_hub.go
+++ b/internal/agent/event_hub.go
@@ -62,12 +62,23 @@ func (h *EventHub) Subscribe(userID, agentID, sessionKey string) (<-chan EventEn
 // Publish fans an envelope out to every current subscriber. Slow
 // consumers (full buffer) are skipped, not blocked — a stuck client
 // can't stall the agent loop.
+//
+// The send runs UNDER the write lock, not the read lock over a snapshot.
+// That closes a send-on-closed-channel race: the old code RLocked, copied
+// the slice, unlocked, then sent — so a concurrent unsubscribe (which
+// takes the write lock and close()s the channel) could slot in between the
+// copy and the send, making Publish send on an already-closed channel and
+// panic the process. SSE churns subscriptions constantly (every refresh /
+// reconnect), so that window is not hypothetical. Because every send is
+// non-blocking (`default` arm), holding the write lock here never blocks on
+// a slow consumer; the critical section stays O(subscribers) of buffered
+// enqueues. unsubscribe's close() and this send are now mutually excluded
+// by h.mu, so a closed channel is always already absent from h.subs[key].
 func (h *EventHub) Publish(userID, agentID, sessionKey string, env EventEnvelope) {
 	key := hubKey(userID, agentID, sessionKey)
-	h.mu.RLock()
-	subs := append([]chan EventEnvelope(nil), h.subs[key]...)
-	h.mu.RUnlock()
-	for _, ch := range subs {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, ch := range h.subs[key] {
 		select {
 		case ch <- env:
 		default:

--- a/internal/agent/event_hub.go
+++ b/internal/agent/event_hub.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // EventEnvelope is a ChatEvent stamped with the persistent seq the
@@ -25,11 +26,35 @@ type EventEnvelope struct {
 type EventHub struct {
 	mu   sync.RWMutex
 	subs map[string][]chan EventEnvelope
+	// turns tracks the in-flight turn per (user, agent, session):
+	// whether one is running and the partial text of the current
+	// round accumulated from content_delta events. content_delta is
+	// deliberately never persisted (see emitEvent), so a client that
+	// attaches mid-round has no way to recover the half-generated
+	// text from session_events — this buffer is what the subscribe
+	// handler snapshots into a synthetic `content_snapshot` event on
+	// attach. Entries are dropped on `done`; turnStaleAfter guards
+	// against turns that died without one (process kill, timeout path).
+	turns map[string]*turnState
 }
+
+type turnState struct {
+	partial   string
+	lastEvent time.Time
+}
+
+// turnStaleAfter bounds how long a turn with no terminal `done` event
+// still counts as active. Slightly above the chat handler's 45-minute
+// agentTurnTimeout so a legitimately long turn is never declared dead
+// while it can still emit.
+const turnStaleAfter = 50 * time.Minute
 
 // NewEventHub returns an empty hub.
 func NewEventHub() *EventHub {
-	return &EventHub{subs: make(map[string][]chan EventEnvelope)}
+	return &EventHub{
+		subs:  make(map[string][]chan EventEnvelope),
+		turns: make(map[string]*turnState),
+	}
 }
 
 // Subscribe registers a buffered channel for one (user, agent,
@@ -78,12 +103,55 @@ func (h *EventHub) Publish(userID, agentID, sessionKey string, env EventEnvelope
 	key := hubKey(userID, agentID, sessionKey)
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	h.trackTurnLocked(key, env.Event)
 	for _, ch := range h.subs[key] {
 		select {
 		case ch <- env:
 		default:
 		}
 	}
+}
+
+// trackTurnLocked updates the in-flight turn state for one published
+// event. Caller must hold h.mu.
+func (h *EventHub) trackTurnLocked(key string, evt ChatEvent) {
+	if evt.Type == "done" {
+		delete(h.turns, key)
+		return
+	}
+	st := h.turns[key]
+	if st == nil {
+		st = &turnState{}
+		h.turns[key] = st
+	}
+	st.lastEvent = time.Now()
+	switch evt.Type {
+	case "content_delta":
+		if d, _ := evt.Data["delta"].(string); d != "" {
+			st.partial += d
+		}
+	case "content":
+		// Round sealed — the full text is persisted now, so the
+		// partial buffer would only duplicate it on the next attach.
+		st.partial = ""
+	}
+}
+
+// TurnSnapshot reports whether a turn is currently in flight for the
+// (user, agent, session) tuple and the partial text of its current
+// round (accumulated content_delta chunks not yet sealed by a
+// `content` event). Used by the subscribe handler to give a client
+// that attaches mid-turn the half-generated text plus a "something is
+// running" signal, neither of which exists in session_events.
+func (h *EventHub) TurnSnapshot(userID, agentID, sessionKey string) (partial string, active bool) {
+	key := hubKey(userID, agentID, sessionKey)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	st := h.turns[key]
+	if st == nil || time.Since(st.lastEvent) > turnStaleAfter {
+		return "", false
+	}
+	return st.partial, true
 }
 
 func hubKey(userID, agentID, sessionKey string) string {

--- a/internal/agent/event_hub_test.go
+++ b/internal/agent/event_hub_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestEventHubPublishUnsubscribeRace hammers Publish concurrently with
+// Subscribe/unsubscribe churn on the same key. Before Publish took the
+// write lock and sent under it, a publisher could copy the subscriber
+// slice, unlock, and then send on a channel that a concurrent unsubscribe
+// had already close()d — a "send on closed channel" panic that takes down
+// the whole process. SSE reconnect churn makes that window real. This test
+// would panic (and flag under -race) against the old snapshot-then-send
+// Publish; it must stay clean.
+func TestEventHubPublishUnsubscribeRace(t *testing.T) {
+	hub := NewEventHub()
+	const (
+		publishers = 8
+		churners   = 8
+		iterations = 500
+	)
+	env := EventEnvelope{Seq: 1, Event: ChatEvent{Type: "content"}}
+
+	var wg sync.WaitGroup
+
+	// Publishers: fan out to the shared key as fast as they can.
+	for p := 0; p < publishers; p++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				hub.Publish("u", "a", "s", env)
+			}
+		}()
+	}
+
+	// Churners: subscribe then immediately unsubscribe, closing channels
+	// under the write lock while publishers race to send.
+	for c := 0; c < churners; c++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				ch, cleanup := hub.Subscribe("u", "a", "s")
+				// Drain opportunistically so buffered sends don't wedge,
+				// then tear the subscription down.
+				select {
+				case <-ch:
+				default:
+				}
+				cleanup()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// After all churn, the key must be fully cleaned up (no leaked subs).
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	if got := len(hub.subs["u/a/s"]); got != 0 {
+		t.Fatalf("expected no lingering subscribers, got %d", got)
+	}
+}

--- a/internal/agent/event_hub_test.go
+++ b/internal/agent/event_hub_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"sync"
 	"testing"
+	"time"
 )
 
 // TestEventHubPublishUnsubscribeRace hammers Publish concurrently with
@@ -61,5 +62,65 @@ func TestEventHubPublishUnsubscribeRace(t *testing.T) {
 	defer hub.mu.Unlock()
 	if got := len(hub.subs["u/a/s"]); got != 0 {
 		t.Fatalf("expected no lingering subscribers, got %d", got)
+	}
+}
+
+// TestTurnSnapshotLifecycle covers the in-flight turn tracking that
+// backs the subscribe handler's content_snapshot event: deltas
+// accumulate, a content seal clears the partial, done ends the turn.
+func TestTurnSnapshotLifecycle(t *testing.T) {
+	hub := NewEventHub()
+
+	// No events yet → no active turn.
+	if _, active := hub.TurnSnapshot("u", "a", "s"); active {
+		t.Fatal("expected inactive turn before any publish")
+	}
+
+	pub := func(evt ChatEvent) { hub.Publish("u", "a", "s", EventEnvelope{Seq: -1, Event: evt}) }
+
+	pub(ChatEvent{Type: "content_delta", Data: map[string]any{"delta": "Hel"}})
+	pub(ChatEvent{Type: "content_delta", Data: map[string]any{"delta": "lo"}})
+	partial, active := hub.TurnSnapshot("u", "a", "s")
+	if !active || partial != "Hello" {
+		t.Fatalf("expected active turn with partial %q, got active=%v partial=%q", "Hello", active, partial)
+	}
+
+	// Round seal clears the partial but the turn stays active.
+	pub(ChatEvent{Type: "content", Data: map[string]any{"content": "Hello"}})
+	partial, active = hub.TurnSnapshot("u", "a", "s")
+	if !active || partial != "" {
+		t.Fatalf("expected active turn with empty partial after seal, got active=%v partial=%q", active, partial)
+	}
+
+	// Tool activity keeps the turn active with no partial change.
+	pub(ChatEvent{Type: "tool_call", Data: map[string]any{"name": "exec"}})
+	if _, active = hub.TurnSnapshot("u", "a", "s"); !active {
+		t.Fatal("expected turn active during tool round")
+	}
+
+	// done terminates the turn and drops the state entry.
+	pub(ChatEvent{Type: "done"})
+	if _, active = hub.TurnSnapshot("u", "a", "s"); active {
+		t.Fatal("expected inactive turn after done")
+	}
+	hub.mu.RLock()
+	_, leaked := hub.turns["u/a/s"]
+	hub.mu.RUnlock()
+	if leaked {
+		t.Fatal("expected turn state entry removed after done")
+	}
+}
+
+// TestTurnSnapshotStaleness: a turn whose last event is older than
+// turnStaleAfter no longer reports active (crash / timeout without a
+// terminal done).
+func TestTurnSnapshotStaleness(t *testing.T) {
+	hub := NewEventHub()
+	hub.Publish("u", "a", "s", EventEnvelope{Seq: -1, Event: ChatEvent{Type: "content_delta", Data: map[string]any{"delta": "x"}}})
+	hub.mu.Lock()
+	hub.turns["u/a/s"].lastEvent = time.Now().Add(-turnStaleAfter - time.Minute)
+	hub.mu.Unlock()
+	if _, active := hub.TurnSnapshot("u", "a", "s"); active {
+		t.Fatal("expected stale turn to report inactive")
 	}
 }

--- a/internal/setup/handlers.go
+++ b/internal/setup/handlers.go
@@ -1173,6 +1173,10 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	// cancels — at a true turn terminal (`done` / agentDone-without-
 	// continuation / the timeout).
 	defer cancel()
+	// Make this turn stoppable via POST /api/chat/stop. The handle is
+	// per-turn so a stop→resend race can't evict the new turn's entry.
+	stopHandle := s.registerTurnCancel(uid, agentID, req.SessionID, cancel)
+	defer s.unregisterTurnCancel(uid, agentID, req.SessionID, stopHandle)
 	agentCtx = agent.ContextWithStream(agentCtx, nil, s.dataStore, hub, uid, agentID, req.SessionID)
 
 	agentDone := make(chan struct{})
@@ -1395,6 +1399,14 @@ func (s *Server) handleChatSubscribe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hub := s.chatEventHub()
+	// Snapshot the in-flight turn BEFORE subscribing: any content_delta
+	// published after Subscribe lands in the live channel, so taking
+	// the snapshot first guarantees no delta is both inside the
+	// snapshot text AND replayed live (duplicated text). The reverse
+	// gap — a delta emitted between snapshot and Subscribe is simply
+	// missing — self-heals when the round's `content` seal replaces
+	// the partial text with the full round text client-side.
+	turnPartial, turnActive := hub.TurnSnapshot(uid, agentID, sessionID)
 	// Subscribe BEFORE replay so any event that lands while we're
 	// scanning the DB ends up either in the replayed range OR in the
 	// live channel — never both, never lost.
@@ -1419,6 +1431,20 @@ func (s *Server) handleChatSubscribe(w http.ResponseWriter, r *http.Request) {
 				sinceSeq = rec.Seq
 			}
 		}
+	}
+
+	// A turn is in flight for this session: hand the client the
+	// half-generated text of the current round (content_delta is never
+	// persisted, so replay above cannot contain it) plus a "running"
+	// signal so the UI can attach visibly — typing bubble, Stop button
+	// — instead of sitting silent until the turn's `done`. Sent even
+	// with empty partial text: the running flag alone is information
+	// the client has no other way to get.
+	if turnActive {
+		forwardSyntheticEvent(w, flusher, agent.ChatEvent{
+			Type: "content_snapshot",
+			Data: map[string]any{"content": turnPartial, "running": true},
+		})
 	}
 
 	// Legacy webChan path: cron-fired bus.Outbound messages. Kept until

--- a/internal/setup/handlers.go
+++ b/internal/setup/handlers.go
@@ -1153,13 +1153,25 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	// Detach the agent's ctx from the request: when the browser tab
 	// disconnects (refresh, close, network blip) we want the agent to
 	// keep running so its already-paid-for LLM call finishes and the
-	// reply lands in session_events. The 15-minute cap is the only thing
-	// that can kill it.
+	// reply lands in session_events. The agentTurnTimeout cap is the only
+	// thing that can kill it.
+	//
+	// WithoutCancel severs the request→agent cancel propagation, but that
+	// alone is not enough: this handler also owns `cancel`, and the
+	// clientGone branch below used to `return` on disconnect, which fired
+	// `defer cancel()` and killed the agent anyway. The detach is only
+	// real because clientGone no longer returns — it parks the handler
+	// until the turn ends naturally. Do NOT reintroduce an early return on
+	// client disconnect; that is exactly the "工具调用莫名其妙 stopped" bug.
 	agentCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), agentTurnTimeout)
-	// cancel lives on the handler, not the agent goroutine: when a slash
-	// queues a continuation we keep the SSE open past HandleMessage's
-	// return, and inner-scope cancel would tear down agentCtx before the
-	// continuation's events can reach this handler's safety-net check.
+	// cancel stays on the handler defer (not a per-goroutine scope) on
+	// purpose: a slash that queues a continuation keeps the SSE open past
+	// HandleMessage's return, and the loop reuses agentCtx.Done() as the
+	// upper bound of that wait. Cancelling the moment HandleMessage returns
+	// would tear agentCtx down before the continuation's events reach this
+	// handler's safety-net check. The handler only returns — and thus only
+	// cancels — at a true turn terminal (`done` / agentDone-without-
+	// continuation / the timeout).
 	defer cancel()
 	agentCtx = agent.ContextWithStream(agentCtx, nil, s.dataStore, hub, uid, agentID, req.SessionID)
 
@@ -1180,6 +1192,11 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 
 	clientGone := r.Context().Done()
 	forwardedAny := false
+	// clientDropped latches when the receiving SSE goes away (tab refresh,
+	// conversation switch, network blip). Once set, we stop touching the
+	// dead response writer but keep this handler parked — see the
+	// clientGone case for why returning here would kill the agent.
+	clientDropped := false
 	// turnPending flips on when the slash handler reports it queued a
 	// continuation via bus.Inbound (`turn_pending` event). The POST
 	// goroutine's HandleMessage has already returned, but the real
@@ -1192,11 +1209,20 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-clientGone:
-			// Client dropped; the agent goroutine keeps running on
-			// its detached ctx and persists every event it emits.
-			// User reloading the chat page will pick up the rest via
-			// /api/chat/subscribe?since=N.
-			return
+			// The client dropped the receiving stream. This must NOT
+			// cancel the agent: returning here would fire `defer cancel()`
+			// and tear down agentCtx mid-turn, killing in-flight tool
+			// calls / sub-agents and losing the rest of the reply. Instead
+			// latch clientDropped and keep looping until the turn ends
+			// naturally (`done` / agentDone / the agentCtx timeout). The
+			// agent's events still persist to session_events via the stream
+			// ctx, so a reloaded page picks up the full reply through
+			// /api/chat/subscribe?since=N. Nil the channel so this case
+			// stops selecting (r.Context().Done() stays closed forever) and
+			// stop the keepalive — nothing is listening on the wire.
+			clientDropped = true
+			clientGone = nil
+			keepalive.Stop()
 		case <-agentDone:
 			// Race: HandleMessage publishes `turn_pending` to the hub
 			// AND `defer close(agentDone)` fires from the same goroutine.
@@ -1216,11 +1242,15 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 						continue
 					}
 					if env.Event.Type == "done" {
-						forwardEvent(w, flusher, env)
+						if !clientDropped {
+							forwardEvent(w, flusher, env)
+						}
 						forwardedAny = true
 						return
 					}
-					forwardEvent(w, flusher, env)
+					if !clientDropped {
+						forwardEvent(w, flusher, env)
+					}
 					forwardedAny = true
 				default:
 					break drain
@@ -1230,11 +1260,11 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 				// HandleMessage returned silent after queueing a
 				// continuation. Don't close; wait for the continuation's
 				// `done` event over the hub instead. agentCtx.Done()
-				// (15-min timeout) is the upper bound if it never lands.
+				// (agentTurnTimeout) is the upper bound if it never lands.
 				agentDone = nil
 				continue
 			}
-			if !forwardedAny {
+			if !forwardedAny && !clientDropped {
 				forwardSyntheticEvent(w, flusher, agent.ChatEvent{
 					Type: "error",
 					Data: map[string]any{"message": "agent finished without emitting a response"},
@@ -1247,6 +1277,11 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 			// ever arrives.
 			return
 		case <-keepalive.C:
+			// keepalive.Stop() was called once the client dropped, but a
+			// tick may already be buffered — skip the write either way.
+			if clientDropped {
+				continue
+			}
 			fmt.Fprintf(w, ": ping\n\n")
 			flusher.Flush()
 		case env, ok := <-sub:
@@ -1257,7 +1292,9 @@ func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request) {
 				turnPending = true
 				continue
 			}
-			forwardEvent(w, flusher, env)
+			if !clientDropped {
+				forwardEvent(w, flusher, env)
+			}
 			forwardedAny = true
 			if env.Event.Type == "done" {
 				return

--- a/internal/setup/handlers_stop.go
+++ b/internal/setup/handlers_stop.go
@@ -1,0 +1,103 @@
+package setup
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// turnCancelHandle wraps one in-flight turn's agentCtx cancel. The
+// registry stores a pointer so unregister can verify it still owns the
+// slot: if a second turn for the same session registered meanwhile
+// (send → stop → immediate resend), the first turn's deferred
+// unregister must not evict the newcomer.
+type turnCancelHandle struct {
+	cancel context.CancelFunc
+}
+
+// registerTurnCancel makes an in-flight web turn stoppable via
+// POST /api/chat/stop. Returns the handle to pass to
+// unregisterTurnCancel (defer it next to the ctx cancel).
+func (s *Server) registerTurnCancel(uid, agentID, sessionID string, cancel context.CancelFunc) *turnCancelHandle {
+	h := &turnCancelHandle{cancel: cancel}
+	s.turnCancelsMu.Lock()
+	defer s.turnCancelsMu.Unlock()
+	if s.turnCancels == nil {
+		s.turnCancels = make(map[string]*turnCancelHandle)
+	}
+	s.turnCancels[uid+"/"+agentID+"/"+sessionID] = h
+	return h
+}
+
+func (s *Server) unregisterTurnCancel(uid, agentID, sessionID string, h *turnCancelHandle) {
+	key := uid + "/" + agentID + "/" + sessionID
+	s.turnCancelsMu.Lock()
+	defer s.turnCancelsMu.Unlock()
+	if s.turnCancels[key] == h {
+		delete(s.turnCancels, key)
+	}
+}
+
+func (s *Server) takeTurnCancel(uid, agentID, sessionID string) context.CancelFunc {
+	key := uid + "/" + agentID + "/" + sessionID
+	s.turnCancelsMu.Lock()
+	defer s.turnCancelsMu.Unlock()
+	h := s.turnCancels[key]
+	if h == nil {
+		return nil
+	}
+	delete(s.turnCancels, key)
+	return h.cancel
+}
+
+// handleChatStop cancels the in-flight turn for (agent, session) — the
+// web UI's Stop button. Cancelling agentCtx makes the agent loop's
+// provider/tool calls fail with context.Canceled, after which the loop
+// emits its own terminal `error` + `done` events; subscribers see the
+// turn close through the normal event flow. A durable `status` event
+// is persisted first so the stop itself is visible in the session log
+// (the auto-emitted "context canceled" error is filtered client-side).
+//
+// 200 {"stopped":true} when a turn was cancelled; 409
+// {"stopped":false} when none was registered — mirrors steer's
+// contract so clients can fall back (e.g. to aborting their fetch).
+// Only turns started via POST /api/chat/stream register; IM- and
+// cron-initiated turns are not stoppable here.
+func (s *Server) handleChatStop(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		AgentID   string `json:"agentId"`
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	ag := s.resolveAgent(r, req.AgentID)
+	if ag == nil {
+		jsonResponse(w, http.StatusNotFound, map[string]any{"error": "agent not found"})
+		return
+	}
+	uid := s.effectiveUserID(r)
+	if uid == "" {
+		jsonResponse(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+		return
+	}
+	agentID := ag.Name()
+	cancel := s.takeTurnCancel(uid, agentID, req.SessionID)
+	if cancel == nil {
+		jsonResponse(w, http.StatusConflict, map[string]any{"stopped": false})
+		return
+	}
+	// Persist the stop before cancelling so the status row lands ahead
+	// of the cancellation-error/done events in session_events order.
+	if s.dataStore != nil {
+		blob, _ := json.Marshal(map[string]any{"state": "stopped", "at": time.Now().UTC().Format(time.RFC3339)})
+		if _, err := s.dataStore.AppendSessionEvent(r.Context(), uid, agentID, req.SessionID, "status", blob); err != nil {
+			slog.Warn("persist stop status event failed", "agent", agentID, "session", req.SessionID, "error", err)
+		}
+	}
+	cancel()
+	jsonResponse(w, http.StatusOK, map[string]any{"stopped": true})
+}

--- a/internal/setup/handlers_team_chat.go
+++ b/internal/setup/handlers_team_chat.go
@@ -200,11 +200,22 @@ func (s *Server) runTeamAgentTurn(w http.ResponseWriter, flusher http.Flusher, r
 	keepalive := time.NewTicker(30 * time.Second)
 	defer keepalive.Stop()
 	clientGone := r.Context().Done()
+	// clientDropped mirrors handleChatStream: when the receiving SSE goes
+	// away (refresh / switch / blip) we must NOT return here — returning
+	// fires `defer cancel()` and kills this member's in-flight agentCtx
+	// (and its sub-agents), the exact stopped bug. Latch the flag, stop
+	// writing to the dead response, and keep looping so the running turn
+	// finishes and persists to session_events. Once it reaches a natural
+	// terminal we return false so the caller stops the team loop instead
+	// of spinning up the NEXT member's turn for a client that's gone.
+	clientDropped := false
 	turnPending := false
 	for {
 		select {
 		case <-clientGone:
-			return false
+			clientDropped = true
+			clientGone = nil
+			keepalive.Stop()
 		case <-agentDone:
 		drain:
 			for {
@@ -218,9 +229,11 @@ func (s *Server) runTeamAgentTurn(w http.ResponseWriter, flusher http.Flusher, r
 						continue
 					}
 					if env.Event.Type == "done" {
-						return true
+						return !clientDropped
 					}
-					forwardTeamEvent(w, flusher, member.AgentID, env)
+					if !clientDropped {
+						forwardTeamEvent(w, flusher, member.AgentID, env)
+					}
 				default:
 					break drain
 				}
@@ -229,10 +242,13 @@ func (s *Server) runTeamAgentTurn(w http.ResponseWriter, flusher http.Flusher, r
 				agentDone = nil
 				continue
 			}
-			return true
+			return !clientDropped
 		case <-agentCtx.Done():
 			return false
 		case <-keepalive.C:
+			if clientDropped {
+				continue
+			}
 			fmt.Fprintf(w, ": ping\n\n")
 			flusher.Flush()
 		case env, ok := <-sub:
@@ -244,9 +260,11 @@ func (s *Server) runTeamAgentTurn(w http.ResponseWriter, flusher http.Flusher, r
 				continue
 			}
 			if env.Event.Type == "done" {
-				return true
+				return !clientDropped
 			}
-			forwardTeamEvent(w, flusher, member.AgentID, env)
+			if !clientDropped {
+				forwardTeamEvent(w, flusher, member.AgentID, env)
+			}
 		}
 	}
 }

--- a/internal/setup/server.go
+++ b/internal/setup/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fastclaw-ai/fastclaw/internal/agent"
@@ -86,8 +87,14 @@ type Server struct {
 	// clients across browser tabs. Lazy-init on first use so older
 	// callers that didn't wire it explicitly still work.
 	chatEvents *agent.EventHub
-	usage      usage.Meter
-	startedAt  time.Time
+	// turnCancels maps an in-flight web-chat turn (hub key) to a handle
+	// holding its agentCtx cancel, so POST /api/chat/stop can kill it.
+	// Registered by handleChatStream; only web stream turns are
+	// stoppable — IM / cron turns never register and stop returns 409.
+	turnCancelsMu sync.Mutex
+	turnCancels   map[string]*turnCancelHandle
+	usage         usage.Meter
+	startedAt     time.Time
 	// runtimeMgr powers the coding-agent project runtime (live dev server
 	// + preview). Optional: nil when the deployment hasn't wired a
 	// sandbox-backed runtime, in which case the /runtime endpoints return
@@ -263,6 +270,7 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/chat/stream", auth(s.handleChatStream))
 	mux.HandleFunc("POST /api/chat/team/stream", auth(s.handleTeamChatStream))
 	mux.HandleFunc("POST /api/chat/steer", auth(s.handleChatSteer))
+	mux.HandleFunc("POST /api/chat/stop", auth(s.handleChatStop))
 	mux.HandleFunc("GET /api/chats", auth(s.handleChats))
 	mux.HandleFunc("GET /api/chat/history", auth(s.handleChatHistory))
 	mux.HandleFunc("GET /api/chat/todo", auth(s.handleChatTodo))

--- a/web/src/components/chat-screen.tsx
+++ b/web/src/components/chat-screen.tsx
@@ -6,7 +6,7 @@ import { useAgentIdFromURL } from "@/hooks/use-agent-id";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { fileUrl, getAgent, getAgentKnowledgeFile, getChangedFiles, getChatHistoryWithCursor, getChatSessions, getChatTodo, getMe, getScopePreview, getScopePreviewLogs, getSessionHistory, listAgentFiles, listProjects, renameChatSession, restoreSessionHistory, revealAgentWorkspace, sendChatStream, steerChat, uploadAgentFiles, getSkills, type ChatHistoryMessage, type ChatStreamEvent, type KnowledgeSource, type ScopePreview, type SkillInfo, type TodoItem, type ToolResultMetadata, type WorkspaceFile, type WorkspaceHistoryEntry } from "@/lib/api";
+import { fileUrl, getAgent, getAgentKnowledgeFile, getChangedFiles, getChatHistoryWithCursor, getChatSessions, getChatTodo, getMe, getScopePreview, getScopePreviewLogs, getSessionHistory, listAgentFiles, listProjects, renameChatSession, restoreSessionHistory, revealAgentWorkspace, sendChatStream, steerChat, stopChat, uploadAgentFiles, getSkills, type ChatHistoryMessage, type ChatStreamEvent, type KnowledgeSource, type ScopePreview, type SkillInfo, type TodoItem, type ToolResultMetadata, type WorkspaceFile, type WorkspaceHistoryEntry } from "@/lib/api";
 import { Bot, Send, Copy, Check, Pencil, Wrench, ChevronDown, ChevronRight, Download, X, File, FileText, Folder, FolderSearch, Image as ImageIcon, FileCode, Film, Music, Puzzle, SlidersHorizontal, ShieldCheck, Paperclip, Square, FolderOpen, RefreshCw, Eye, Code2, RotateCcw, ListChecks, Terminal, ExternalLink, MoreHorizontal, PanelLeftClose, PanelLeftOpen, BookOpen } from "lucide-react";
 import Link from "next/link";
 import { ChatMarkdown } from "@/components/chat-markdown";
@@ -512,6 +512,11 @@ export function ChatScreen() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
+  // A turn is running server-side that THIS tab didn't start (or lost
+  // its POST stream to a refresh): set from subscribe-path signals
+  // (content_snapshot / live deltas / tool events), cleared on `done`.
+  // Drives the Stop button for attached-but-not-sending viewers.
+  const [remoteTurnActive, setRemoteTurnActive] = useState(false);
   // todo.md state for the current session — agent maintains the file,
   // we re-fetch on every write_file/edit_file event that touches
   // todo.md plus once at mount. Empty `items` hides the panel.
@@ -806,6 +811,18 @@ export function ChatScreen() {
     const since = subscribeSinceRef.current;
     const url = `/api/chat/subscribe?agentId=${encodeURIComponent(selectedAgent)}&sessionId=${encodeURIComponent(sessionId)}&since=${since}`;
     const es = new EventSource(url, { withCredentials: true });
+    // Per-connection render state for turns this tab did NOT start (or
+    // whose POST stream it lost to a refresh): mirrors the POST
+    // callback's closure state so an attached viewer sees deltas and
+    // tool activity live instead of a silent screen until `done`.
+    // subStreamId is the delta-accretion bubble of the current round;
+    // subGroupId/subCalls the current tool-group; subSawLive marks that
+    // this connection rendered in-flight turn content and must swap it
+    // for canonical history on `done`.
+    let subStreamId: string | null = null;
+    let subGroupId = "";
+    let subCalls: { id: string; name: string; arguments: string; result?: string; metadata?: ToolResultMetadata }[] = [];
+    let subSawLive = false;
     es.onmessage = (ev) => {
       let data: {
         seq?: number;
@@ -813,6 +830,12 @@ export function ChatScreen() {
         text?: string;
         data?: {
           content?: string;
+          delta?: string;
+          id?: string;
+          name?: string;
+          arguments?: string;
+          result?: string;
+          running?: boolean;
           message?: string;
           metadata?: ToolResultMetadata;
           // subagent_progress fields
@@ -838,21 +861,157 @@ export function ChatScreen() {
         // replies are event-only, so that reload clears the visible
         // answer and makes the send look like it did nothing.
         if (inFlightSendSessionRef.current === sessionId) return;
-        // CAREFUL: do NOT bump maxSeqRef before the switch. This handler
-        // intentionally drops tool_call / tool_result during catch-up
-        // (the post-`done` history reload renders them properly) — but
-        // a pre-switch bump would mark those seqs as "rendered" and the
-        // parallel POST sendChatStream callback would dedup-skip the
-        // very same events when it tries to actually render them. Bump
-        // only inside cases that really took ownership of this seq.
+        // CAREFUL: do NOT bump maxSeqRef before the switch — bump only
+        // inside cases that really took ownership of this seq (claim()).
+        // A pre-switch bump would mark seqs as "rendered" and make the
+        // parallel POST sendChatStream callback dedup-skip events it
+        // still needs to render itself.
         const claim = () => {
           if (seq >= 0) maxSeqRef.current = seq;
         };
         switch (data.type) {
+          case "content_snapshot": {
+            // Synthetic attach event from /api/chat/subscribe: a turn
+            // is in flight. data.content carries the half-generated
+            // text of the current round (deltas are never persisted so
+            // replay can't include it); live deltas append onto it from
+            // here. Empty content still means "running" — surface the
+            // Stop button either way.
+            subSawLive = true;
+            setRemoteTurnActive(true);
+            const text = data.data?.content || "";
+            if (text) {
+              const id = `sub-a-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+              subStreamId = id;
+              setMessages((prev) => [
+                ...prev,
+                { id, role: "agent", content: text, timestamp: Date.now() },
+              ]);
+            }
+            break;
+          }
+          case "content_delta": {
+            // Live token chunk of an in-flight turn (always seq=-1 —
+            // deltas are never persisted). Renders only when no POST
+            // stream owns this session (the guard above returned
+            // otherwise), i.e. exactly the re-attached / other-tab case.
+            const delta = data.data?.delta || "";
+            if (!delta) break;
+            subSawLive = true;
+            setRemoteTurnActive(true);
+            if (subCalls.length > 0 && !subStreamId) {
+              // Text after tool calls = new round; the finished group
+              // stays as its own message.
+              subGroupId = "";
+              subCalls = [];
+            }
+            if (!subStreamId) {
+              const id = `sub-a-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+              subStreamId = id;
+              setMessages((prev) => [
+                ...prev,
+                { id, role: "agent", content: delta, timestamp: Date.now() },
+              ]);
+            } else {
+              const id = subStreamId;
+              setMessages((prev) => {
+                const idx = prev.findIndex((m) => m.id === id);
+                if (idx < 0) return prev;
+                const updated = [...prev];
+                updated[idx] = { ...updated[idx], content: (updated[idx].content || "") + delta };
+                return updated;
+              });
+            }
+            break;
+          }
+          case "tool_call": {
+            // Render tool activity live for attached viewers instead of
+            // dropping it until the post-`done` history reload — the
+            // old behavior made a re-attached tab sit silent through
+            // tool-heavy turns, then dump everything at once.
+            claim();
+            subSawLive = true;
+            setRemoteTurnActive(true);
+            // Next round's deltas open a fresh bubble.
+            subStreamId = null;
+            if (subCalls.length > 0 && subCalls.every((c) => c.result !== undefined)) {
+              subGroupId = "";
+              subCalls = [];
+            }
+            if (!subGroupId) {
+              subGroupId = `sub-tg-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+            }
+            subCalls.push({
+              id: data.data?.id || "",
+              name: data.data?.name || "",
+              arguments: data.data?.arguments || "{}",
+            });
+            {
+              const groupId = subGroupId;
+              const calls = [...subCalls];
+              setMessages((prev) => {
+                const idx = prev.findIndex((m) => m.id === groupId);
+                if (idx >= 0) {
+                  const updated = [...prev];
+                  updated[idx] = { ...updated[idx], toolCalls: calls };
+                  return updated;
+                }
+                return [
+                  ...prev,
+                  { id: groupId, role: "tool-group" as const, content: "", timestamp: Date.now(), toolCalls: calls },
+                ];
+              });
+            }
+            break;
+          }
+          case "tool_result": {
+            claim();
+            subSawLive = true;
+            const tc = subCalls.find((c) => c.id === (data.data?.id || ""));
+            if (tc) {
+              tc.result = data.data?.result || "";
+              if (data.data?.metadata) tc.metadata = data.data.metadata;
+            }
+            if (!subGroupId) break;
+            {
+              const groupId = subGroupId;
+              const calls = [...subCalls];
+              setMessages((prev) => {
+                const idx = prev.findIndex((m) => m.id === groupId);
+                if (idx < 0) return prev;
+                const updated = [...prev];
+                updated[idx] = { ...updated[idx], toolCalls: calls };
+                return updated;
+              });
+            }
+            break;
+          }
           case "content": {
             const content = data.data?.content || "";
             const meta = data.data?.metadata;
             if (!content && !meta) break;
+            // Seal the delta-accretion bubble: the round's `content`
+            // carries the full final text, and the bubble may hold a
+            // truncated prefix (snapshot taken mid-round misses deltas
+            // emitted before attach). REPLACE, don't append — appending
+            // would duplicate every delta already rendered.
+            if (subStreamId) {
+              const id = subStreamId;
+              subStreamId = null;
+              claim();
+              setMessages((prev) => {
+                const idx = prev.findIndex((m) => m.id === id);
+                if (idx < 0) return prev;
+                const updated = [...prev];
+                updated[idx] = {
+                  ...updated[idx],
+                  content: content || updated[idx].content,
+                  metadata: meta ? { ...updated[idx].metadata, ...meta } : updated[idx].metadata,
+                };
+                return updated;
+              });
+              break;
+            }
             // The active POST sendChatStream is rendering this turn
             // via content_delta into streamingMsgIdRef. Both
             // subscriptions sit on the same hub, so the `content`
@@ -935,23 +1094,27 @@ export function ChatScreen() {
           }
           case "done": {
             claim();
+            setRemoteTurnActive(false);
             // Defensive clear — content events should already have
             // sealed the streaming bubble, but a turn that errors out
             // before the trailing `content` event lands would leave
             // the ref dangling and cause the next turn's first
             // content_delta to write into the stale id.
             streamingMsgIdRef.current = null;
-            // Only reload history when we actually built a transient
-            // bubble from subscribe-replayed content events (i.e. the
-            // user reloaded mid-turn and we need to swap the
-            // placeholder for the canonical message saved in
-            // session_messages). When the active POST stream rendered
-            // the turn directly, transient bubble is null — a reload
-            // here would clobber any rendered error bubbles too,
-            // because LLM-error turns never write an assistant
-            // message to session_messages.
-            if (transientBubbleIdRef.current) {
+            // Reload history when this connection rendered any live /
+            // transient content for the turn (delta bubbles, tool
+            // groups, replayed-content placeholder): the reload swaps
+            // them for the canonical messages in session_messages.
+            // When the active POST stream rendered the turn directly,
+            // both flags are unset — a reload here would clobber any
+            // rendered error bubbles too, because LLM-error turns
+            // never write an assistant message to session_messages.
+            if (transientBubbleIdRef.current || subSawLive) {
               transientBubbleIdRef.current = null;
+              subSawLive = false;
+              subStreamId = null;
+              subGroupId = "";
+              subCalls = [];
               getChatHistoryWithCursor(selectedAgent, sessionId)
                 .then(({ history, latestEventSeq }) => {
                   if (latestEventSeq > maxSeqRef.current) maxSeqRef.current = latestEventSeq;
@@ -971,9 +1134,6 @@ export function ChatScreen() {
             }
             break;
           }
-          // tool_call / tool_result during catch-up are skipped here —
-          // the next history reload (on `done`) will render them
-          // properly via buildChatMessages.
         }
         return;
       }
@@ -996,6 +1156,7 @@ export function ChatScreen() {
       // keep flapping but is harmless.
     };
     return () => {
+      setRemoteTurnActive(false);
       es.close();
     };
   }, [selectedAgent, sessionId, loadedSessionId]);
@@ -1793,9 +1954,26 @@ export function ChatScreen() {
     }
   }, [input, attachments, selectedAgent, sessionId, sending, isReadOnlyView, isReadOnlySafeSlashCommand, loadSessions, pathname, router, urlProjectId]);
 
+  // Stop = cancel the turn server-side (POST /api/chat/stop), THEN
+  // abort the local fetch. The local abort alone no longer stops
+  // anything — the stream handler deliberately keeps the agent running
+  // when the client drops (that's the detach fix) — so without the
+  // server call this button would only stop the *display*. The abort
+  // still runs afterwards (and as the fallback when no stoppable turn
+  // was registered, e.g. IM/cron-started turns) so the composer resets
+  // immediately instead of waiting for the terminal events.
   const handleStop = useCallback(() => {
+    const agentId = selectedAgent;
+    const sid = sessionId;
+    setRemoteTurnActive(false);
+    if (agentId && sid) {
+      stopChat(agentId, sid)
+        .catch(() => {})
+        .finally(() => abortRef.current?.abort());
+      return;
+    }
     abortRef.current?.abort();
-  }, []);
+  }, [selectedAgent, sessionId]);
 
   // handleSteer fires while a turn is streaming: it buffers the message
   // into the running turn (the agent folds it in between tool rounds and
@@ -2539,7 +2717,7 @@ export function ChatScreen() {
                         </div>
                       )}
                     </div>
-                    {sending ? (
+                    {sending || remoteTurnActive ? (
                       <Button
                         onClick={handleStop}
                         size="icon"
@@ -2604,7 +2782,7 @@ export function ChatScreen() {
                     className="flex-1 resize-none bg-transparent text-[15px] leading-8 placeholder:text-muted-foreground/50 outline-none disabled:opacity-50"
                     style={{ maxHeight: 200, minHeight: 32 }}
                   />
-                  {sending ? (
+                  {sending || remoteTurnActive ? (
                     <Button
                       onClick={handleStop}
                       size="icon"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1087,6 +1087,22 @@ export async function steerChat(
   return data?.buffered === true;
 }
 
+// stopChat cancels the in-flight turn for (agent, session) server-side
+// — the real Stop. Returns true when a turn was cancelled; false (409)
+// when no stoppable turn was registered, so the caller can fall back
+// to aborting its local fetch (pre-stop-endpoint behavior).
+export async function stopChat(agentId: string, sessionId: string): Promise<boolean> {
+  const res = await apiFetch("/api/chat/stop", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ agentId, sessionId }),
+  });
+  if (res.status === 409) return false;
+  if (!res.ok) throw new Error(`stop failed: ${res.status}`);
+  const data = await res.json().catch(() => ({}));
+  return data?.stopped === true;
+}
+
 export interface ToolResultMetadata {
   sandbox?: boolean;
   knowledgeSources?: KnowledgeSource[];
@@ -1114,9 +1130,15 @@ export interface ChatStreamEvent {
   type:
     | "content"
     | "content_delta"
+    // content_snapshot is synthetic, emitted once by /api/chat/subscribe
+    // on attach when a turn is in flight: data.content carries the
+    // half-generated text of the current round (deltas are never
+    // persisted, so replay can't provide it) and data.running is true.
+    | "content_snapshot"
     | "tool_call"
     | "tool_result"
     | "steer"
+    | "status"
     | "error"
     | "done"
     | "subagent_progress";
@@ -1140,6 +1162,8 @@ export interface ChatStreamEvent {
     arguments?: string;
     result?: string;
     message?: string;
+    // running accompanies content_snapshot: a turn is in flight.
+    running?: boolean;
     metadata?: ToolResultMetadata;
     // subagent_progress payload — only populated when type === "subagent_progress".
     iteration?: number;


### PR DESCRIPTION
## Problem

The web chat's detach design (persist events + `/api/chat/subscribe` replay) doesn't survive contact with real usage. Three separate defects compound into one bad experience:

1. **A page refresh mid-turn kills the whole turn.** `handleChatStream` detaches the agent ctx with `context.WithoutCancel`, but the `clientGone` branch `return`s on disconnect, which fires the handler's own `defer cancel()` — tearing down `agentCtx` and killing every in-flight tool call and sub-agent. The detach was only ever on paper. (Also present in the team-chat variant.)

2. **`EventHub.Publish` has a send-on-closed-channel race.** It RLocks, copies the subscriber slice, unlocks, then sends — a concurrent unsubscribe can `close()` a channel between the copy and the send and panic the process. SSE reconnect churn (every refresh) makes the window real.

3. **A re-attached page renders nothing until the turn ends, then dumps everything at once.** The subscribe-path frontend handler has no `content_delta` case and deliberately drops `tool_call`/`tool_result` until the post-`done` history reload. Tool-heavy turns look frozen for minutes. And since fix #1 removes the disconnect-kill path, the Stop button (which only aborted the local fetch) would stop nothing — the turn needs a real server-side stop.

## Changes

Three commits, in dependency order:

**`fix(agent): close EventHub send-on-closed-channel race`** — Publish sends under the write lock (every send is non-blocking, so the critical section stays O(subscribers) buffered enqueues); close() and send are now mutually excluded. Includes a churn test that panics against the old implementation under `-race`.

**`fix(chat): keep agent alive when SSE client disconnects`** — `clientGone` latches a `clientDropped` flag instead of returning: the handler parks (skips writes to the dead response, stops keepalive) until the turn reaches a natural terminal (`done` / agentDone / the ctx timeout), at which point the existing `defer cancel()` fires correctly. Events keep persisting to `session_events`, so a reloaded page picks the reply up via subscribe. Team chat additionally finishes the in-flight member but doesn't start the next member's turn for a client that left.

**`feat(chat): real attach/detach UX`** —
- *Frontend subscribe handler renders in-flight turns*: `content_delta` streams into a live bubble; `tool_call`/`tool_result` render as live tool-groups; the round's `content` seal **replaces** the delta bubble (append would duplicate text); `done` swaps everything for canonical history.
- *`content_snapshot` on attach*: the hub tracks per-session in-flight turn state (partial round text accumulated from `content_delta`, which is never persisted); `/api/chat/subscribe` emits one synthetic `content_snapshot` (`{content, running:true}`) after replay so a mid-round refresh recovers the half-generated text plus a running signal. Stale entries (no `done` within 50min) self-expire.
- *`POST /api/chat/stop`*: `handleChatStream` registers its `agentCtx` cancel in a per-turn registry (handle pointer guards a stop→resend race); stop persists a `status: stopped` event then cancels — the loop's own `error` + `done` close the turn for every subscriber. 409 when no stoppable turn is registered (IM/cron-started turns), so clients fall back to their local abort. The Stop button now works from any attached tab, including ones that didn't start the turn.

## Testing

- `go build ./...`, `go vet`, full `go test ./...` clean; new EventHub tests (race churn under `-race`, turn-snapshot lifecycle + staleness).
- `tsc --noEmit` and `next build` clean.
- Manually verified against a live deployment: refresh mid-turn no longer kills tool calls; re-attached pages show tool activity and streaming text immediately; Stop cancels from both the sending tab and a second attached tab.